### PR TITLE
Fix for large lfs objects

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -6,7 +6,7 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: false
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
   hosts:
   - ""
 

--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -5,8 +5,10 @@
 ingress:
   enabled: true
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: 'nginx'
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+    nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
   hosts:
   - ""
 

--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -6,7 +6,7 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
   hosts:
   - ""
 

--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
 {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ quote $value }}
+    {{ $key }}: "{{ $value }}"
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -19,9 +19,9 @@ metadata:
     chart: {{ template "renku.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{- range $key, $value :=  .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
 {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: "{{ $value }}"
+    {{ $key }}: {{ $value | quote }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -20,8 +20,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-{{- range $key, $value :=  .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+{{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ quote $value }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -19,9 +19,9 @@ metadata:
     chart: {{ template "renku.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
   annotations:
-{{- range $key, $value :=  .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: ' off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: '"off"' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: ' off' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: '"off"' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: 'nginx'
     # kubernetes.io/tls-acme: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: ! off # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: 'nginx'
     # kubernetes.io/tls-acme: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off;' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: ! off # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -56,10 +56,10 @@ ingress:
   ## Annotations for the created ingress
   annotations:
     ## The ingress class
-    kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: 'nginx'
+    # kubernetes.io/tls-acme: 'true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -57,9 +57,9 @@ ingress:
   annotations:
     ## The ingress class
     kubernetes.io/ingress.class: 'nginx'
-    # kubernetes.io/tls-acme: 'true"
+    # kubernetes.io/tls-acme: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off;' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,6 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
+    nginx.ingress.kubernetes.io/proxy-request-buffering: off # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -59,7 +59,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: off # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -33,7 +33,7 @@ curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 # install helm
-curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz
+curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
 tar xvf helm.tar.gz
 chmod +x linux-amd64/helm
 sudo mv linux-amd64/helm /usr/local/bin/


### PR DESCRIPTION
See: https://gitlab.com/gitlab-org/gitlab-workhorse/issues/130
`proxy-request-buffering` is disabled in GitLab, for pushing LFS objects as it caused issues.
The ingress (`nginx`) has it on by default.