### PR TITLE
set prometheus_multiproc_dir=/dev/shm/gitlab

### DIFF
--- a/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/gitlab/templates/_gitlab.rb.tpl
@@ -95,7 +95,7 @@ gitlab_rails['lfs_object_store_connection'] = eval(ENV['GITLAB_LFS_CONNECTION'])
 
 prometheus['enable'] = false
 gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8', '10.0.0.0/8']
-gitlab_rails['env'] = { 'prometheus_multiproc_dir' => '/dev/shm' }
+gitlab_rails['env'] = { 'prometheus_multiproc_dir' => '/dev/shm/gitlab' }
 
 ### GitLab Registry settings
 registry_external_url '{{ .Values.registry.externalUrl }}'


### PR DESCRIPTION
make the path explicit, especially to help with version of gitlab<12.7