### PR TITLE
Fix logout for Renku and missing value

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -71,6 +71,7 @@ notebooks:
         callbackUrl: '""' # Forces the default callback url
 
 gateway:
+  secretKey: 5495ef917488a19d1d4106452c899f5824972acd87edce11fd65e7956bea3bb0
   jupyterhub:
     clientId: *gatewayClient
     clientSecret: *gatewaySecret

--- a/charts/renku/templates/configmap.yaml
+++ b/charts/renku/templates/configmap.yaml
@@ -63,7 +63,7 @@ data:
 
     # configure the logout redirect
     curl -f -is -X PUT -H "Private-token: ${GITLAB_SUDO_TOKEN}" \
-      ${GITLAB_SERVICE_URL}/api/v4/application/settings?after_sign_out_path={{ template "http" . }}://{{ .Values.global.renku.domain }}/auth/realms/Renku/protocol/openid-connect/logout?redirect_uri=${GITLAB_URL}
+      ${GITLAB_SERVICE_URL}/api/v4/application/settings?after_sign_out_path={{ template "http" . }}://{{ .Values.global.renku.domain }}/auth/realms/Renku/protocol/openid-connect/logout?redirect_uri={{ template "http" . }}://{{ .Values.global.renku.domain }}/api/auth/logout%3Fgitlab_logout=1
   {{- end }}
   # Init scripts that populate /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
Unfortunately gitlab "redirect after logout" is a global setting. So either it works nice with the Renku UI (redirecting to the renku home page) or it works nice when using gitlab only (redirecting to gitlab's home page and potentially directly to keycloak login again).