### PR TITLE
Added missing step to minikube first steps documentation.

### DIFF
--- a/charts/README.rst
+++ b/charts/README.rst
@@ -19,6 +19,7 @@ Requires minikube, kubectl, helm and python.
     $ helm init
     $ helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
     $ helm repo add gitlab https://charts.gitlab.io
+    $ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
     $ helm dep build renku
     $ helm upgrade --install nginx-ingress --namespace kube-system \
         --set controller.hostNetwork=true \


### PR DESCRIPTION
After fresh install of helm, one also has to add the jupyterhub repository.