### PR TITLE
Rename main renku client in Keycloak

### DIFF
--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -7,13 +7,13 @@ dependencies:
   version: 0.5.1
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.5.0
+  version: 0.6.0-b332cdc
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.3.1-6fb1535
 - name: renku-graph
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.10.0
+  version: 0.19.0
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.14.4
@@ -23,5 +23,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:ec3e37d458279261ea8ac14f7fc5369a0d14bccb081e86b48c545c592de7d5f2
-generated: "2019-08-28T10:57:29.16659+02:00"
+digest: sha256:4a5596f20ffb9a2aaa8ad426ce3c1244005e6f43ffb146f8cfc4d4d4084c2e08
+generated: "2019-10-15T22:44:31.843702+02:00"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.5.0-53e3962 "
+  version: "0.6.0-b332cdc"
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.3.1-6fb1535"

--- a/charts/renku/templates/_keycloak-clients-users.tpl
+++ b/charts/renku/templates/_keycloak-clients-users.tpl
@@ -5,8 +5,8 @@ Define clients and users for Keycloak
 {{- define "renku.keycloak.clients" -}}
 [
   {
-    "clientId": "gateway",
-    "baseUrl": "{{ template "http" . }}://{{ .Values.global.renku.domain }}/api",
+    "clientId": "renku",
+    "baseUrl": "{{ template "http" . }}://{{ .Values.global.renku.domain }}",
     "secret": "{{ required "Fill in .Values.global.gateway.clientSecret with `uuidgen -r`" .Values.global.gateway.clientSecret }}",
     "redirectUris": [
         "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
@@ -15,12 +15,12 @@ Define clients and users for Keycloak
         "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
     ],
     "protocolMappers": [{
-      "name": "audience for gateway",
+      "name": "audience for renku",
       "protocol": "openid-connect",
       "protocolMapper": "oidc-audience-mapper",
       "consentRequired": false,
       "config": {
-        "included.client.audience": "gateway",
+        "included.client.audience": "renku",
         "id.token.claim": false,
         "access.token.claim": true,
         "userinfo.token.claim": false


### PR DESCRIPTION
This PR renames the the "gateway" client application in Keycloak to "renku".

Merge right after https://github.com/SwissDataScienceCenter/renku-gateway/pull/176.

Closes #519 and #641.