### PR TITLE
Prep 0.4.1

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.3.1
+version: 0.4.1

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: renku-ui
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.5.1
+  version: 0.6.2
 - name: renku-notebooks
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.3.3
+  version: 0.4.0
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.4.0
+  version: 0.4.1
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.3.1-6fb1535
 - name: renku-graph
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.1.0
+  version: 0.6.0-5411305
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -23,5 +23,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:47683be1c8c6eec28d23556906e15f5d4e754874fb916244652304583b4eb278
-generated: "2019-06-12T17:55:20.911149+02:00"
+digest: sha256:3c2fbc9e9e9ea927cb70865e0b013f355d3a243a738e53dd5bee62a5fa3a9e4f
+generated: "2019-08-06T17:52:56.191589+02:00"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -2,15 +2,15 @@ dependencies:
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.5.1"
+  version: "0.6.2"
 - name: renku-notebooks
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.3.3"
+  version: "0.4.0"
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.4.0"
+  version: "0.4.1"
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.3.1-6fb1535"
@@ -18,7 +18,7 @@ dependencies:
 - name: renku-graph
   alias: graph
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.5.0"
+  version: "0.6.0-5411305"
   condition: graph.enabled
 - name: postgresql
   version: 0.14.4

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -338,6 +338,10 @@ gitlab:
     repository: gitlab/gitlab-ce
     tag: 11.8.10-ce.0
 
+  ## automatically log in to gitlab
+  oauth:
+    autoSignIn: true
+
   ## Pod affinity for Gitlab deployment
   # affinity: {}
   ## Node selector for Gitlab deployment

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -551,7 +551,7 @@ notebooks:
     singleuser:
       image:
         name: renku/singleuser
-        tag: 0.3.4-renku0.5.0
+        tag: 0.3.5-renku0.5.2
     #   # use JupyterLab by default in notebook servers
     #   defaultUrl: /lab
 


### PR DESCRIPTION
https://swissdatasciencecenter.github.io/helm-charts/renku-0.4.1-rc2.tgz is deployed on https://limited.renku.ch -- seems to be fine, upgrade was mostly trivial apart from adjusting a few values. 

closes #603 