### PR TITLE
Deploy renku-ui-server

### DIFF
--- a/charts/renku/requirements.yaml
+++ b/charts/renku/requirements.yaml
@@ -7,6 +7,10 @@ dependencies:
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: 0.11.1-9918ae5
+- name: renku-ui-server
+  alias: uiserver
+  repository: "https://swissdatasciencecenter.github.io/helm-charts/"
+  version: 0.11.1
 - name: renku-notebooks
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/charts/renku/templates/_helpers.tpl
+++ b/charts/renku/templates/_helpers.tpl
@@ -61,6 +61,10 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "ui" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "ui-server.fullname" -}}
+{{- printf "%s-%s" .Release.Name "uiserver" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "jupyterhub.fullname" -}}
 {{- printf "%s-%s" .Release.Name "jupyterhub" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
Deploy the UI server from https://github.com/SwissDataScienceCenter/renku-ui/pull/1043

The UI project needs to be tagged before the renku-ui-server chart is available with the version specified here.