### PR TITLE
[chart] increase timeout for keycloak readiness probe

### DIFF
--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -90,6 +90,9 @@ keycloak:
     ## Keycloak admin user configuration
     username: admin
     password: admin
+    
+    readinessProbe:
+      initialDelaySeconds: 120
 
     extraInitContainers: |
       - name: theme-provider

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -91,6 +91,8 @@ keycloak:
     username: admin
     password: admin
     
+    livenessProbe:
+      initialDelaySeconds: 180
     readinessProbe:
       initialDelaySeconds: 120
 


### PR DESCRIPTION
It was too short, so keycloak mey not have the time to start