### PR TITLE
chore(ci): add possibility to auto-update PRs

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,0 +1,16 @@
+name: autoupdate
+on:
+  # This will trigger on all pushes to all branches.
+  push: {}
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.RENKU_CI_TOKEN }}"
+          PR_FILTER: "labelled"
+          PR_LABELS: "autoupdate"
+          MERGE_MSG: "Branch was auto-updated."
+


### PR DESCRIPTION
This PR adds the sibling of `automerge`. Set both the `autoupdate` and `automerge` label on an accepted PR and let the 🤖 do the rest.