### PR TITLE
Use docker executor for gitlab runner

### DIFF
--- a/charts/renku/charts/gitlab/templates/registry-service.yaml
+++ b/charts/renku/charts/gitlab/templates/registry-service.yaml
@@ -10,6 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  clusterIP: 10.100.123.45
   type: NodePort
   ports:
     - port: 8105

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -7,11 +7,6 @@ dependencies:
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.1.0-3a7db4d"
-- name: gitlab-runner
-  alias: runner
-  version: 0.1.16
-  repository: https://charts.gitlab.io/
-  condition: runner.enabled
 - name: jupyterhub
   version: "v0.6"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -590,18 +590,3 @@ tests:
   image:
     repository: renku/tests
     tag: latest
-
-## Gitlab runners configuration
-## See: http://docs.gitlab.com/ee/install/kubernetes/gitlab_runner_chart.html
-runner:
-  ## Set to true to deploy the runners
-  enabled: false
-  ## Gitlab URL
-  gitlabUrl: http://renku-gitlab/gitlab/ # renku-gitlab <- gitlab chart name
-  ## Registration token, must be equal to `gitlab.sharedRunnersRegistrationToken`
-  runnerRegistrationToken: 8dbf016f5b73d5608390183bbea9ce5fbed83a9dadefa719245ab93eb255cc29
-  runners:
-    ## To ba able to use docker:dind
-    privileged: true
-  rbac:
-    create: true

--- a/scripts/minikube_deploy.py
+++ b/scripts/minikube_deploy.py
@@ -8,6 +8,7 @@ from glob import glob
 from io import StringIO
 from subprocess import run, PIPE, CalledProcessError
 from tempfile import TemporaryDirectory
+import json
 
 from ruamel.yaml import YAML
 
@@ -83,8 +84,8 @@ def main():
             '--set', 'ui.gitlabUrl=http://{mip}/gitlab'.format(mip=minikube_ip()),
             '--set', 'ui.jupyterhubUrl=http://{mip}/jupyterhub'.format(mip=minikube_ip()),
             '--set', 'jupyterhub.hub.extraEnv.GITLAB_URL=http://{mip}/gitlab'.format(mip=minikube_ip()),
-            '--set', 'jupyterhub.hub.extraEnv.IMAGE_REGISTRY={mip}:30105'.format(mip=minikube_ip()),
-            '--set', 'gitlab.registry.externalUrl=http://{mip}:30105/'.format(mip=minikube_ip()),
+            '--set', 'jupyterhub.hub.extraEnv.IMAGE_REGISTRY=10.100.123.45:8105',
+            '--set', 'gitlab.registry.externalUrl=http://10.100.123.45:8105/',
             '--timeout', '1800',
         ]
 
@@ -200,7 +201,7 @@ def deploy_runner():
         launch_runner = run([
             'docker', 'run',
             '-d', '--name', 'gitlab-runner',
-            '--restart always',
+            '--restart', 'always',
             '-v', '/srv/gitlab-runner/config:/etc/gitlab-runner',
             '-v', '/var/run/docker.sock:/var/run/docker.sock',
             'gitlab/gitlab-runner:latest',

--- a/scripts/minikube_deploy.py
+++ b/scripts/minikube_deploy.py
@@ -83,12 +83,16 @@ def main():
             '--set', 'ui.gitlabUrl=http://{mip}/gitlab'.format(mip=minikube_ip()),
             '--set', 'ui.jupyterhubUrl=http://{mip}/jupyterhub'.format(mip=minikube_ip()),
             '--set', 'jupyterhub.hub.extraEnv.GITLAB_URL=http://{mip}/gitlab'.format(mip=minikube_ip()),
+            '--set', 'jupyterhub.hub.extraEnv.IMAGE_REGISTRY={mip}:30105'.format(mip=minikube_ip()),
             '--set', 'gitlab.registry.externalUrl=http://{mip}:30105/'.format(mip=minikube_ip()),
             '--timeout', '1800',
         ]
 
         print('Running: {}'.format(' '.join(helm_deploy_cmd)))
         run(helm_deploy_cmd).check_returncode()
+
+    # 5. Deploy GitLab runner
+    deploy_runner()
 
 
 def renku_base_dir():
@@ -181,6 +185,60 @@ def kubectl_use_minikube_context():
         result.check_returncode()
     except CalledProcessError:
         raise RuntimeError('Could not run kubectl config use-context minikube:\n{}'.format(result.stdout.decode('utf-8')))
+
+
+def deploy_runner():
+    """Deploys gitlab runner with docker executor in minikube"""
+    runner_exists = run(['docker', 'ps', '-q', '-f', 'name=^/gitlab-runner$'], stdout=PIPE)
+    try:
+        runner_exists.check_returncode()
+    except CalledProcessError:
+        raise RuntimeError('Could not run docker ps:\n{}'.format(runner_exists.stdout.decode('utf-8')))
+
+    runner = runner_exists.stdout.decode('utf-8')
+    if runner == '':
+        launch_runner = run([
+            'docker', 'run',
+            '-d', '--name', 'gitlab-runner',
+            '--restart always',
+            '-v', '/srv/gitlab-runner/config:/etc/gitlab-runner',
+            '-v', '/var/run/docker.sock:/var/run/docker.sock',
+            'gitlab/gitlab-runner:latest',
+        ], stdout=PIPE)
+        try:
+            launch_runner.check_returncode()
+        except CalledProcessError:
+            raise RuntimeError('Could not launch runner:\n{}'.format(launch_runner.stdout.decode('utf-8')))
+    else:
+        unregister_runner = run([
+            'docker', 'exec', '-ti', 'gitlab-runner',
+            'gitlab-runner', 'unregister', '--all-runners',
+        ], stdout=PIPE)
+        try:
+            unregister_runner.check_returncode()
+        except CalledProcessError:
+            raise RuntimeError('Could not unregister runner:\n{}'.format(unregister_runner.stdout.decode('utf-8')))
+
+
+    register_runner = run([
+        'docker', 'exec', '-ti', 'gitlab-runner',
+        'gitlab-runner', 'register',
+        '-n', '-u', 'http://{mip}/gitlab/'.format(mip=minikube_ip()),
+        '--name', 'docker-minikube',
+        '-r', '8dbf016f5b73d5608390183bbea9ce5fbed83a9dadefa719245ab93eb255cc29', # From values.yaml
+        '--executor', 'docker',
+        '--locked=false',
+        '--run-untagged=true',
+        '--docker-image="docker:stable"',
+        '--docker-privileged',
+        '--docker-volumes', '/var/run/docker.sock:/var/run/docker.sock',
+        '--tag-list', 'image-build',
+        '--docker-pull-policy', 'if-not-present',
+    ], stdout=PIPE)
+    try:
+        register_runner.check_returncode()
+    except CalledProcessError:
+        raise RuntimeError('Could not register runner:\n{}'.format(register_runner.stdout.decode('utf-8')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Image building and notebook launch button work out of the box with `make minikube-deploy`.
The registry url uses the in cluster IP as a way to achieve this.

~~TODO:~~
~~- [ ] add doc for `.gitlab-ci.yml`~~

Closes #327 

~~Making the gitlab registry work properly is still not simple, so recommended to simply not use it in `.gitlab-ci.yml`:~~
```yaml
image_build:
  stage: build
  image: python:3.6
  before_script:
    - curl -sSL https://get.docker.com/ | sh
    # - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN http://$CI_REGISTRY
  script:
    - CI_COMMIT_SHA_7=$(echo $CI_COMMIT_SHA | cut -c1-7)
    - docker build --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7 .
    # - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7
  tags:
    - image-build
```

~~As the image is built in minikube, the image is available for JH.~~