### PR TITLE
Introduce settings for external LFS objects

### DIFF
--- a/charts/renku/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/renku/charts/gitlab/templates/_gitlab.rb.tpl
@@ -80,6 +80,22 @@ gitlab_rails['redis_host'] = "{{ template "redis.fullname" . }}"
 # gitlab_rails['redis_password'] = nil
 # gitlab_rails['redis_database'] = 0
 
+### GitLab LFS object store
+### Docs: https://docs.gitlab.com/ce/workflow/lfs/lfs_administration.html
+{{ if .Values.lfsObjects.enabled -}}
+gitlab_rails['lfs_object_store_enabled'] = true
+gitlab_rails['lfs_object_store_remote_directory'] = "{{ .Values.lfsObjects.bucketName }}"
+gitlab_rails['lfs_object_store_connection'] = {
+    'provider' => 'AWS',
+    'region' => '{{ .Values.lfsObjects.region }}',
+    'aws_access_key_id' => '{{ .Values.lfsObjects.access_key }}',
+    'aws_secret_access_key' => '{{ .Values.lfsObjects.secret_key }}',
+    'host' => '{{ .Values.lfsObjects.host }}',
+    'endpoint' => '{{ .Values.lfsObjects.endpoint }}',
+    'path_style' => false
+}
+{{- end }}
+
 prometheus['enable'] = false
 
 {{- end -}}

--- a/charts/renku/charts/gitlab/values.yaml
+++ b/charts/renku/charts/gitlab/values.yaml
@@ -9,6 +9,15 @@ image:
 
 sshPort: 22
 
+lfsObjects:
+  enabled: false
+  bucketName: lfs-objects
+  region:
+  access_key:
+  secret_key:
+  host:
+  endpoint:
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -196,6 +196,25 @@ gitlab:
   ## This setting affects the copy-paste repo git+ssh URL
   # sshPort: 22
 
+  ## LFS objects settings
+  ## Used to store git-lfs objects externally
+  ## Note: bucket must exist before use, GitLab won't do it
+  # lfsObjects:
+      ## Set to true to enable remote LFS objects
+      # enabled: false
+      ## S3 bucket name
+      # bucketName: lfs-objects
+      ## AWS region
+      # region:
+      ## S3 access key
+      # access_key:
+      ## S3 secret key
+      # secret_key:
+      ## S3 host
+      # host:
+      ## S3 endpoint URL
+      # endpoint:
+
   ## Persistent Volume settings
   persistence:
     ## Set to false to disable the use of Persistent Volume


### PR DESCRIPTION
This PR allows to setup remote LFS objects in GitLab.
Docs: https://docs.gitlab.com/ce/workflow/lfs/lfs_administration.html

This is useful to avoid filling up the persistent disk with lfs objects.

This has been tested on staging, with objects pushed to a designated OpenStack Swift container.