### PR TITLE
Runners on minikube

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -30,3 +30,6 @@ global:
 notebooks:
   jupyterhub_base_url: /jupyterhub/
   jupyterhub_api_token: notebookstoken
+
+runner:
+  enabled: true

--- a/charts/renku/charts/gitlab/templates/deployment.yaml
+++ b/charts/renku/charts/gitlab/templates/deployment.yaml
@@ -49,7 +49,12 @@ spec:
               name: {{ template "gitlab.fullname" . }}
               key: gitlab-password
         - name: RENKU_DOMAIN
-          value: {{ .Values.global.renku.domain }}
+          value: {{ .Values.global.renku.domain }}\
+        - name: GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "gitlab.fullname" . }}
+              key: shared-runners-registration-token
         ports:
         - name: ssh
           containerPort: 22

--- a/charts/renku/charts/gitlab/templates/secret.yaml
+++ b/charts/renku/charts/gitlab/templates/secret.yaml
@@ -27,3 +27,5 @@ data:
 {{- else }}
   gitlab-client-secret: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
+
+  shared-runners-registration-token: {{ .Values.sharedRunnersRegistrationToken | b64enc | quote }}

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -1,5 +1,10 @@
 dependencies:
 - name: renku-ui
   alias: ui
-  version: "0.1.0-93b6830"
+  version: "0.1.0-af8af46"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
+- name: gitlab-runner
+  alias: runner
+  version: 0.1.16
+  repository: https://charts.gitlab.io/
+  condition: runner.enabled

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -186,6 +186,9 @@ gitlab:
   ## Resource requests/limits for Gitlab
   # resources: {}
 
+  ## Registration token for gitlab runners (initial value, can be regenerated from gitlab admin ui)
+  sharedRunnersRegistrationToken: '8dbf016f5b73d5608390183bbea9ce5fbed83a9dadefa719245ab93eb255cc29'
+
   ## Persistent Volume settings
   persistence:
     ## Set to false to disable the use of Persistent Volume
@@ -352,3 +355,18 @@ jupyterhub:
 
 tests:
   image: renku/renku-tests:latest
+
+## Gitlab runners configuration
+## See: http://docs.gitlab.com/ee/install/kubernetes/gitlab_runner_chart.html
+runner:
+  ## Set to true to deploy the runners
+  enabled: false
+  ## Gitlab URL
+  gitlabUrl: http://renku-gitlab/gitlab/ # renku-gitlab <- gitlab chart name
+  ## Registration token, must be equal to `gitlab.sharedRunnersRegistrationToken`
+  runnerRegistrationToken: '8dbf016f5b73d5608390183bbea9ce5fbed83a9dadefa719245ab93eb255cc29'
+  runners:
+    ## To ba able to use docker:dind
+    privileged: true
+  rbac:
+    create: true


### PR DESCRIPTION
* Added runners setup working with dind on minikube

caveat: have to force the docker host, e.g.
```yaml
build:
  stage: build
  image: docker:stable
  # When using dind, it's wise to use the overlayfs driver for
  # improved performance.
  # variables:
  #   DOCKER_DRIVER: overlay
  services:
  - docker:dind
  before_script:
  - export DOCKER_HOST="tcp://localhost:2375"
  - docker info
  script:
  - docker build -t my-docker-image .

```