### PR TITLE
Update 06_create_workflow.rst

### DIFF
--- a/docs/tutorials/first_steps/03_python_environment.rst
+++ b/docs/tutorials/first_steps/03_python_environment.rst
@@ -73,7 +73,7 @@ And we need to capture this change in git.
 .. code-block:: console
 
     git add requirements.txt
-    git commit -m"Installed pandas and seaborn"
+    git commit -m "Installed pandas and seaborn"
     git push
 
     # [master 1772863] Installed pandas and seaborn

--- a/docs/tutorials/first_steps/06_create_workflow.rst
+++ b/docs/tutorials/first_steps/06_create_workflow.rst
@@ -112,7 +112,7 @@ and other commands.
     If in the process of working through the tutorial, you stopped the
     interactive environment and started a new one along the way, this may
     happen. Why?
-    `Under the hood <https://renku-python.readthedocs.io/en/latest/api.html>`_,
+    `Under the hood <https://renku.readthedocs.io/en/latest/user/lfs.html#>`_,
     we use
     `git-lfs <https://git-lfs.github.com/>`_
     to save large files, and these files may not be fetched when a new


### PR DESCRIPTION
The "under the hood" link to https://renku-python.readthedocs.io/en/latest/api.html Yields a "SORRY This page does not exist yet" error. I replaced it with something else from the docs that details Renku's data procedures in more detail.