### PR TITLE
Allow for having multiple redis instances

### DIFF
--- a/charts/chartpress.yaml
+++ b/charts/chartpress.yaml
@@ -6,25 +6,25 @@ charts:
       published: https://swissdatasciencecenter.github.io/helm-charts
     paths:
       - ./gitlab
-  # - name: renku
-  #   imagePrefix: renku/
-  #   repo:
-  #     git: SwissDataScienceCenter/helm-charts
-  #     published: https://swissdatasciencecenter.github.io/helm-charts
-  #   paths:
-  #     - .
-  #     - ../services/apispec
-  #     - ../tests
-  #   images:
-  #     apispec:
-  #       contextPath: ../services/apispec
-  #       dockerfilePath: ../services/apispec/Dockerfile
-  #       valuesPath: apispec.image
-  #       paths:
-  #         - ../services/apispec
-  #     tests:
-  #       contextPath: ../tests
-  #       dockerfilePath: ../tests/Dockerfile
-  #       valuesPath: tests.image
-  #       paths:
-  #         - ../tests
+  - name: renku
+    imagePrefix: renku/
+    repo:
+      git: SwissDataScienceCenter/helm-charts
+      published: https://swissdatasciencecenter.github.io/helm-charts
+    paths:
+      - .
+      - ../services/apispec
+      - ../tests
+    images:
+      apispec:
+        contextPath: ../services/apispec
+        dockerfilePath: ../services/apispec/Dockerfile
+        valuesPath: apispec.image
+        paths:
+          - ../services/apispec
+      tests:
+        contextPath: ../tests
+        dockerfilePath: ../tests/Dockerfile
+        valuesPath: tests.image
+        paths:
+          - ../tests

--- a/charts/chartpress.yaml
+++ b/charts/chartpress.yaml
@@ -6,25 +6,25 @@ charts:
       published: https://swissdatasciencecenter.github.io/helm-charts
     paths:
       - ./gitlab
-  - name: renku
-    imagePrefix: renku/
-    repo:
-      git: SwissDataScienceCenter/helm-charts
-      published: https://swissdatasciencecenter.github.io/helm-charts
-    paths:
-      - .
-      - ../services/apispec
-      - ../tests
-    images:
-      apispec:
-        contextPath: ../services/apispec
-        dockerfilePath: ../services/apispec/Dockerfile
-        valuesPath: apispec.image
-        paths:
-          - ../services/apispec
-      tests:
-        contextPath: ../tests
-        dockerfilePath: ../tests/Dockerfile
-        valuesPath: tests.image
-        paths:
-          - ../tests
+  # - name: renku
+  #   imagePrefix: renku/
+  #   repo:
+  #     git: SwissDataScienceCenter/helm-charts
+  #     published: https://swissdatasciencecenter.github.io/helm-charts
+  #   paths:
+  #     - .
+  #     - ../services/apispec
+  #     - ../tests
+  #   images:
+  #     apispec:
+  #       contextPath: ../services/apispec
+  #       dockerfilePath: ../services/apispec/Dockerfile
+  #       valuesPath: apispec.image
+  #       paths:
+  #         - ../services/apispec
+  #     tests:
+  #       contextPath: ../tests
+  #       dockerfilePath: ../tests/Dockerfile
+  #       valuesPath: tests.image
+  #       paths:
+  #         - ../tests

--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.2.0
+version: 0.2.1

--- a/charts/gitlab/requirements.lock
+++ b/charts/gitlab/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 3.7.2
+digest: sha256:0fd490e3f2effaf0ee234577830ec7b0674698f9fc74dcf1f876860721181fe8
+generated: 2018-09-24T13:54:13.380379241+02:00

--- a/charts/gitlab/requirements.yaml
+++ b/charts/gitlab/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: redis
+  version: 3.7.2
+  repository: "@stable"

--- a/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/gitlab/templates/_gitlab.rb.tpl
@@ -75,7 +75,7 @@ gitlab_rails['db_port'] = 5432
 ###! Docs: https://docs.gitlab.com/omnibus/settings/redis.html
 
 #### Redis TCP connection
-gitlab_rails['redis_host'] = '{{ template "redis.fullname" . }}-master'
+gitlab_rails['redis_host'] = '{{ include "call-nested" (list . "redis" "redis.fullname") }}-master'
 # gitlab_rails['redis_port'] = 6379
 # gitlab_rails['redis_password'] = nil
 # gitlab_rails['redis_database'] = 0

--- a/charts/gitlab/templates/_helpers.tpl
+++ b/charts/gitlab/templates/_helpers.tpl
@@ -12,3 +12,13 @@ Create chart name and version as used by the chart label.
 {{- define "gitlab.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Hack for calling templates in a fake scope (until this is solved https://github.com/helm/helm/issues/4535)
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 }}
+{{- $template := index . 2 }}
+{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}

--- a/charts/gitlab/templates/deployment.yaml
+++ b/charts/gitlab/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         app: {{ template "gitlab.name" . }}
         release: {{ .Release.Name }}
-        {{ template "redis.fullname" . }}-client: "true"
+        {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -85,3 +85,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+redis:
+
+  nameOverride: gl-redis
+
+  cluster:
+    enabled: false
+
+  usePassword: false
+
+  master:
+    persistence:
+      enabled: false
+
+  networkPolicy:
+    enabled: true
+    allowExternal: false

--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
-version: 0.2.0
+version: 0.2.1

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -10,13 +10,10 @@ dependencies:
   version: 0.2.0-rc4
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.2.0-886da54
+  version: 0.0-072ab7e
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
-- name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 3.7.2
 - name: keycloak
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 3.2.0

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.0
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.2.1-dba1fe4
+  version: 0.2.1-01a82df
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -20,5 +20,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:448b5d85c69eb964b8c0c688da879469abb5ff9f33b8bd9062774734cb53d52d
-generated: 2018-10-09T08:36:34.996516471+02:00
+digest: sha256:82956b22b3a0ebe5d6a1c6961fb87a1babb07873366235fb62ba85737cc1fc77
+generated: 2018-10-10T08:37:55.598830963+02:00

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.0-rc4
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.2.0-rc4
+  version: 0.2.0-886da54
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -23,5 +23,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:e16e62be0c93c2f5fc7f4b0d77850a9f2f451c9e8367eff8c429792ec6a2f1b7
-generated: 2018-09-06T17:37:49.587656705+02:00
+digest: sha256:f7c7bd3fe4714fe04ddd4f503c3854a23f8b1911cdf4d2960f15ba23ab0ee280
+generated: 2018-09-24T16:09:24.035046691+02:00

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.0-rc4
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.0-072ab7e
+  version: 0.2.0-88fd7bd
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -20,5 +20,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:f7c7bd3fe4714fe04ddd4f503c3854a23f8b1911cdf4d2960f15ba23ab0ee280
-generated: 2018-09-24T16:09:24.035046691+02:00
+digest: sha256:a54421f03ac67a1550b0ea8fc4d3b99bc493f16e04f45692bc04d21f7027a918
+generated: 2018-09-26T09:10:53.712369739+02:00

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.0
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.2.0-88fd7bd
+  version: 0.2.1-dba1fe4
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -20,5 +20,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:a54421f03ac67a1550b0ea8fc4d3b99bc493f16e04f45692bc04d21f7027a918
-generated: 2018-09-26T09:10:53.712369739+02:00
+digest: sha256:448b5d85c69eb964b8c0c688da879469abb5ff9f33b8bd9062774734cb53d52d
+generated: 2018-10-09T08:36:34.996516471+02:00

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.2.0-rc4"
 - name: gitlab
-  version: "0.2.0-rc4"
+  version: "0.2.0-886da54"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   condition: gitlab.enabled
 - name: postgresql

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.2.0"
 - name: gitlab
-  version: "0.2.0-88fd7bd"
+  version: "0.2.1-dba1fe4"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   condition: gitlab.enabled
 - name: postgresql

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -12,16 +12,12 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.2.0-rc4"
 - name: gitlab
-  version: "0.2.0-886da54"
+  version: "0.0-072ab7e"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   condition: gitlab.enabled
 - name: postgresql
   version: 0.14.4
   repository: "@stable"
-- name: redis
-  version: 3.7.2
-  repository: "@stable"
-  condition: gitlab.enabled
 - name: keycloak
   version: 3.2.0
   repository: "@stable"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.2.0"
 - name: gitlab
-  version: "0.2.1-dba1fe4"
+  version: "0.2.1-01a82df"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   condition: gitlab.enabled
 - name: postgresql

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.2.0-rc4"
 - name: gitlab
-  version: "0.0-072ab7e"
+  version: "0.2.0-88fd7bd"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   condition: gitlab.enabled
 - name: postgresql

--- a/charts/renku/templates/_helpers.tpl
+++ b/charts/renku/templates/_helpers.tpl
@@ -53,9 +53,11 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "keycloak" | replace "+" "_" | trunc 20 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
 {{- define "redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+*/}}
 
 {{- define "gitlab.fullname" -}}
 {{- printf "%s-%s" .Release.Name "gitlab" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}

--- a/charts/renku/templates/_helpers.tpl
+++ b/charts/renku/templates/_helpers.tpl
@@ -53,12 +53,6 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "keycloak" | replace "+" "_" | trunc 20 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-{{- define "redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "redis" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-*/}}
-
 {{- define "gitlab.fullname" -}}
 {{- printf "%s-%s" .Release.Name "gitlab" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -42,7 +42,7 @@ global:
     domain: example.local
     ## Renku version to be used (currently for project creation in
     ## the UI) If not set explicitly the version will be picked up
-    ## from the respective renku (sub)chart. 
+    ## from the respective renku (sub)chart.
     ## version: '0.0.0'
   ## Set to true if using https
   useHTTPS: false
@@ -494,23 +494,6 @@ gitlab:
     #   - hosts:
     #     - registry.example.com
     #     secretName: registry-tls
-
-## Redis configuration
-## Redis is used by Gitlab
-redis:
-
-  cluster:
-    enabled: false
-
-  usePassword: false
-
-  master:
-    persistence:
-      enabled: false
-
-  networkPolicy:
-    enabled: true
-    allowExternal: false
 
 ## Configuration for the UI service
 ui:


### PR DESCRIPTION
by resolving redis.fullname in a sort of scoped namespace. Once the related helm issue (https://github.com/helm/helm/issues/4535) is solved, we can also clean the other re-definitions of fullnames.