### PR TITLE
Let tests always pull the latest renku-demo image

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -28,12 +28,11 @@ set -ex
 # FIXME: make helm lint work
 # helm lint charts/renku -f charts/minikube-values.yaml
 
-docker pull renku/renku-demo:latest
-sleep 60 # can help
 kubectl -n $RENKU_DEPLOY run renku-demo -it \
 --env="GITLAB_URL=http://$MAXIKUBE_HOST:32080/gitlab" \
 --env="KEYCLOAK_URL=http://$MAXIKUBE_HOST:32080" \
 --image=renku/renku-demo:latest \
+--image-pull-policy=Always \
 --restart=Never
 
 helm test $RENKU_DEPLOY


### PR DESCRIPTION
@leafty Looks to me like the docker pull is not necessary and we can shorten the build a bit. Or am I missing something?