### PR TITLE
chore(cd): do not deploy to CD on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
     - scripts/**
     - acceptance-tests/**
     branches: ['master']
-    tags: ['*']
   workflow_dispatch:
 
 


### PR DESCRIPTION
CD should reflect the HEAD of master and not tags from (potentially incompatible) release branches.