### PR TITLE
ci: remove broken steps in PR-teardown

### DIFF
--- a/.github/workflows/pull-request-teardown.yml
+++ b/.github/workflows/pull-request-teardown.yml
@@ -32,9 +32,7 @@ jobs:
           helm init --client-only
           echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
           helm delete --purge $RENKU_RELEASE
-          kubectl delete namespace $RENKU_RELEASE
           helm delete --purge $RENKU_RELEASE-tmp-notebooks || true
-          kubectl delete namespace $RENKU_RELEASE-tmp || true
     - name: gitlab teardown
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}


### PR DESCRIPTION
Renkubot doesn't have the permission to remove namespaces, therefore these lines are failing.