### PR TITLE
Periodically remove old github actions artifacts

### DIFF
--- a/.github/workflows/remove-old-artifacts.yaml
+++ b/.github/workflows/remove-old-artifacts.yaml
@@ -1,0 +1,20 @@
+name: Remove old artifacts
+
+on:
+  schedule:
+    # Every day at 1am
+    - cron: '0 1 * * *'
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Remove old artifacts
+      uses: c-hive/gha-remove-artifacts@v1
+      with:
+        age: '1 week'
+        # Optional inputs
+        skip-tags: true
+        skip-recent: 10


### PR DESCRIPTION
Looks like it's doing the job. The first attempt with a version that also triggered "on PR" deleted many artifacts.