### PR TITLE
Bump gitlab and gateway versions

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.4.1
+version: 0.5.0

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gitlab/gitlab-ce
-  tag: 11.9.11-ce.0
+  tag: 12.9.5-ce.0
   pullPolicy: IfNotPresent
 
 ssh:

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -14,10 +14,10 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.7.1-c654a54
+  version: 0.8.0
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.4.1-791604e"
+  version: 0.5.0
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -660,6 +660,9 @@ minio:
 gateway:
   ingress:
     enabled: false
+  ## Uncomment this if you are using a GitLab version
+  ## prior to 12.7.0.
+  # oldGitLabLogout: true
 
 ## Configuration for renku-graph
 graph:


### PR DESCRIPTION
GitLab versions >= 12.9.0 require a different logout behaviour from the side of client applications, therefore we also have to update the gateway.

**Merge this PR instead of the auto-generated one after merging https://github.com/SwissDataScienceCenter/renku-gateway/pull/202**

Note that I've built and pushed the gitlab chart `0.5.0` to break the circular versions dependency created by the fact that the gitlab chart is a dependency of the renku chart and also part of the same repo...