### PR TITLE
nginx-ingress: avoid `proxy-request-buffering: off`

### DIFF
--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -84,7 +84,8 @@ ingress:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"   # Needed if GitLab is behind this ingress
+    # The below line is uncommented as a _temporary_ measure, to streamline our charts generation and avoid a certain yaml bug
+    ## nginx.ingress.kubernetes.io/proxy-request-buffering: "off"   # Needed if GitLab is behind this ingress
 
   ## Hosts for the ingress
   ## Should include at least the value from `global.renku.domain`


### PR DESCRIPTION
This PR lives in a grey zone; please pause to discuss merits before reject/accept.

Let's refrain to explain *why* `proxy-request-buffering` is there - that is NOT the issue.