### PR TITLE
shorten server names to avoid >63 character pod names

### DIFF
--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: renku-ui
   alias: ui
-  version: "0.1.0-af8af46"
+  version: "0.1.0-caa9303"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
 - name: gitlab-runner
   alias: runner

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -328,7 +328,7 @@ jupyterhub:
       c.JupyterHub.spawner_class = os.getenv('JUPYTERHUB_SPAWNER_CLASS',
                                            'spawners.Spawner')
 
-      c.RenkuKubeSpawner.pod_name_template = 'jupyterhub-{username}{servername}'
+      c.RenkuKubeSpawner.pod_name_template = 'jupyter-{username}{servername}'
 
       #: Explicitly set notebook directory because we'll be mounting a host volume to
       #: it.  Most jupyter/docker-stacks *-notebook images run the Notebook server as

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -314,6 +314,10 @@ jupyterhub:
     extraConfig: |
       import os
 
+      # JupyterHub uses GITLAB_HOST which is a misnomer -- we use GITLAB_URL
+      # everywhere so set this mapping here
+      os.environ['GITLAB_HOST'] = os.getenv('GITLAB_URL')
+
       #: Automatically begin the login process without showing the button.
       c.Authenticator.auto_login = True
 
@@ -324,7 +328,7 @@ jupyterhub:
       c.JupyterHub.spawner_class = os.getenv('JUPYTERHUB_SPAWNER_CLASS',
                                            'spawners.Spawner')
 
-      c.RenkuKubeSpawner.pod_name_template = 'jupyterhub-{username}-{servername}'
+      c.RenkuKubeSpawner.pod_name_template = 'jupyterhub-{username}{servername}'
 
       #: Explicitly set notebook directory because we'll be mounting a host volume to
       #: it.  Most jupyter/docker-stacks *-notebook images run the Notebook server as

--- a/services/jupyterhub/jupyterhub_config.py
+++ b/services/jupyterhub/jupyterhub_config.py
@@ -64,8 +64,8 @@ c.JupyterHub.spawner_class = os.getenv(
 
 NETWORK_NAME = 'review'
 
-c.RenkuDockerSpawner.container_name_template = '{prefix}-{username}-{servername}'
-c.RenkuKubeSpawner.pod_name_template = 'jupyterhub-{username}-{servername}'
+c.RenkuDockerSpawner.container_name_template = 'jupyter-{username}{servername}'
+c.RenkuKubeSpawner.pod_name_template = 'jupyter-{username}{servername}'
 
 #: Configure the image used by notebook spawner.
 IMAGE = os.getenv('JUPYTERHUB_NOTEBOOK_IMAGE', 'jupyterhub/singleuser:latest')

--- a/services/jupyterhub/spawners.py
+++ b/services/jupyterhub/spawners.py
@@ -36,7 +36,7 @@ class SpawnerMixin():
         namespace = options.get('namespace')
         project = options.get('project')
 
-        url = os.environ.get('GITLAB_HOST', 'http://gitlab.renku.build')
+        url = os.environ.get('GITLAB_URL', 'http://gitlab.renku.build')
 
         scheme, netloc, path, query, fragment = urlsplit(url)
 

--- a/services/notebooks/notebooks_service.py
+++ b/services/notebooks/notebooks_service.py
@@ -44,11 +44,6 @@ auth = HubOAuth(
 app = Flask(__name__)
 
 
-def _server_name(*args):
-    """Return a name for Jupyter server."""
-    return hashlib.md5(('-'.join(args)).encode()).hexdigest()[:7]
-
-
 def authenticated(f):
     """Decorator for authenticating with the Hub"""
 
@@ -102,7 +97,11 @@ def whoami(user):
 @authenticated
 def launch_notebook(user, namespace, project, commit_sha, notebook=None):
     """Launch user server with a given name."""
-    server_name = _server_name(namespace, project, commit_sha)
+    server_name = '{namespace}-{project}-{commit_sha}'.format(
+        namespace=namespace[:10],
+        project=project[:10],
+        commit_sha=commit_sha[:7]
+    )
 
     headers = {auth.auth_header_name: 'token {0}'.format(auth.api_token)}
 

--- a/services/notebooks/notebooks_service.py
+++ b/services/notebooks/notebooks_service.py
@@ -46,7 +46,7 @@ app = Flask(__name__)
 
 def _server_name(*args):
     """Return a name for Jupyter server."""
-    return hashlib.md5(('-'.join(args)).encode()).hexdigest()
+    return hashlib.md5(('-'.join(args)).encode()).hexdigest()[:7]
 
 
 def authenticated(f):
@@ -109,8 +109,8 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
     # 1. launch using spawner that checks the access
     r = requests.request(
         'POST',
-        auth.api_url + '/users/{user[name]}/servers/{server_name}'.format(
-            user=user, server_name=server_name
+        '{prefix}/users/{user[name]}/servers/{server_name}'.format(
+            prefix=auth.api_url, user=user, server_name=server_name
         ),
         json={
             'branch': request.args.get('branch', 'master'),
@@ -151,8 +151,8 @@ def stop_notebook(user, namespace, project, commit_sha):
 
     r = requests.request(
         'DELETE',
-        auth.api_url + '/users/{user[name]}/servers/{server_name}'.format(
-            user=user, server_name=server_name
+        '{prefix}/users/{user[name]}/servers/{server_name}'.format(
+            prefix=auth.api_url, user=user, server_name=server_name
         ),
         headers=headers
     )


### PR DESCRIPTION
pod names are now, e.g.: 

```
jupyter-cramakri--f590027
```

closes #248 