### PR TITLE
Bump redis chart version in gitlab chart

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.5.1
+version: 0.5.2

--- a/charts/gitlab/requirements.lock
+++ b/charts/gitlab/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 3.7.2
-digest: sha256:0fd490e3f2effaf0ee234577830ec7b0674698f9fc74dcf1f876860721181fe8
-generated: 2018-09-24T13:54:13.380379241+02:00

--- a/charts/gitlab/requirements.yaml
+++ b/charts/gitlab/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis
-  version: 3.7.2
-  repository: "@stable"
+  version: 10.7.11
+  repository: "https://charts.bitnami.com/bitnami"

--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 0.8.1-4a36b1e
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.5.1
+  version: 0.5.2
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph


### PR DESCRIPTION
Addresses parts of https://github.com/SwissDataScienceCenter/renku/issues/1271.

Note that the gitlab 0.5.2 chart according to this PR has already been built and published manually. Should there be any changes the published chart would have to be deleted and recreated.