### PR TITLE
docs: use patched sphinx until upstream PR is merged

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,7 +29,7 @@ requests==2.19.1
 simplegeneric==0.8.1
 six==1.11.0
 snowballstemmer==1.2.1
-sphinx==1.7.5
+-e git+https://github.com/rokroskar/sphinx.git@use-doc-dir#egg=sphinx
 sphinxcontrib-spelling==4.2.0
 sphinxcontrib-websupport==1.1.0
 traitlets==4.3.2


### PR DESCRIPTION
This builds the doc against my patch of the sphinx graphviz extension, which enables relative paths in custom node images (i.e. the icons actually show up). See https://renku.readthedocs.io/en/fix-324/user/reproducibility.html

The patch has been submitted as a PR to sphinx.