### PR TITLE
Modify Renku chart to enable anonymous notebook sessions (optional)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,23 @@
 .. _changelog:
 
+0.6.2
+-----
+
+New features
+~~~~~~~~~~~~
+
+- Logged-in users without developer access can launch interactive sessions from a project.
+
+- Interactive sessions can be enabled for logged-out users. Please see the
+  `documentation <https://renku.readthedocs.io/en/latest/admin/index.html#enabling-notebooks-for-anonymous-users>`__ for details.
+
+Upgrading from 0.6.1
+~~~~~~~~~~~~~~~~~~~~
+
+* If you want to enable interactive sessions for anonymous users, see the
+  `values changelog <https://github.com/SwissDataScienceCenter/renku/blob/master/charts/values.yaml.changelog.md>`__ file.
+
+
 0.6.1
 -----
 

--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.6.0
+version: 0.6.1

--- a/charts/renku/requirements.lock
+++ b/charts/renku/requirements.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.10.3-a68dcb7
 - name: renku-ui
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.9.2-8a4685a
+  version: 0.9.1-n008.ha2f5325
 - name: renku-notebooks
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.7.1-0aec590
+  version: 0.7.2-e00ce47
 - name: renku-gateway
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.7.1-deb488b
@@ -26,5 +26,5 @@ dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.0
-digest: sha256:b3d7d18fda8118a73ec27c805f110da5a4940d0c2d144562fecfb6fc43252f56
-generated: 2020-04-14T19:04:30.178207317Z
+digest: sha256:34c16bf7a89fb1217cf5af0708e2ca3b054e8ce5741ed5275c90370a2fcae2aa
+generated: "2020-04-14T18:25:32.231125+02:00"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -6,11 +6,11 @@ dependencies:
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.9.2-8a4685a
+  version: 0.9.1-n008.ha2f5325
 - name: renku-notebooks
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.7.1-0aec590
+  version: 0.7.2-e00ce47
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/charts/renku/templates/NOTES.txt
+++ b/charts/renku/templates/NOTES.txt
@@ -8,3 +8,28 @@ You have configured a demo user for the platform. The details (password) of this
 can be accessed using the following one-liner (you need to have jq installed).
 kubectl get secrets -n <k8s-namespace> {{ template "renku.fullname" . }} -o json | jq -r .data.users | base64 --decode
 {{- end -}}
+
+{{- if .Values.global.anonymousSessions.enabled -}}
+You have enabled anonymous interactive sessions. For this feature to work you
+will have to perform a few manual steps. These are the ready-made or almost ready
+commands that you will need. Check out the docs for more information:
+https://renku.readthedocs.io/en/latest/admin/index.html#enabling-notebooks-for-anonymous-users
+
+{{ if .Values.global.anonymousSessions.autoCreateTmpNamespace -}}
+A secondary namespace {{ .Release.Namespace }}-tmp has been created.
+{{ else }}
+Please create a secondary namespace using the following command:
+$ kubectl create namespace {{ .Release.Namespace }}-tmp
+{{- end }}
+
+You have to copy a secret into this secondary namespace using this command:
+$ kubectl get secret renku-jupyterhub-tmp-postgres -n {{ .Release.Namespace }} -o yaml | grep -v '^\s*namespace:\s' | kubectl apply -n {{ .Release.Namespace }}-tmp -f -
+
+The following two commands have to be executed from renku-notebooks/helm-chart.
+
+The command to create a values file for your secondary notebooks-service deployment:
+$ pipenv run ./make-values-tmp.py  --values-file <path-to-renku-values> --renku-namespace {{ .Release.Namespace }}
+
+Finally, the command for deploying the secondary notebooks service:
+$ helm upgrade --install {{ .Release.Namespace }}-tmp-notebooks --namespace {{ .Release.Namespace }}-tmp -f ./notebooks-tmp-values.yaml --timeout 1800  ./renku-notebooks
+{{ end }}

--- a/charts/renku/templates/anonymous-notebooks-namespace.yaml
+++ b/charts/renku/templates/anonymous-notebooks-namespace.yaml
@@ -1,0 +1,11 @@
+{{ if and .Values.global.anonymousSessions.enabled .Values.global.anonymousSessions.autoCreateTmpNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}-tmp
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{ end }}

--- a/charts/renku/templates/configmap.yaml
+++ b/charts/renku/templates/configmap.yaml
@@ -170,3 +170,18 @@ data:
           grant all privileges on database "{{ .Values.global.jupyterhub.postgresDatabase }}" to "{{ .Values.global.jupyterhub.postgresUser }}";
           grant all privileges on schema "public" to "{{ .Values.global.jupyterhub.postgresUser }}";
       EOSQL
+{{ if .Values.global.anonymousSessions.enabled }}
+      JUPYTERHUB_TMP_POSTGRES_PASSWORD=$(cat /jupyterhub-tmp-postgres/jupyterhub-tmp-postgres-password)
+
+      psql -v ON_ERROR_STOP=1 <<-EOSQL
+          create database "{{ .Values.global.jupyterhub.postgresDatabase }}-tmp";
+          create user "{{ .Values.global.jupyterhub.postgresUser }}-tmp" password '$JUPYTERHUB_TMP_POSTGRES_PASSWORD';
+      EOSQL
+
+      psql -v ON_ERROR_STOP=1 --dbname "{{ .Values.global.jupyterhub.postgresDatabase }}-tmp" <<-EOSQL
+          create extension if not exists "pg_trgm";
+          revoke all on schema "public" from "public";
+          grant all privileges on database "{{ .Values.global.jupyterhub.postgresDatabase }}-tmp" to "{{ .Values.global.jupyterhub.postgresUser }}-tmp";
+          grant all privileges on schema "public" to "{{ .Values.global.jupyterhub.postgresUser }}-tmp";
+      EOSQL
+{{ end }}

--- a/charts/renku/templates/jupyterhub-tmp-postgres-secret.yaml
+++ b/charts/renku/templates/jupyterhub-tmp-postgres-secret.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.global.anonymousSessions.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: renku-jupyterhub-tmp-postgres
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{ if or .Values.global.anonymousSessions.postgresPassword.value .Values.global.anonymousSessions.postgresPassword.overwriteOnHelmUpgrade -}}
+    "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
+    {{- else -}}
+    "helm.sh/hook": "pre-install,pre-rollback"
+    {{- end }}
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  jupyterhub-tmp-postgres-password: {{ default (randAlphaNum 64) .Values.global.anonymousSessions.postgresPassword.value | b64enc | quote }}
+{{ end }}

--- a/charts/renku/templates/post-install-job-postgres.yaml
+++ b/charts/renku/templates/post-install-job-postgres.yaml
@@ -44,6 +44,11 @@ spec:
             - name: jupyterhub-postgres
               mountPath: /jupyterhub-postgres
               readOnly: true
+            {{ if .Values.global.anonymousSessions.enabled }}
+            - name: jupyterhub-tmp-postgres
+              mountPath: /jupyterhub-tmp-postgres
+              readOnly: true
+            {{ end }}
             - name: graph-db-postgres
               mountPath: /graph-db-postgres
               readOnly: true
@@ -83,6 +88,11 @@ spec:
         - name: jupyterhub-postgres
           secret:
             secretName: renku-jupyterhub-postgres
+        {{ if .Values.global.anonymousSessions.enabled }}
+        - name: jupyterhub-tmp-postgres
+          secret:
+            secretName: renku-jupyterhub-tmp-postgres
+        {{ end }}
         - name: graph-db-postgres
           secret:
             secretName: {{ template "renku.fullname" . }}-graph-db-postgres

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -83,6 +83,20 @@ global:
       dataset:
   ## Set to true if using https
   useHTTPS: false
+  anonymousSessions:
+    ## Set to true to enable anonymous sessions through
+    ## a secondary Jupyterhub instance
+    enabled: false
+    ## Set the postgres password for you secondary JH deployment
+    ## or force the (re)generation of it on helm upgrade.
+    postgresPassword:
+      value:
+      overwriteOnHelmUpgrade: false
+    ## Set to false to avoid auotmatically creating the secondary
+    ## k8s namespace for the tmp notebooks-service deployment. This
+    ## can be necessary to avoid permission problems in renku.dev.ch
+    ## deployments.
+    autoCreateTmpNamespace: true
 
 ## Ingress configuration
 ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/
@@ -575,13 +589,14 @@ notebooks:
     # rbac:
     #   enabled: true
     ## Set the notebooks service API token
-    # hub:
-    #   services:
+    hub:
+      services:
         # notebooks:
         #   api_token: notebookstoken
 
         ## define the client ID and secret for the gateway
-        # gateway:
+        gateway:
+          oauth_no_confirm: true
         #  oauth_client_id: gateway
         #  apiToken: # use `openssl rand -hex 32`
         #  oauth_redirect_uri: http://<gateway>/api/auth/jupyterhub/token

--- a/charts/values.yaml.changelog.md
+++ b/charts/values.yaml.changelog.md
@@ -5,6 +5,12 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
+## Changes on top of Renku 0.6.1
+Interactive sessions for logged-out users are now possible, see
+[the docs](https://renku.readthedocs.io/en/latest/admin/index.html#enabling-notebooks-for-anonymous-users).
+* NEW - *global.anonymousSessions.enabled*: set to true to turn on notebook sessions
+for logged out users.
+* NEW - *global.anonymousSessions.postgresPassword.overwriteOnHelmUpgrade*: set to `true` when upgrading an existing deployment, then back to `false` (default value).
 
 ## Changes on top of Renku 0.5.2
 * NEW - *ui.sentry*: added Sentry information for logging runtime exceptions

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -122,6 +122,43 @@ For instance, make a user admin on GitLab.
 3. modify any users you want to modify (e.g. to make them admin)
 4. turn the automatic redirect back on
 
+Enabling notebooks for anonymous users
+--------------------------------------
+
+Interactive sessions launched from public notebooks can be made available to
+logged-out users. However, this feature is deactivated by default. In order
+to activate it, you need a secondary deployment of the renku-notebooks chart
+(including a secondary Jupyterhub as a dependency) to handle the anonymous
+("temporary") sessions.
+
+1. Set :code:`global.anonymousSessions.enabled: true` in your values.yaml file. If you are
+   updating an existing deployment you have to set :code:`global.anonymousSessions.postgresPassword.overwriteOnHelmUpgrade: true`
+   for the upgrade and then back to `false` for upcoming deployments.
+
+2. Deploy renkulab (or update your existing deployment) just as you would otherwise.
+
+3. Copy a necessary secret from your primary to your secondary namespace (the exact command
+   should have been rendered and displayed after a successful deployment in the previous step:
+
+.. code-block:: bash
+
+   kubectl get secret renku-jupyterhub-tmp-postgres -n <primary-namespace> -o yaml | grep -v '^\s*namespace:\s' | kubectl apply -n <secondary-namespace> -f -
+
+4. Now change to the :code:`helm-chart` folder of the :code:`renku-notebooks` repository and use the `./make-values.py <https://github.com/SwissDataScienceCenter/renku-notebooks/blob/master/helm-chart/make-values.py>`_
+   script to create a values file for your secondary notebooks deployment:
+
+.. code-block:: bash
+
+   pipenv run ./make-values-tmp.py  --values-file <renku-values> --renku-namespace <primary-namespace>
+
+5. From :code:`renku-notebooks/helm-charts` deploy the secondary renku-notebooks deployment:
+
+.. code-block:: bash
+
+   helm upgrade --install <some-unique-release-name> --namespace <secondary-namespace> -f <notebooks-tmp-values> --timeout 1800  ./renku-notebooks
+
+Note that the release name has to be unique in the entire cluster. For example, you might want to include the target namespace in the release name.
+
 Verifying Renku
 ------------------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -61,6 +61,7 @@ Jena
 json
 jupyter
 JupyterHub
+Jupyterhub
 jupyterlab
 JupyterLab
 keycloak


### PR DESCRIPTION
This PR adds the chart changes necessary to enable anonymous interactive environments. Only merge after

- [x] https://github.com/SwissDataScienceCenter/renku-ui/pull/893 

- [x] https://github.com/SwissDataScienceCenter/renku-notebooks/pull/285 

- [x] https://github.com/SwissDataScienceCenter/renku-gateway/pull/194

have been merged.

Deployments with all these changes are running under:
https://tmp-on.dev.renku.ch/ (anonymous sessions enabled)
https://tmp-off.dev.renku.ch/ (anonymous sessions disabled)