### PR TITLE
Remove localhost from keycloak realm template

### DIFF
--- a/charts/keycloak/templates/_renku-realm.tpl
+++ b/charts/keycloak/templates/_renku-realm.tpl
@@ -362,14 +362,10 @@ TODO: Put back template strings from renku/services/keycloak/renku-realm.json.tp
         "clientAuthenticatorType": "client-secret",
         "secret": "{{ .Values.global.gateway.clientSecret }}",
         "redirectUris": [
-            "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*",
-            "http://localhost:5000/*",
-            "http://localhost:3000/*"
+            "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
         ],
         "webOrigins": [
-            "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*",
-            "http://localhost:5000/*",
-            "http://localhost:3000/*"
+            "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
         ],
         "notBefore": 0,
         "bearerOnly": false,


### PR DESCRIPTION
Remove localhost URLs from the list of allowed hostst/redirectURLs (used for local dev) in the renku realm template.

Closes #340