### PR TITLE
chore: updated version of renku-graph

### DIFF
--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
 - name: renku-graph
   alias: graph
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.22.0"
+  version: "0.24.6"
   condition: graph.enabled
 - name: postgresql
   version: 0.14.4


### PR DESCRIPTION
This PR raises a version of renku-graph to 0.24.6.