### PR TITLE
Specify minikube memory in README.rst

### DIFF
--- a/charts/README.rst
+++ b/charts/README.rst
@@ -11,7 +11,7 @@ Requires minikube, kubectl, helm and python.
 
 .. code-block:: console
 
-    $ minikube start
+    $ minikube start --memory 6144
     $ eval $(minikube docker-env)
     $ pip install chartpress
     $ chartpress --tag latest


### PR DESCRIPTION
Recommend to run minikube with 6 GB of memory. The default of 2 GB (v0.27.0) doesn't seem to be nearly enough for renku.