### PR TITLE
chore: add ui sentry info

### DIFF
--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -528,6 +528,12 @@ ui:
   # templatesRepository:
     # url: https://github.com/SwissDataScienceCenter/renku-project-template
     # ref: 0.1.5
+  ## Configuration for Sentry
+  # sentry:
+  #   enabled: true
+  #   url: 'https://<key>@sentry.io/<project>'
+  #   namespace: 'renku_namespace'
+
 # ## Configuration for the notebooks service
 notebooks:
   ## serverOptions allow for modifications to the notebook pod resource requests and the UI rendering

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -530,9 +530,9 @@ ui:
     # ref: 0.1.5
   ## Configuration for Sentry
   # sentry:
-  #   enabled: true
-  #   url: 'https://<key>@sentry.io/<project>'
-  #   namespace: 'renku_namespace'
+  #   enabled: false
+  #   url: ''
+  #   namespace: ''
 
 # ## Configuration for the notebooks service
 notebooks:

--- a/charts/values.yaml.changelog.md
+++ b/charts/values.yaml.changelog.md
@@ -6,6 +6,9 @@ Please follow this convention when adding a new row
 
 ----
 
+## Changes on top of Renku 0.5.2
+* NEW - *ui.sentry*: added Sentry information for logging runtime exceptions
+
 ## Changes on top of Renku 0.4.3
 * EDIT - *notebooks.serverOptions*: added `<resource>.order` to control ui rendering order. The default values defined in notebooks are now different.
 * DELETE - *graph.knowledgeGraph.services.renku.url*: no need for this anymore as it's linked to `global.renku.domain` internally. Ref: [refactor KG remove services renku URL](https://github.com/SwissDataScienceCenter/renku/commit/6d4a0e5cf02833d193f86a38cc14762609fcd9c0)


### PR DESCRIPTION
This PR adds basic info to `charts/renku/values.yaml` about the new `ui.sentry` settings. Related to SwissDataScienceCenter/renku-ui#761