### PR TITLE
Update sub-chart dependencies in minikube-deploy

### DIFF
--- a/scripts/minikube_deploy.py
+++ b/scripts/minikube_deploy.py
@@ -50,6 +50,8 @@ def main():
     get_minikube_docker_env()
     for dep in dependencies:
         chartpress_dir = os.path.join(dependency_dir(dep['repo_name']), dep['chartpress_dir'])
+        subchart_dir = os.path.join(chartpress_dir, dep['repo_name'])
+        update_subchart_dependencies(subchart_dir)
         update_charts(chartpress_dir)
     update_charts(renku_chartpress_dir)
 
@@ -142,6 +144,11 @@ def update_charts(chartpress_dir):
     if chartpress_tag:
         cmd = cmd + ['--tag', chartpress_tag]
     run(cmd, cwd=chartpress_dir).check_returncode()
+
+
+def update_subchart_dependencies(subchart_dir):
+    """Updates subchart dependencies"""
+    run(['helm', 'dep', 'update'], cwd=subchart_dir).check_returncode()
 
 
 def get_minikube_docker_env():

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 
 # RUN apk add --update openssl
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz && \
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz && \
     tar -xvzf geckodriver* && \
     chmod +x geckodriver && \
     mv geckodriver /usr/local/bin && \

--- a/tests/test_renku.py
+++ b/tests/test_renku.py
@@ -22,6 +22,7 @@ from urllib.parse import urljoin
 
 import pytest
 import splinter
+import time
 
 
 def test_renku_login(browser):
@@ -44,7 +45,18 @@ def test_notebook_launch(browser):
     browser.fill('username', 'cramakri')
     browser.fill('password', 'cramakri')
     browser.find_by_id('kc-login').click()
+
+    # wait a bit for the page to load, helps to avoid test failures
+    time.sleep(2)
     assert 'Renku' in browser.title
+
+    # go to the projects overview page
+    assert browser.is_element_present_by_text(
+        'Projects', wait_time=10
+    )
+    projects_link = browser.find_link_by_text('Projects')
+    assert projects_link
+    projects_link[0].click()
 
     # go to the project page
     assert browser.is_element_present_by_text(


### PR DESCRIPTION
Update the dependencies of the sub-charts (currently only relevant for notebooks service) before packaging the renku chart in the `minikube-deploy` script.

Solves the problem that the jupyterhub service was not included in the minikube deployment unless the renku-notebooks dependencies had been added manually at some point before.