### PR TITLE
chore(charts): remove minio from dependencies

### DIFF
--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -32,7 +32,3 @@ dependencies:
   version: 4.10.1
   repository: "@stable"
   condition: keycloak.enabled
-- name: minio
-  version: 1.6.0
-  repository: "@stable"
-  condition: minio.enabled

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -676,10 +676,6 @@ tests:
   #    email: ckent@example.com
   #    password: IamSuperman
 
-minio:
-  ## Set to true to deploy a minio server, can be used as gateway too.
-  enabled: false
-
 ## Configuration for the Gateway service
 gateway:
   ingress:

--- a/charts/values.yaml.changelog.md
+++ b/charts/values.yaml.changelog.md
@@ -5,6 +5,8 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
+* DELETE - *minio.enabled*: minio has been removed from the Renku dependencies, deploy minio as a standalone service if you need it.
+
 ## Changes on top of Renku 0.6.5
 * NEW - *ui.statuspage.id*: the id for the statuspage.io instance. See the values.yml file
 for more detailed documentation.


### PR DESCRIPTION
If minio is needed, it should be deployed outside of Renku.