### PR TITLE
chore: pin nbconvert dependency

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,4 +21,5 @@ RUN python3 -m pip install \
     'pipx>=0.15.0.0' \
     'pandas==0.25.3' \
     'seaborn==0.9.0' \
+    'nbconvert==5.6.1'
     git+https://github.com/SwissDataScienceCenter/renku-python.git@${renku_python_ref}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,5 +21,5 @@ RUN python3 -m pip install \
     'pipx>=0.15.0.0' \
     'pandas==0.25.3' \
     'seaborn==0.9.0' \
-    'nbconvert==5.6.1'
+    'nbconvert==5.6.1' \
     git+https://github.com/SwissDataScienceCenter/renku-python.git@${renku_python_ref}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get install -y git git-lfs gcc wget nodejs
 
 ARG renku_python_ref=master
 RUN python3 -m pip install \
-    'papermill<1.2.0' \
+    'papermill==2.1.3' \
     'requests>=2.20.0' \
     'jupyterhub==1.1.0' \
     'nbresuse==0.3.3' \
@@ -21,5 +21,4 @@ RUN python3 -m pip install \
     'pipx>=0.15.0.0' \
     'pandas==0.25.3' \
     'seaborn==0.9.0' \
-    'nbconvert==5.6.1' \
     git+https://github.com/SwissDataScienceCenter/renku-python.git@${renku_python_ref}


### PR DESCRIPTION
Pin `nbconvert` to solve incompatibility with `papermill`