### PR TITLE
JH configuration update

### DIFF
--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -191,7 +191,7 @@ gitlab:
 
   ## Set to true to make the user 'demo' a GitLab admin
   demoUserIsAdmin: false
-  
+
   ## External port for git ssh protocol
   ## This setting affects the copy-paste repo git+ssh URL
   # sshPort: 22
@@ -353,10 +353,9 @@ jupyterhub:
       #: For debugging arguments passed to spawned containers
       c.Spawner.debug = bool(os.getenv('DEBUG', False))
 
-      # prevent redirect to /hub if the server is taking slightly longer to start
-      c.JupyterHub.tornado_settings = {
-       'slow_spawn_timeout': 30
-      }
+      # Increase pod initialization timeout to 15 minutes
+      c.KubeSpawner.start_timeout = 60 * 15
+
   singleuser:
     image:
       name: renku/singleuser

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -321,6 +321,12 @@ jupyterhub:
     extraConfig: |
       import os
 
+      # Set the log level by value or name.
+      c.JupyterHub.log_level = 'DEBUG'
+
+      # Enable debug-logging of the single-user server
+      c.Spawner.debug = True
+
       # JupyterHub uses GITLAB_HOST which is a misnomer -- we use GITLAB_URL
       # everywhere so set this mapping here
       os.environ['GITLAB_HOST'] = os.getenv('GITLAB_URL')


### PR DESCRIPTION
The JH chart v0.6 doesn't have a `debug` value setting, so we need to turn on debugging in the JH options. 

Also, since fixing the slow spawn timeout in `renku-notebooks`, we should set the corresponding timeout here for the `KubeSpawner`.