### PR TITLE
Renku hotfix for 0.4.2

### DIFF
--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.4.2
+version: 0.4.3

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
 - name: renku-graph
   alias: graph
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.10.0"
+  version: "0.10.1"
   condition: graph.enabled
 - name: postgresql
   version: 0.14.4


### PR DESCRIPTION
This PR creates a hotfix release 0.4.3 for Renku 0.4.2. The only change is a new version of renku-graph.