### PR TITLE
jh: use jupyterlab

### DIFF
--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -543,7 +543,7 @@ jupyterhub:
   hub:
     image:
       name: renku/jupyterhub-k8s
-      tag: latest
+      tag: 0.0-unclean-1a673b8
     services:
       notebooks:
         url: http://renku-notebooks
@@ -599,9 +599,10 @@ jupyterhub:
   singleuser:
     image:
       name: renku/singleuser
-      tag: latest
+      tag: 0.0-unclean-1a673b8
     storage:
       type: none
+    defaultUrl: /lab
   # FIXME: bug in prepuller makes helm hang in certain cases. Fixed in 0.7
   # so this should be removed eventually.
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/477
@@ -627,12 +628,12 @@ jupyterhub:
 apispec:
   image:
     repository: renku/apispec
-    tag: latest
+    tag: 0.0-unclean-1a673b8
 
 tests:
   image:
     repository: renku/tests
-    tag: latest
+    tag: 0.0-unclean-1a673b8
 
 minio:
   ## Set to true to deploy a minio server, can be used as gateway too.

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -543,7 +543,7 @@ jupyterhub:
   hub:
     image:
       name: renku/jupyterhub-k8s
-      tag: 0.0-unclean-1a673b8
+      tag: latest
     services:
       notebooks:
         url: http://renku-notebooks
@@ -599,7 +599,7 @@ jupyterhub:
   singleuser:
     image:
       name: renku/singleuser
-      tag: 0.0-unclean-1a673b8
+      tag: latest
     storage:
       type: none
     defaultUrl: /lab
@@ -628,12 +628,12 @@ jupyterhub:
 apispec:
   image:
     repository: renku/apispec
-    tag: 0.0-unclean-1a673b8
+    tag: latest
 
 tests:
   image:
     repository: renku/tests
-    tag: 0.0-unclean-1a673b8
+    tag: latest
 
 minio:
   ## Set to true to deploy a minio server, can be used as gateway too.


### PR DESCRIPTION
closes #370  and https://github.com/SwissDataScienceCenter/renku-notebooks/issues/27 -- however, beware that this brings up new problems. For example jupyterlab introduces the idea of workspaces, which seems to conflict a bit with our concept of tying a server to a git commit. Right now, if you try to launch two different jupyterlab sessions for two different commits in your history you will be asked to switch to a different workspace -- at which point you will redirect to an incorrect URL (doesn't take into account the `base_url` from jupyterhub -- bug report?)
