### PR TITLE
Fixed naming of the webhook-service's event consuming endpoint

### DIFF
--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -66,7 +66,7 @@ spec:
         backend:
           serviceName: {{ $uiFullname }}
           servicePort: {{ $uiServicePort }}
-      - path: /webhook-event
+      - path: /webhooks/events
         backend:
           serviceName: {{ $graphFullname }}-webhook-service
           servicePort: 80


### PR DESCRIPTION
I reminded a suggestion that `webhook-service`'s endpoints names are a bit broken. I fixed that as I think it's easier to do it now.