### PR TITLE
Added hookToken.secret value required during webhook-service deployment

### DIFF
--- a/charts/example-configurations/minikube-values-gitlab.yaml
+++ b/charts/example-configurations/minikube-values-gitlab.yaml
@@ -100,6 +100,8 @@ graph:
   webhookService:
     play:
       secret: 79=CRbPUHVQg^kvjQyA>zyZ4s7>ElKz;wW4`<??BlJxO6pQTdlx5M<[jWxWylHx[
+    hookToken:
+      secret: NjFkNmJiODgyYjk4OWUzNwo=
 
   triplesGenerator:
     play:

--- a/charts/example-configurations/minikube-values-renkulab-template.yaml
+++ b/charts/example-configurations/minikube-values-renkulab-template.yaml
@@ -95,6 +95,8 @@ graph:
   webhookService:
     play:
       secret: # generate with `sbt playGenerateSecret`
+    hookToken:
+      secret: # generate with `openssl rand -hex 8|base64`
   triplesGenerator:
     play:
       secret: # generate with `sbt playGenerateSecret`

--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -96,6 +96,8 @@ graph:
   webhookService:
     play:
       secret: 79=CRbPUHVQg^kvjQyA>zyZ4s7>ElKz;wW4`<??BlJxO6pQTdlx5M<[jWxWylHx[
+    hookToken:
+      secret: NjFkNmJiODgyYjk4OWUzNwo=
 
   triplesGenerator:
     play:

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -579,6 +579,8 @@ gateway:
 #   webhookService:
 #     play:
 #       secret:
+#     hookToken:
+#       secret:
 
 #   triplesGenerator:
 #     play:


### PR DESCRIPTION
This secret I forgot the other day and effectively all the environments would be using the same secret for encrypting the hook tokens send from Gitlab