### PR TITLE
chore(cd): add manual trigger for CD pipeline on any branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
     - acceptance-tests/**
     branches: ['master']
     tags: ['*']
+  workflow_dispatch:
+
 
 jobs:
   github-env:


### PR DESCRIPTION
Adding this _should_ allow us to manually trigger the CD pipeline on the non-default branch. See [the github actions docs](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch).