### PR TITLE
Set renku version to 'latest' for minikube deployments

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -13,6 +13,8 @@ ingress:
 global:
   gitlab:
     urlPrefix: /gitlab
+  renku:
+    version: 'latest'
 
 gitlab:
   ssh:

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -40,6 +40,10 @@ global:
   renku:
     ## Domain name for the deployed instance of renku
     domain: example.local
+    ## Renku version to be used (currently for project creation in
+    ## the UI) If not set explicitly the version will be picked up
+    ## from the respective renku (sub)chart. 
+    ## version: '0.0.0'
   ## Set to true if using https
   useHTTPS: false
 


### PR DESCRIPTION
Set the renku version (affecting the template used in project creation) to latest for minikube deployments. Does currently not affect anything than project creation.