### PR TITLE
Fix backend health check

### DIFF
--- a/charts/renku/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/renku/charts/gitlab/templates/_gitlab.rb.tpl
@@ -108,6 +108,6 @@ registry['registry_http_addr'] = '0.0.0.0:8105'
 {{- if .Values.registry.storage }}
 registry['storage'] = {{ .Values.registry.storage }}
 {{- end }}
-registry['health_storagedriver_enabled'] = {{ default .Values.registry.backend_healthcheck true }}
+registry['health_storagedriver_enabled'] = {{ .Values.registry.backendHealthcheck }}
 
 {{- end -}}

--- a/charts/renku/charts/gitlab/values.yaml
+++ b/charts/renku/charts/gitlab/values.yaml
@@ -48,6 +48,7 @@ persistence:
 registry:
   enabled: false
   # exposedAs: NodePort
+  backendHealthcheck: true
   # storage: |-
   #   {
   #     's3' => {


### PR DESCRIPTION
The `default` primitive from the go template engines is not acting as expected, so the default is set explicitly.

Also, change the case for consistency.