### PR TITLE
chore: add vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,11 +258,7 @@ tags
 .vim
 
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files


### PR DESCRIPTION
The `.vscode` folder was included in the gitignore but some specific files (the most relevant once) were excluded. Not sure if this is on purpose or it's just a leftover, but this PR excludes all the folder -- as in the other renku repositories.