### PR TITLE
chore: fix CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
 RENKU (連句)
 ============
 
-.. image:: https://github.com/SwissDataScienceCenter/renku/workflows/Deploy%20and%20Test/badge.svg
+.. image:: https://github.com/SwissDataScienceCenter/renku/workflows/Deploy%20and%20Test/badge.svg?branch=development
    :target: https://github.com/SwissDataScienceCenter/renku/actions?query=workflow%3A%22Deploy+and+Test%22
 
 .. image:: https://readthedocs.org/projects/renku/badge/


### PR DESCRIPTION
The CI badge was showing the status of CI from the default branch (master) which no longer runs our CI... this changes it to show the status of the development branch. 