### PR TITLE
docs: add cookies documentation

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -146,6 +146,59 @@ Check list:
     4. launch a notebook
   - You should be now able to follow "First steps"
 
+Additional configurations
+-------------------------
+
+Privacy page
+~~~~~~~~~~~~
+
+The UI has a privacy page with a completely configurable content, suited for showing
+any policy/terms related information, like the `Privacy Policy Statement` or the
+`Terms of Use`.
+
+The content is read from the privacy ``ConfigMap`` installed with RenkuLab, precisely
+the ``privacy_statement`` key.
+
+.. note::
+
+  The exact name of the privacy ConfigMap may slightly vary depending on your specific
+  RenkuLab configuration. The default is ``renku-ui-privacy``. All the variations
+  will end with `-privacy` in the name.
+
+We support the `Markdown syntax <https://en.wikipedia.org/wiki/Markdown>`_ for the
+privacy page content.
+
+You can refer to the current
+`ConfigMap in the renku-ui repository <https://github.com/SwissDataScienceCenter/renku-ui/blob/master/helm-chart/renku-ui/templates/configmap.yaml>`_
+to find an example of the default Markdown.
+
+
+Cookie banner
+~~~~~~~~~~~~~
+
+Since RenkuLab requires user identification and implements a login system, cookies are
+required at all levels to provide basic functionality. Please mind that cookies are also used
+for anonymous users (i.e. without an account or not currently logged in).
+
+To comply with international laws, it's strongly advised to explicitly require consent to the
+user for storing these data and using cookies. The default cookie banner simply informs the
+user about these requirements and points to the privacy page for further details.
+
+It's possible to customize the banner to your own needs, changing both the appearance and the
+content. We use `cookie consent <https://github.com/Mastermindzh/react-cookie-consent>`_ to
+create the banner and we support customization of all the properties exposed by the library.
+All the adjustments should be provided as values in ``ui.privacy.banner`` as follows:
+
+1. ``content``: The HTML content of the cookie banner. Please mind that links should point
+   to local content. Use the privacy page to add references to third party sites.
+2. ``layout``: The list of properties for the cookies consent plugin. We use
+   `Bootstrap <https://getbootstrap.com/docs>`_ for the UI, therefore all the Bootstrap
+   classes can be used to customize the appearance.
+
+You can refer to the current
+`values.yaml in the renku-ui repository <https://github.com/SwissDataScienceCenter/renku-ui/blob/master/helm-chart/renku-ui/values.yaml>`_
+to check the default values and to find an example of how to apply different settings.
+
 Troubleshooting
 ------------------
 


### PR DESCRIPTION
This is a follow up of SwissDataScienceCenter/renku-ui#949 , adding the relevant documentation about the cookie banner and the privacy page