### PR TITLE
feat: run acceptance tests through helm test

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -91,6 +91,7 @@ jobs:
         CI_RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_RANCHER_APISECRET: ${{ secrets.RENKUBOT_RANCHER_APISECRET }}
         CI_PROJECT_ID: ${{ secrets.CI_PROJECT_ID }}
+        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
         helm repo add stable https://charts.helm.sh/stable
@@ -116,6 +117,10 @@ jobs:
                     --set notebooks.jupyterhub.auth.gitlab.clientId=${APP_ID} \
                     --set notebooks.jupyterhub.auth.gitlab.clientSecret=${APP_SECRET} \
                     --set global.anonymousSessions.enabled=true \
+                    --set tests.parameters.username="renku-test" \
+                    --set tests.parameters.fullname="Renku Bot" \
+                    --set tests.parameters.email="renku@datascience.ch" \
+                    --set tests.parameters.password="$RENKU_BOT_DEV_PASSWORD" \
                     charts/renku
     - name: Turn on anonymous notebooks
       env:

--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -1,15 +1,22 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get install -y curl gnupg
+RUN apt-get update && \
+    apt-get install -y \
+    chromium-driver \
+    gcc \
+    git \
+    git-lfs \
+    gnupg \
+    nodejs \
+    wget
 
 # This 'mkdir' is just to make the openjdk-11-jdk installation to pass
 RUN mkdir -p /usr/share/man/man1 && \
     echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+    wget --quiet -O - "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get update && \
-    apt-get install -y openjdk-11-jdk sbt
-
-RUN apt-get install -y git git-lfs gcc wget nodejs
+    apt-get install -y openjdk-11-jdk sbt && \
+    rm -rf /var/cache/apt
 
 ARG renku_python_ref=master
 RUN python3 -m pip install \
@@ -22,3 +29,7 @@ RUN python3 -m pip install \
     'pandas==0.25.3' \
     'seaborn==0.9.0' \
     git+https://github.com/SwissDataScienceCenter/renku-python.git@${renku_python_ref}
+
+ENV DOCKER="1"
+COPY . /tests
+ENTRYPOINT ["/tests/docker-run-tests.sh"]

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -16,37 +16,71 @@ normally of the form `test_[timestamp]`. This makes it easy to identify the test
 name collisions. If the test runs successfully to completion, the project is deleted at the end of the test.
 If the test fails, then the project is left around to aid debugging.
 
+## Running on Docker
 
-## Running over Docker
+The easiest way to run the tests is to use docker/docker-compose.
 
-The easiest way to run the tests is to use docker/docker-compose. The docker-compose environment is made up of
-two containers: one hosting selenium, and one running the tests.
+### Installation
 
+The `docker-compose` command has to be available: it is easiest to install it with `pip`.
 
-#### Installation
-The `docker-compose` command has to be available. For installation steps see: https://docs.docker.com/compose/install/.
+### Running
 
-#### Running
-For running with docker, the parameters to the test need to be provided as environment variables:
+To run through docker-compose, the tests parameters need to be provided as environment variables:
 
 ```
-docker-compose run -e RENKU_TEST_URL=https://renku-kuba.dev.renku.ch -e RENKU_TEST_FULL_NAME="<full user name>" -e RENKU_TEST_EMAIL=<email> -e RENKU_TEST_USERNAME=<username> -e RENKU_TEST_PASSWORD=<password> sbt
+docker-compose run \
+-e RENKU_TEST_URL=https://renku-kuba.dev.renku.ch \
+-e RENKU_TEST_FULL_NAME="<full user name>" \
+-e RENKU_TEST_EMAIL=<email> \
+-e RENKU_TEST_USERNAME=<username> \
+-e RENKU_TEST_PASSWORD=<password> \
+sbt
 ```
 
 By default, all tests are run. You can provide an argument to run a specific test:
-
 ```
-docker-compose run -e RENKU_TEST_URL=https://renku-kuba.dev.renku.ch -e RENKU_TEST_FULL_NAME="<full user name>"
--e RENKU_TEST_EMAIL=<email> -e RENKU_TEST_USERNAME=<username> -e RENKU_TEST_PASSWORD=<password> sbt
-/tests/docker-run-tests.sh *<test-class-name>*
+docker-compose run \
+-e RENKU_TEST_URL=https://renku-kuba.dev.renku.ch \
+-e RENKU_TEST_FULL_NAME="<full user name>" \
+-e RENKU_TEST_EMAIL=<email> \
+-e RENKU_TEST_USERNAME=<username> \
+-e RENKU_TEST_PASSWORD=<password> \
+sbt *<test-class-name>*
 ```
 __**IMPORTANT**__
 
 Once you do changes to the `Dockerfile` do not forget to build the image with `docker-compose build`.
 
+## Running through Helm test
+
+The `helm test` command can also be used to execute the tests against a Helm release of Renku.
+
+When testing a Renku release that relies on an external GitLab instance, the test user must already
+have an existing account on that GitLab instance with login credentials specified in the
+values.yaml file. Note that the same user (with the same username/password combination!) must also exist in the Keycloak instance which is part of the Renku release being tested. Alternatively, if the `.Values.tests.registerTestUser` is set to `true`, the test suit will try to register a new user with the provided details.
+```yaml
+tests:
+  ## User account for running `helm test`
+  testUser:
+   username: foo.bar
+   fullname: Foo Bar
+   email: foo.bar@example.com
+   password: FooBar
+```
+The tests can now be executed:
+```bash
+helm --namespace renku-foo test renku-foo --logs
+```
+
+The acceptance tests will run on the Kubernetes cluster where `renku-foo` is deployed, in the
+same namespace, in a pod named `renku-foo-acceptance-tests`. Once the tests are completed
+(successfully or otherwise) the container is terminated.
+
 ## Running using sbt
 
-#### Installation
+### Installation
+
 In order to run the tests you need to install:
 * Java Development Kit (JDK) >= 8 (see: https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=openj9)
 * sbt >= 1.3.3 (use `sbt sbtVersion` to verify current version but run it not from the project root)
@@ -64,7 +98,8 @@ In order to run the tests you need to install:
   * jupyterlab-git = 0.20.0
   * pipx >= 0.15.0.0
 
-#### Running
+### Running
+
 The tests are run by executing `sbt` in the project's root.
 
 In order to run the acceptance tests, it is necessary to provide information for reaching and logging into the
@@ -96,7 +131,6 @@ For example, the following may be run in the project's root: `sbt -Denv=https://
 
 In the case there's a need of running a single test the `test` part should be replaced with `"testOnly
 *<test-class-name>*"`.
-
 
 On some machines, providing values with spaces using `-D` causes sbt to complain `Could not find or load main
 class`. In this case, the environment variables should be used to provide the values.

--- a/acceptance-tests/docker-compose.yml
+++ b/acceptance-tests/docker-compose.yml
@@ -1,20 +1,10 @@
 version: '3.2'
 services:
-  chrome:
-    image: selenium/standalone-chrome:3.141.59-xenon
-    volumes:
-      - /dev/shm:/dev/shm
-    ports:
-      - "4444:4444"
   sbt:
     build:
       context: .
       cache_from:
         - renku/tests:latest
-    command: ['/tests/docker-run-tests.sh']
-    environment:
-      - DOCKER=1
     volumes:
-      - .:/tests
-    depends_on:
-      - chrome
+      - /dev/shm:/dev/shm
+      - ./target:/tests/target

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
@@ -2,11 +2,10 @@ package ch.renku.acceptancetests.tooling
 
 import ch.renku.acceptancetests.workflows.{Environments, JupyterNotebook}
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.chrome.{ChromeDriver, ChromeDriverService, ChromeOptions}
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.scalatest.{BeforeAndAfterAll, FeatureSpec, GivenWhenThen, Matchers => ScalatestMatchers}
 import org.scalatestplus.selenium.{Chrome, Driver, WebBrowser}
-
 import scala.language.postfixOps
 
 trait AcceptanceSpec
@@ -29,10 +28,11 @@ trait AcceptanceSpec
 
   private def getWebDriver: WebDriver =
     sys.env.get("DOCKER") match {
-      // NOTE We could also support running against the selenium container from the host machine:
-      // RemoteWebDriver.builder().url("http://localhost:4444/wd/hub").addAlternative(new ChromeOptions()).build()
       case Some(_) =>
-        RemoteWebDriver.builder().url("http://chrome:4444/wd/hub").addAlternative(new ChromeOptions()).build()
+        new ChromeDriver(
+          new ChromeDriverService.Builder().withWhitelistedIps("127.0.0.1").build,
+          new ChromeOptions().addArguments("--no-sandbox", "--headless")
+        )
       case None =>
         Chrome.webDriver
     }

--- a/charts/renku/templates/tests/test-renku.yaml
+++ b/charts/renku/templates/tests/test-renku.yaml
@@ -1,51 +1,58 @@
+{{ if .Values.tests.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Release.Name }}-test"
+  name: '{{ .Release.Name }}-acceptance-tests'
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
-  initContainers:
-  - name: renku-demo
-    image: renku/renku-demo:0.3.0
-    env:
-      - name: GITLAB_URL
-        value: {{ template "http" . }}://{{ .Values.global.renku.domain }}{{ .Values.global.gitlab.urlPrefix }}
-      - name: KEYCLOAK_ADMIN_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ template "renku.fullname" . }}-keycloak-password
-            key: keycloak-password
-      - name: KEYCLOAK_ADMIN_USER
-        value: {{ .Values.keycloak.keycloak.username }}
-      - name: KEYCLOAK_URL
-        value: {{ template "http" . }}://{{ .Values.global.renku.domain }}
-    volumeMounts:
-      {{- if .Values.tests.users_json }}
-      - name: demo-users
-        readOnly: true
-        mountPath: /app/users.json
-        subPath: users.json
-      {{- end }}
-  containers:
-  - name: {{ .Release.Name }}-test
-    image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
-    env:
-      - name: RENKU_ENDPOINT
-        value: {{ template "http" . }}://{{ .Values.global.renku.domain }}
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/tests/demo-cleanup.sh"]
-    volumeMounts:
-      {{- if .Values.tests.users_json }}
-      - name: demo-users
-        readOnly: true
-        mountPath: /tests/users.json
-        subPath: users.json
-      {{- end }}
-  restartPolicy: Never
   volumes:
-    - name: demo-users
-      secret:
-        secretName: {{ template "renku.fullname" . }}-users
+  - name: dshm
+    emptyDir:
+      medium: Memory
+  restartPolicy: Never
+  containers:
+  - name: sbt
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    env:
+      - name: RENKU_TEST_URL
+        value: '{{ template "http" . }}://{{ .Values.global.renku.domain }}'
+      - name: RENKU_TEST_EMAIL
+        value: '{{ .Values.tests.parameters.email }}'
+      - name: RENKU_TEST_USERNAME
+        value: '{{ .Values.tests.parameters.username }}'
+      - name: RENKU_TEST_FULL_NAME
+        value: '{{ .Values.tests.parameters.fullname }}'
+      - name: RENKU_TEST_PASSWORD
+        value: '{{ .Values.tests.parameters.password }}'
+      - name: RENKU_TEST_PROVIDER
+        value: '{{ .Values.tests.parameters.provider }}'
+      - name: RENKU_TEST_REGISTER
+        value: '{{ .Values.tests.parameters.testRegister | default "true" }}'
+      - name: RENKU_TEST_DOCS_RUN
+        value: '{{ .Values.tests.parameters.docsRun | default "" }}'
+      - name: RENKU_TEST_EXTANT_PROJECT
+        value: '{{ .Values.tests.parameters.extantProject | default "" }}'
+      - name: RENKU_TEST_ANON_PROJECT
+        value: '{{ .Values.tests.parameters.anonProject | default "" }}'
+      - name: RENKU_TEST_ANON_AVAILABLE
+        value: '{{ .Values.tests.parameters.anonAvailable | default "false" }}'
+      - name: RENKU_TEST_BATCH_REMOVE
+        value: '{{ .Values.tests.parameters.batchRemove | default "false"}}'
+      - name: RENKU_TEST_REMOVE_PATTERN
+        value: '{{ .Values.tests.parameters.removePattern | default "" }}'
+    volumeMounts:
+      - mountPath: /dev/shm
+        name: dshm
+    {{ if .Values.tests.parameters.testTarget -}}
+    args:
+      - '{{ .Values.tests.parameters.testTarget }}'
+    {{ end }}
+    resources:
+      requests:
+        memory: "4G"
+        cpu: "2"
+      limits:
+        memory: "4G"
+        cpu: "2"
+{{- end }}

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -134,6 +134,10 @@ keycloak:
       repository: renku/init-realm
       tag: 'latest'
 
+  ## Skip Keycloak testing when running Helm test
+  test:
+    enabled: false
+
   keycloak:
 
     ## Keycloak admin user configuration
@@ -589,22 +593,25 @@ notebooks:
     #     enabled: true
 
 tests:
+  enabled: false
   image:
     repository: renku/tests
     tag: 'latest'
-  ## User accounts for running `helm test`
-  ## Replace passwords with random strings in a production setup
-  #users_json:
-  #  - username: bwayne
-  #    firstName: Bruce
-  #    lastName: Wayne
-  #    email: bwayne@example.com
-  #    password: IamBatman
-  #  - username: ckent
-  #    firstName: Clark
-  #    lastName: Kent
-  #    email: ckent@example.com
-  #    password: IamSuperman
+  ## User account for running `helm test`
+  #parameters:
+  #  email: bwayne@example.com
+  #  username: bwayne
+  #  fullname: Bruce Wayne
+  #  password: IamBatman
+  #  provider:
+  #  testRegister: true
+  #  docsRun:
+  #  extantProject:
+  #  anonProject:
+  #  anonAvailable: false
+  #  batchRemove: false
+  #  removePattern:
+  #  testTarget:
 
 ## Configuration for the Gateway service
 gateway:


### PR DESCRIPTION
 * Refactor container for acceptance test to include Selenium/chromium-driver

 * Modify acceptance tests spec to use chromium-driver within the same container

 * Add manifest for `helm test` to use the refactored container in a pod

 * Update values.yaml to request the necessary parameters to run the tests

 * Update documentation

Part of #1762.