### PR TITLE
jh: pin python-gitlab version

### DIFF
--- a/services/jupyterhub/requirements.txt
+++ b/services/jupyterhub/requirements.txt
@@ -20,5 +20,5 @@
 jupyterhub-kubespawner
 nullauthenticator
 oauthenticator
-python-gitlab
+python-gitlab==1.5.1
 requests-oauthlib


### PR DESCRIPTION
python-gitlab 1.5.0 was released and it seems to have a broken API (https://github.com/python-gitlab/python-gitlab/issues/537) -- pin the version to 1.5.1. Tested on staging. 