### PR TITLE
ci: speed up tests by avoiding build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
       run: |
         cd tests
+        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build sbt
         docker-compose run -e RENKU_TEST_URL=https://dev.renku.ch \
                            -e RENKU_TEST_FULL_NAME="Renku Bot" \
                            -e RENKU_TEST_EMAIL="renku@datascience.ch" \
@@ -114,6 +115,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          DOCKER_BUILDKIT: "1"
         run: |
           cd charts
           chartpress --push --publish-chart

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -139,6 +139,7 @@ jobs:
         echo $PR_NUMBER
         export RENKU_RELEASE="ci-${PR_NUMBER}-renku"
         cd tests
+        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build sbt
         docker-compose run -e RENKU_TEST_URL=https://${RENKU_RELEASE}.dev.renku.ch \
                            -e RENKU_TEST_FULL_NAME="Renku Bot" \
                            -e RENKU_TEST_EMAIL="renku@datascience.ch" \

--- a/charts/chartpress.yaml
+++ b/charts/chartpress.yaml
@@ -25,6 +25,8 @@ charts:
         paths:
           - ../services/apispec
       tests:
+        buildArgs:
+          BUILDKIT_INLINE_CACHE: "1"
         contextPath: ../tests
         dockerfilePath: ../tests/Dockerfile
         valuesPath: tests.image

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 services:
   chrome:
     image: selenium/standalone-chrome:3.141.59-xenon
@@ -7,7 +7,10 @@ services:
     ports:
       - "4444:4444"
   sbt:
-    build: .
+    build:
+      context: .
+      cache_from:
+        - renku/tests:latest
     command: ['/tests/docker-run-tests.sh']
     environment:
       - DOCKER=1


### PR DESCRIPTION
I wanted to try out the more advanced caching features that the new docker build kit offers and quickly applied this to our test setup. This PR uses the `renku/tests:latest` during the `sbt` build, thus shortening the tests by a few minutes. It relies on `renku/tests:latest` being built by the new docker build kit.