### PR TITLE
chore: push automatic dependency updates to development

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
-          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_BRANCH: "development"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,7 @@ on:
     - scripts/**
     - acceptance-tests/**
     - .github/**
-    branches: ['master']
-    tags: ['*']
+    branches: ['development']
   workflow_dispatch:
 
 

--- a/actions/update-component-version/update-upstream.sh
+++ b/actions/update-component-version/update-upstream.sh
@@ -14,6 +14,7 @@ fi
 
 # set up environment variables
 UPSTREAM_REPO=${UPSTREAM_REPO:=SwissDataScienceCenter/renku}
+UPSTREAM_BRANCH=${UPSTREAM_BRANCH:=development}
 GIT_EMAIL=${GIT_EMAIL:=renku@datascience.ch}
 GIT_USER=${GIT_USER:="Renku Bot"}
 CHART_NAME=${CHART_NAME:=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)}
@@ -32,7 +33,7 @@ git config --global user.email "$GIT_EMAIL"
 git config --global user.name "$GIT_USER"
 
 # update the chart requirements and push
-git checkout -b auto-update/${CHART_NAME}-${CHART_VERSION} master
+git checkout -b auto-update/${CHART_NAME}-${CHART_VERSION} ${UPSTREAM_BRANCH}
 yq w -i charts/renku/requirements.yaml "dependencies.(name==${CHART_NAME}).version" $CHART_VERSION
 
 git add charts/renku/requirements.yaml


### PR DESCRIPTION
This PR changes the CI/CD pipeline to deploy from the `development` branch. The updates are in three places:

* the github action used by repositories --> this is changed to create the PR based on the development branch
* the automatic PR creation action --> this uses `development` as the base branch
* the CD pipeline is deployed using the `development` branch

The idea is that updates are pushed to `development` and occasionally a merge is made back to `master`, which remains the default branch. All development that is not an automatic PR for a dependency update should still go to the `master` branch. However, merges to `master` from `development` should happen when we are approaching a release and they should be squashed so that the number of automatic commits is minimized in the git history. In principle, this should get us closer to a point where production is updated whenever a merge to `master` is made. 