### PR TITLE
chore(ci): increase automerge timeout to 1 day

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,5 +25,5 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_DELETE_BRANCH: "true"
           MERGE_LABELS: "automerge,!do-not-merge"
-          MERGE_RETRIES: 120
-          MERGE_RETRY_SLEEP: 60000
+          MERGE_RETRIES: 288
+          MERGE_RETRY_SLEEP: 300000


### PR DESCRIPTION
Keep trying to automerge a PR every 5 minutes for 24 hours. The current setting of two hours seems to be too short or our tests sometimes.