### PR TITLE
Increase timeout for gitlab

### DIFF
--- a/charts/renku/charts/gitlab/templates/deployment.yaml
+++ b/charts/renku/charts/gitlab/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             path: /gitlab/help
             port: http
           initialDelaySeconds: 60
-          timeoutSeconds: 1
+          timeoutSeconds: 15
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3


### PR DESCRIPTION
Wrong probe makes service unreachable.