### PR TITLE
build: enable gitlab json logging

### DIFF
--- a/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/gitlab/templates/_gitlab.rb.tpl
@@ -116,4 +116,13 @@ gitlab_rails['rack_attack_git_basic_auth'] = {
   'enabled' => false
 }
 
+{{ if .Values.logging.useJson -}}
+gitaly['logging_format'] = 'json'
+gitlab_shell['log_format'] = 'json'
+gitlab_workhorse['log_format'] = 'json'
+registry['log_formatter'] = 'json'
+sidekiq['log_format'] = 'json'
+gitlab_pages['log_format'] = 'json'
+{{- end }}
+
 {{- end -}}

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -117,3 +117,7 @@ redis:
   networkPolicy:
     enabled: true
     allowExternal: false
+
+# Enable json logs for all services
+logging:
+  useJson: true


### PR DESCRIPTION
This turns on gitlab json logging for all services. From gitlab 12.x this is anyway the default in which case these options will not be needed. 