### PR TITLE
feat: add ingress rule for /entities

### DIFF
--- a/charts/renku/templates/ingress.yaml
+++ b/charts/renku/templates/ingress.yaml
@@ -66,6 +66,10 @@ spec:
         backend:
           serviceName: {{ $gatewayFullname }}
           servicePort: {{ $gatewayServicePort }}
+      - path: /entities
+        backend:
+          serviceName: {{ $gatewayFullname }}
+          servicePort: {{ $gatewayServicePort }}
       - path: /
         backend:
           serviceName: {{ $uiFullname }}


### PR DESCRIPTION
This PR adds an ingress rule which forwards traffic from `/entities` to the gateway.

Currently deployed together with https://github.com/swissdatasciencecenter/renku-gateway/issues/174 under https://andreas.dev.renku.ch