### PR TITLE
singleuser: Make jovyan sudoer

### DIFF
--- a/services/singleuser/Dockerfile
+++ b/services/singleuser/Dockerfile
@@ -53,6 +53,8 @@ COPY git-config.bashrc /home/jovyan/
 RUN cat /home/jovyan/git-config.bashrc >> /home/jovyan/.bashrc && rm /home/jovyan/git-config.bashrc
 
 # Add user `jovyan` to sudoers (passwordless)
+USER root
 RUN echo "jovyan ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER jovyan
 
 CMD '/usr/local/bin/start-singleuser.sh'

--- a/services/singleuser/Dockerfile
+++ b/services/singleuser/Dockerfile
@@ -52,4 +52,7 @@ RUN python3 -m pip install renku
 COPY git-config.bashrc /home/jovyan/
 RUN cat /home/jovyan/git-config.bashrc >> /home/jovyan/.bashrc && rm /home/jovyan/git-config.bashrc
 
+# Add user `jovyan` to sudoers (passwordless)
+RUN echo "jovyan ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 CMD '/usr/local/bin/start-singleuser.sh'


### PR DESCRIPTION
Because at times, some python packages have system dependencies.

Example:
```bash
$ pip install opencv-python
[...]
Successfully installed numpy-1.15.0 opencv-python-3.4.2.17
$ python -c "import cv2"
[...]
ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
```

Need to run:
```bash
$ sudo apt update && sudo apt install -y python-opencv
```

Of course, we'd still recommend to add the `apt install` to the Dockerfile, but it's not nice to have to fully
cycle a jupyter server and wait for an image build to install things.