### PR TITLE
hotfix against YAML 1.2 rendering issues for renku.yaml

### DIFF
--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
+icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
 version: 0.3.1

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -84,7 +84,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: off   # Needed if GitLab is behind this ingress
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"   # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`


### PR DESCRIPTION
Unquoted `nginx.ingress.kubernetes.io/proxy-request-buffering: off` potentially results in problematic rendering by YAML 1.2 parsing, exposing us to issues such as:
* Un-quoted "on" and "off" strings evaluated as true/false in values.yaml
   ref. https://github.com/helm/helm/issues/5497

Namely, when this value is unquoted `off` it can be interpreted as `false`, then nginx cannot digest it and it results in service suppression.

p.s. the icon 1 line diff in `renku/Chart.yaml` is cosmetic, I merely avoid a trivial PR.