### PR TITLE
configure image builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,7 +296,7 @@ services:
           - jupyterhub.${PLATFORM_DOMAIN}
 
   notebooks:
-    build: services/notebooks
+    image: ${DOCKER_PREFIX}renku-notebooks:${PLATFORM_VERSION}
     environment:
       FLASK_DEBUG: 1
       OAUTHLIB_INSECURE_TRANSPORT: 1

--- a/scripts/renku-start.sh
+++ b/scripts/renku-start.sh
@@ -85,13 +85,14 @@ registerGitlabRunners() {
                 -n -u ${GITLAB_URL} \
                 --name $$container-shell \
                 -r ${GITLAB_RUNNERS_TOKEN} \
-                --executor shell \
+                --executor docker \
                 --env RENKU_REVIEW_DOMAIN=${PLATFORM_DOMAIN} \
                 --env RENKU_RUNNER_NETWORK=${DOCKER_NETWORK} \
                 --locked=false \
-                --run-untagged=false \
-                --docker-image ${DOCKER_PREFIX}renku-python:${PLATFORM_VERSION} \
+                --run-untagged=true \
+                --docker-image "docker:stable" \
                 --docker-network-mode=review \
+                --docker-privileged \
                 --docker-pull-policy "if-not-present"; \
     done
 }

--- a/scripts/renku-start.sh
+++ b/scripts/renku-start.sh
@@ -83,16 +83,16 @@ registerGitlabRunners() {
     do
         docker exec -ti $container gitlab-runner register \
                 -n -u ${GITLAB_URL} \
-                --name $$container-shell \
+                --name $$container-docker \
                 -r ${GITLAB_RUNNERS_TOKEN} \
                 --executor docker \
-                --env RENKU_REVIEW_DOMAIN=${PLATFORM_DOMAIN} \
-                --env RENKU_RUNNER_NETWORK=${DOCKER_NETWORK} \
                 --locked=false \
                 --run-untagged=true \
                 --docker-image "docker:stable" \
                 --docker-network-mode=review \
                 --docker-privileged \
+                --docker-volumes "/var/run/docker.sock:/var/run/docker.sock" \
+                --tag-list image-build \
                 --docker-pull-policy "if-not-present"; \
     done
 }

--- a/services/jupyterhub/spawners.py
+++ b/services/jupyterhub/spawners.py
@@ -304,6 +304,8 @@ try:
                 image='alpine/git',
                 command=['sh', '-c'],
                 args=[
+                    'rm -rf {mount_path}/* && '
+                    '(rm -rf {mount_path}/.* || true) && '
                     'apk update && apk add git-lfs && '
                     'git clone {repository} {mount_path} && '
                     '(git checkout {branch} || git checkout -b {branch}) && '

--- a/services/jupyterhub/spawners.py
+++ b/services/jupyterhub/spawners.py
@@ -86,6 +86,7 @@ class SpawnerMixin():
         options = self.user_options
         namespace = options.get('namespace')
         project = options.get('project')
+        commit_sha_7 = options.get('commit_sha')[:7]
 
         url = os.getenv('GITLAB_URL', 'http://gitlab.renku.build')
 
@@ -109,8 +110,13 @@ class SpawnerMixin():
         self.image = '{image_registry}'\
                      '/{namespace}'\
                      '/{project}'\
-                     ':{commit_sha}'.format(image_registry=os.getenv('IMAGE_REGISTRY'), **options)
+                     ':{commit_sha_7}'.format(
+                        image_registry=os.getenv('IMAGE_REGISTRY'),
+                        commit_sha_7=commit_sha_7,
+                        **options
+        )
 
+        self.cmd = 'jupyterhub-singleuser'
         try:
             result = yield super().start(*args, **kwargs)
         except docker.errors.ImageNotFound:


### PR DESCRIPTION
Change configuration to allow use of images built by CI. See https://github.com/SwissDataScienceCenter/renku-python/issues/207 for details on the CI setup needed. 

Note that the spawner mixins need to be refactored (right now there is some redundant code) because the image spec is named differently between `DockerSpawner` and `KubeSpawner` -- but this should happen when we upgrade the JH version to 0.9 because the naming is different there. 

---

closes #176 