### PR TITLE
[docs] Recommend disk size 40g for minikube

### DIFF
--- a/docs/developer/minikube.rst
+++ b/docs/developer/minikube.rst
@@ -54,7 +54,7 @@ resources, e.g.
 
 .. code-block:: console
 
-    $ minikube start --cpus 2 --memory 8192
+    $ minikube start --cpus 2 --memory 8192 --disk-size 40g
 
 Once minikube is started, make sure you can access it by running:
 


### PR DESCRIPTION
While developing on minikube, there's a high chance of encountering disk pressure on minikube.