### PR TITLE
docs: fix relative path to reqs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,7 @@ renku_python_version = version
 
 if renku_python_version not in ["stable", "latest"]:
     # tag build, update respective renku-python as well
-    with open("./charts/renku/requirements.yaml", "r") as f:
+    with open("../charts/renku/requirements.yaml", "r") as f:
         requirements = yaml.load(f)
     renku_core_entry = next(
         (d for d in requirements["dependencies"] if d["name"] == "renku-core"), None


### PR DESCRIPTION
There was an error in the relative path in `docs/conf.py` that meant docs failed to build on tags. This change has been used on the 0.7.x branch (see build [here](https://readthedocs.org/projects/renku/builds/12250687/)).