### PR TITLE
DB Event Log instead of File Event Log for Graph

### DIFF
--- a/charts/example-configurations/minikube-values-gitlab.yaml
+++ b/charts/example-configurations/minikube-values-gitlab.yaml
@@ -30,6 +30,8 @@ global:
   renku:
     version: 'latest'
   graph:
+    dbEventLog:
+      postgresPassword: 48393478cb806eb12660b74fbe2ce2eb
     tokenRepository:
       postgresPassword: 7cbc3ee01539e546c0b80ddebe619d04
 

--- a/charts/example-configurations/minikube-values-renkulab-template.yaml
+++ b/charts/example-configurations/minikube-values-renkulab-template.yaml
@@ -32,6 +32,8 @@ global:
   renku:
     version: 'latest'
   graph:
+    dbEventLog:
+      postgresPassword: 58dd574b6a19f9b6b2cedaf20f402abf
     tokenRepository:
       postgresPassword: 12db5d7b3f0e38c79ad08b6e7f2bcaf4
 

--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -28,6 +28,8 @@ global:
   renku:
     version: 'latest'
   graph:
+    dbEventLog:
+      postgresPassword: c9cbc7c900c4c60ff329998036b3f6cb
     tokenRepository:
       postgresPassword: 1bed5ee10efe7132a1904b09e1f3701a
 

--- a/charts/renku/templates/configmap.yaml
+++ b/charts/renku/templates/configmap.yaml
@@ -139,6 +139,26 @@ data:
   {{- end }}
 
   {{- if .Values.graph.enabled }}
+
+  init-dbEventLog-db.sh: |-
+      #!/bin/bash
+      set -x
+
+      DB_EVENT_LOG_POSTGRES_PASSWORD=$(cat /passwords/graph-dbEventLog-postgresPassword)
+      DB_EVENT_LOG_DB_NAME=event_log
+
+      psql -v ON_ERROR_STOP=1 <<-EOSQL
+        create database "$DB_EVENT_LOG_DB_NAME";
+        create user "{{ .Values.global.graph.dbEventLog.postgresUser }}" password '$DB_EVENT_LOG_POSTGRES_PASSWORD';
+      EOSQL
+
+      psql postgres -v ON_ERROR_STOP=1 --dbname "$DB_EVENT_LOG_DB_NAME" <<-EOSQL
+        create extension if not exists "pg_trgm";
+        revoke all on schema "public" from "public";
+        grant all privileges on database "$DB_EVENT_LOG_DB_NAME" to "{{ .Values.global.graph.dbEventLog.postgresUser }}";
+        grant all privileges on schema "public" to "{{ .Values.global.graph.dbEventLog.postgresUser }}";
+      EOSQL
+
   init-tokenRepository-db.sh: |-
       #!/bin/bash
       set -x

--- a/charts/renku/templates/secrets.yaml
+++ b/charts/renku/templates/secrets.yaml
@@ -30,4 +30,5 @@ data:
   jupyterhub-auth-gitlab-client-secret: {{ required "Fill in .Values.notebooks.jupyterhub.auth.gitlab.clientSecret with `openssl rand -hex 32`" .Values.notebooks.jupyterhub.auth.gitlab.clientSecret | b64enc | quote }}
   gateway-gitlab-client-secret: {{ required "Fill in .Values.global.gateway.gitlabClientSecret with `openssl rand -hex 32`" .Values.global.gateway.gitlabClientSecret | b64enc | quote }}
 
+  graph-dbEventLog-postgresPassword: {{ required "Fill in .Values.global.graph.dbEventLog.postgresPassword with `openssl rand -hex 16`" .Values.global.graph.dbEventLog.postgresPassword | b64enc | quote }}
   graph-tokenRepository-postgresPassword: {{ required "Fill in .Values.global.graph.tokenRepository.postgresPassword with `openssl rand -hex 16`" .Values.global.graph.tokenRepository.postgresPassword | b64enc | quote }}

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -54,6 +54,12 @@ global:
     version: 0.3.1
   ## Note that the graph will not turned on by default until renku 0.4.0
   graph:
+    dbEventLog:
+      ## Name of the postgres user to be used to access the Event Log db
+      postgresUser: eventlog
+      ## Postgres password to be used to access the Event Log db
+      ## Generated using: `openssl rand -hex 16`
+      postgresPassword:
     tokenRepository:
       ## Name of the postgres user to be used to access the db storing access tokens
       postgresUser: tokenstorage

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -606,17 +606,7 @@ graph:
     tokenEncryption:
       secret: 1234
 
-  triplesGenerator:
-    play:
-      ## A Play app secret used for built in encryption utilities
-      ## Generated using: `sbt playGenerateSecret`
-      secret: 1234
-
   webhookService:
-    play:
-      ## A Play app secret used for built in encryption utilities
-      ## Generated using: `sbt playGenerateSecret`
-      secret: 1234
     hookToken:
       ## A secret for signing request header tokens to be sent by GitLab with the Push Events
       ## Generated using: `openssl rand -hex 8|base64`


### PR DESCRIPTION
This change is to make https://github.com/SwissDataScienceCenter/renku-graph/pull/59 compatible with `renku`.