### PR TITLE
Fix minikube-values.yaml

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -50,7 +50,7 @@ notebooks:
       baseUrl: '/jupyterhub/'
       db:
         type: postgres
-        url: postgres+psycopg2://jupyterhub:jupyterhub@renku-postgresql:5432/jupyterhub
+        url: postgres+psycopg2://jupyterhub:d6f59c5df645abe2fd1a0572b6bd5a8d@renku-postgresql:5432/jupyterhub
       services:
         notebooks:
           apiToken: notebookstoken


### PR DESCRIPTION
Fix the postgres password in the url used by jupyterhub to connect to postgres.

Note: This  works, however it's not very elegant to just copy paste a value from another line in `minikube-values.yaml`. On the other hand, values files are not templateable themselves... Is there a better way to do this?