### PR TITLE
build: add renku-core-service

### DIFF
--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.5.1
+version: 0.6.0

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: renku-core
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.1.0-0a5391d
+  version: 0.1.0-d0fcb21
 - name: renku-ui
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.7.2
@@ -10,7 +10,7 @@ dependencies:
   version: 0.6.2
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.7.0-bcf034e
+  version: 0.7.0-ee94e63
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.4.1-791604e
@@ -26,5 +26,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:33c26d911d5fb17a9efc946a6fd75d142d35a24109985f186b09b384c04280d8
-generated: "2020-01-07T13:53:55.344523+01:00"
+digest: sha256:38a3bc29f6854ed06746dddb0d4933e71543044b29ff5ccaac6ca9d2fc5cc327
+generated: "2020-01-10T13:51:23.973958+01:00"

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
-- name: renku-core-service
+- name: renku-core
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.1.0-70bd8a9
+  version: 0.1.0-0a5391d
 - name: renku-ui
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.7.2
@@ -10,7 +10,7 @@ dependencies:
   version: 0.6.2
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.7.0-6a722bd
+  version: 0.7.0-bcf034e
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.4.1-791604e
@@ -26,5 +26,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:46126cfc4e0beb2598522e1020f6c8b8762755ded54b63a482a506e8d6afb6fb
-generated: "2019-12-11T16:39:56.175303+01:00"
+digest: sha256:33c26d911d5fb17a9efc946a6fd75d142d35a24109985f186b09b384c04280d8
+generated: "2020-01-07T13:53:55.344523+01:00"

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: renku-core-service
+  repository: https://swissdatasciencecenter.github.io/helm-charts/
+  version: 0.1.0-70bd8a9
 - name: renku-ui
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.7.2
@@ -7,7 +10,7 @@ dependencies:
   version: 0.6.2
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.6.0
+  version: 0.7.0-6a722bd
 - name: gitlab
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.4.1-791604e
@@ -23,5 +26,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:4e342d217eeb8ee04ede751a6fd600a2d714747d46214a739758c6ccd895a7f2
-generated: 2020-01-06T17:13:28.804840746Z
+digest: sha256:46126cfc4e0beb2598522e1020f6c8b8762755ded54b63a482a506e8d6afb6fb
+generated: "2019-12-11T16:39:56.175303+01:00"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
-- name: renku-core-service
-  alias: core-service
+- name: renku-core
+  alias: core
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.1.0-70bd8a9"
+  version: "0.1.0-0a5391d"
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
@@ -14,7 +14,7 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.7.0-6a722bd"
+  version: "0.7.0-bcf034e"
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.4.1-791604e"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - name: renku-core
   alias: core
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.1.0-0a5391d"
+  version: "0.1.0-d0fcb21"
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
@@ -14,7 +14,7 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.7.0-bcf034e"
+  version: "0.7.0-ee94e63"
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.4.1-791604e"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -1,4 +1,8 @@
 dependencies:
+- name: renku-core-service
+  alias: core-service
+  repository: "https://swissdatasciencecenter.github.io/helm-charts/"
+  version: "0.1.0-70bd8a9"
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
@@ -10,7 +14,7 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.6.0"
+  version: "0.7.0-6a722bd"
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.4.1-791604e"

--- a/charts/renku/templates/_helpers.tpl
+++ b/charts/renku/templates/_helpers.tpl
@@ -80,3 +80,7 @@ Define subcharts full names
 {{- define "knowledgeGraph.fullname" -}}
 {{- printf "%s-%s" .Release.Name "knowledge-graph" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "core-service.fullname" -}}
+{{- printf "%s-%s" .Release.Name "core-service" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/renku/templates/_helpers.tpl
+++ b/charts/renku/templates/_helpers.tpl
@@ -81,6 +81,6 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "knowledge-graph" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "core-service.fullname" -}}
-{{- printf "%s-%s" .Release.Name "core-service" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- define "core.fullname" -}}
+{{- printf "%s-%s" .Release.Name "core" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -673,3 +673,11 @@ graph:
   #     ## A secret for signing request header tokens to be sent by GitLab with the Push Events
   #     ## Generated using: `openssl rand -hex 8|base64`
   #     secret: 1234
+
+## Configuration for renku-core-service
+# repository:
+  ## Default cache directory
+  # cacheDirectory: /svc/cache
+
+  ## Default clone depth
+  # projectCloneDepth: 1

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -674,7 +674,7 @@ graph:
   #     ## Generated using: `openssl rand -hex 8|base64`
   #     secret: 1234
 
-## Configuration for renku-core-service
+## Configuration for renku-core service
 # repository:
   ## Default cache directory
   # cacheDirectory: /svc/cache


### PR DESCRIPTION
Adds the renku core-service to the deployment. 

closes #709

depends on https://github.com/swissdatasciencecenter/renku-python/issues/772 and https://github.com/swissdatasciencecenter/renku-gateway/issues/180