### PR TITLE
add info about git and git-lfs to docs

### DIFF
--- a/docs/user/cli-installation.rst
+++ b/docs/user/cli-installation.rst
@@ -51,6 +51,64 @@ If you want to have Renku as a project dependency, you may install it using
   pipenv shell
 
 
+Installing from source
+----------------------
+
+Using conda, we can very easily install renku from source into an isolated
+environment.
+
+
+Bleeding-edge
+^^^^^^^^^^^^^
+
+To install the latest bleeding-edge version of Renku and keep it from
+polluting your application environment, an easy solution is to place it inside
+an  isolated conda environment. If you don't have ``conda`` already, you
+should `install miniconda <https://conda.io/miniconda.html>`__. Once you have
+it installed, you can run
+
+.. code-block:: console
+
+  conda create -y -n renku python=3.6
+  $(conda env list | grep renku | awk '{print $2}')/bin/pip install -e git+https://github.com/SwissDataScienceCenter/renku-python.git#egg=renku
+  mkdir -p ~/.renku/bin
+  ln -s "$(conda env list | grep renku | awk '{print $2}')/bin/renku" ~/.renku/bin/renku
+
+This will create an isolated environment for renku and link the binary to
+``.renku/bin`` in your home directory. If you want to use it, you should
+add this to your ``PATH``:
+
+.. code-block:: console
+
+  export PATH=~/.renku/bin:$PATH
+
+If you want it to be done automatically for your shell (bash), add it to ``.bashrc``:
+
+.. code-block:: console
+
+  echo "export PATH=~/.renku/bin:$PATH" >> $HOME/.bashrc
+  source $HOME/.bashrc
+
+When you want to update the installed version again, simply do
+
+.. code-block:: console
+
+  $(conda env list | grep renku | awk '{print $2}')/bin/pip install -e git+https://github.com/SwissDataScienceCenter/renku-python.git#egg=renku
+
+
+Specific version
+^^^^^^^^^^^^^^^^
+
+To install a specific version of renku the procedure is nearly identical
+the above, but instead of installing from source you install a version with ``pip``.
+For example, after creating the conda environment as described in the previous
+section, you can install `renku v0.2.0` with
+
+.. code-block:: console
+
+  $(conda env list | grep renku | awk '{print $2}')/bin/pip install renku==0.2.0
+
+
 .. note::
 
     You may get a ``ValueError: unknown locale: UTF-8`` - see `here

--- a/docs/user/cli-installation.rst
+++ b/docs/user/cli-installation.rst
@@ -54,7 +54,7 @@ If you want to have Renku as a project dependency, you may install it using
 Installing from source
 ----------------------
 
-Using conda, we can very easily install renku from source into an isolated
+Using ``conda``, we can very easily install renku from source into an isolated
 environment.
 
 Bleeding-edge
@@ -62,7 +62,7 @@ Bleeding-edge
 
 To install the latest bleeding-edge version of Renku and keep it from
 polluting your application environment, an easy solution is to place it inside
-an  isolated conda environment. If you don't have ``conda`` already, you
+an  isolated ``conda`` environment. If you don't have ``conda`` already, you
 should `install miniconda <https://conda.io/miniconda.html>`__. Once you have
 it installed, you can run
 
@@ -100,7 +100,7 @@ Specific version
 
 To install a specific version of renku the procedure is nearly identical
 the above, but instead of installing from source you install a version with ``pip``.
-For example, after creating the conda environment as described in the previous
+For example, after creating the ``conda`` environment as described in the previous
 section, you can install `renku v0.2.0` with
 
 .. code-block:: console

--- a/docs/user/cli-installation.rst
+++ b/docs/user/cli-installation.rst
@@ -57,7 +57,6 @@ Installing from source
 Using conda, we can very easily install renku from source into an isolated
 environment.
 
-
 Bleeding-edge
 ^^^^^^^^^^^^^
 

--- a/docs/user/firststeps.rst
+++ b/docs/user/firststeps.rst
@@ -396,11 +396,17 @@ To update all the outputs, we can run the following.
 
     renku update
 
-That's it! The intermediate data file ``data/preprocessed/zhbikes.feather``
+That's it! The intermediate data file ``data/preprocessed/zhbikes.parquet``
 and the figures in ``figs/``, are recreated by re-running the necessary steps.
 See the `renku update documentation <https://renku-python.readthedocs.io/en/latest/cli.html
 #renku-update>`_ for a detailed explanation of how the workflow is re-
 executed.
+
+.. note::
+
+    A very similar command is `renku rerun <https://renku-python.readthedocs.io/en/latest/cli.html#module-renku.cli.rerun>`__, except that it also allows
+    you to modify the inputs. This is useful, for example, to vary hyperparameters
+    or input data sources.
 
 Lastly, let's not forget to push our work:
 

--- a/docs/user/firststeps.rst
+++ b/docs/user/firststeps.rst
@@ -404,9 +404,10 @@ executed.
 
 .. note::
 
-    A very similar command is `renku rerun <https://renku-python.readthedocs.io/en/latest/cli.html#module-renku.cli.rerun>`__, except that it also allows
-    you to modify the inputs. This is useful, for example, to vary hyperparameters
-    or input data sources.
+    A very similar command is `renku rerun <https://renku-
+    python.readthedocs.io/en/latest/cli.html#module-renku.cli.rerun>`__,
+    except that it also allows you to modify the inputs. This is useful, for
+    example, to vary hyper-parameters or input data sources.
 
 Lastly, let's not forget to push our work:
 

--- a/docs/user/git_tips.rst
+++ b/docs/user/git_tips.rst
@@ -46,7 +46,7 @@ easier.
 
 
 Now lets say you decide your data imports and everything that followed was
-wrong and you want to go back to "renku dataset create zhvelo", i.e.
+wrong and you want to go back to ``renku dataset create zhvelo``, i.e.
 commit ``f346c1f36f211840b22a63e7fc2c9bfb52616212``, you would do:
 
 .. code-block:: console

--- a/docs/user/git_tips.rst
+++ b/docs/user/git_tips.rst
@@ -1,0 +1,56 @@
+.. _git_tips:
+
+Git cheat sheet for Renku
+=========================
+
+Renku is based on ``git`` so here is a cheat sheet to make your life a bit
+easier.
+
+**To undo what you just did:**
+
+.. code-block:: console
+
+    git reset --hard HEAD~1
+
+(this means, move my git history back by one commit from where I currently stand)
+
+**To go back to a sane state:** First find the "sane state" with ``git log``, e.g.
+
+.. code-block:: console
+
+    $ git log
+    commit 7df2389f3e7df6c013467b399e4de23b0f2f4b78
+    Author: Rok Roskar <roskarr@ethz.ch>
+    Date:   Thu Oct 4 01:04:04 2018 +0200
+
+        renku run python src/plot_data.py data/preprocessed/zhbikes.parquet
+
+    commit e6590bd40bdda10339417b992d1869523915b767
+    Author: Rok Roskar <roskarr@ethz.ch>
+    Date:   Thu Oct 4 01:03:14 2018 +0200
+
+        renku run python src/clean_data.py data/zhvelo ...
+
+    commit b3ce8ac5b9d239fd710b3be2ae2afad1f7a4509d
+    Author: Rok Roskar <roskarr@ethz.ch>
+    Date:   Thu Oct 4 00:56:36 2018 +0200
+
+        renku dataset add zhvelo --relative-to data/zhvelo ...
+        git+ssh://renkulab.io/team-renku/zurich-bikes-data.git
+
+    commit f346c1f36f211840b22a63e7fc2c9bfb52616212
+    Author: Rok Roskar <roskarr@ethz.ch>
+    Date:   Wed Oct 3 22:26:38 2018 +0200
+
+        renku dataset create zhvelo
+
+
+Now lets say you decide your data imports and everything that followed was
+wrong and you want to go back to "renku dataset create zhvelo", i.e.
+commit ``f346c1f36f211840b22a63e7fc2c9bfb52616212``, you would do:
+
+.. code-block:: console
+
+    git reset --hard f346c1f36f211840b22a63e7fc2c9bfb52616212
+
+Easy!

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -8,4 +8,6 @@ User Documentation
 
    First Steps <firststeps>
    CLI Installation <cli-installation>
+   Data in Renku <lfs>
+   Git tips <git_tips>
    Troubleshooting <troubleshooting>

--- a/docs/user/lfs.rst
+++ b/docs/user/lfs.rst
@@ -1,0 +1,42 @@
+.. _lfs:
+
+Data in Renku
+=============
+
+Renku uses the `git Large File Storage (LFS) <https://git-lfs.github.com/>`_ for handling data.
+Using standard git for large files is difficult because the data itself is
+converted into git objects and placed in the repository. Git LFS lets you
+include large data files in your repository efficiently while using more
+or less just the standard set of git commands. In addition, git LFS places
+large files on the server and allows you to work with your repository without
+actually having a local copy of the data. You can pull the data from the server
+as it becomes needed, saving you time and resources.
+
+Using git LFS responsibly
+-------------------------
+
+The default configuration of git LFS is to pull recent data from the server
+and into the working copy of the repository. This is fine if the data is
+reasonably small (~GB size) but as it becomes larger, the default behavior
+can start to pose problems.
+
+Imagine a renku project with 100GB of data in LFS. If a few collaborators all
+decide to work on the project at the same time and launch the JupyterLab
+environment to iterate over some changes, each might attempt to download 100GB
+of data to each of their JupterLab sessions. Not only will this take  a long
+time, but it might also eventually lead to resource starvation on the host
+node.
+
+Data in JupyterLab sessions
+---------------------------
+
+Due to the resource concerns, we therefore do not pull data into user
+JupyterLab sessions by default. As a result, you do need to be aware of dealing
+with data stored in LFS if you want to use it efficiently in your work with
+renku.
+
+Useful git LFS commands
+-----------------------
+
+* ``git lfs ls-files``: shows all the files currently in LFS
+* ``git lfs pull <remote> -I <path>``: pull a specific file from LFS


### PR DESCRIPTION
Improves the user documentation including:

* info about how to install into an isolated environment with conda
* some first instructions to use git-lfs
* git tips
* add a note about `renku rerun` to the first steps 

addresses #452 
addresses #343 