### PR TITLE
charts: disable security context for allowing telepresence

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -44,6 +44,8 @@ gitlab:
 notebooks:
   jupyterhub_base_url: /jupyterhub/
   jupyterhub_api_token: notebookstoken
+  securityContext:
+    enabled: false
 
 runner:
   enabled: true


### PR DESCRIPTION
`securityContext` is on by default -- this disables it for minikube to allow telepresence development. 