### PR TITLE
feat: run GH action acceptance tests through helm test

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -125,6 +125,7 @@ jobs:
                     --set tests.parameters.email="renku@datascience.ch" \
                     --set tests.parameters.password="$RENKU_BOT_DEV_PASSWORD" \
                     --set tests.parameters.anonAvailable="true" \
+                    --set tests.parameters.register="true" \
                     --set tests.resultsS3.host="os.zhdk.cloud.switch.ch" \
                     --set tests.resultsS3.bucket="dev-acceptance-tests-results" \
                     --set tests.resultsS3.filename="tests-artifacts-${GITHUB_SHA}" \

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -92,6 +92,8 @@ jobs:
         RENKUBOT_RANCHER_APISECRET: ${{ secrets.RENKUBOT_RANCHER_APISECRET }}
         CI_PROJECT_ID: ${{ secrets.CI_PROJECT_ID }}
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        OS_DEV_ACCESS: ${{ secrets.OS_DEV_ACCESS }}
+        OS_DEV_SECRET: ${{ secrets.OS_DEV_SECRET }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
         helm repo add stable https://charts.helm.sh/stable
@@ -117,10 +119,18 @@ jobs:
                     --set notebooks.jupyterhub.auth.gitlab.clientId=${APP_ID} \
                     --set notebooks.jupyterhub.auth.gitlab.clientSecret=${APP_SECRET} \
                     --set global.anonymousSessions.enabled=true \
+                    --set tests.enabled="true" \
                     --set tests.parameters.username="renku-test" \
                     --set tests.parameters.fullname="Renku Bot" \
                     --set tests.parameters.email="renku@datascience.ch" \
                     --set tests.parameters.password="$RENKU_BOT_DEV_PASSWORD" \
+                    --set tests.parameters.anonAvailable="true" \
+                    --set tests.resultsS3.host="os.zhdk.cloud.switch.ch" \
+                    --set tests.resultsS3.bucket="dev-acceptance-tests-results" \
+                    --set tests.resultsS3.filename="tests-artifacts-${GITHUB_SHA}" \
+                    --set tests.resultsS3.accessKey=$OS_DEV_ACCESS \
+                    --set tests.resultsS3.secretKey=$OS_DEV_SECRET \
+                    --set keycloak.test.enabled=false \
                     charts/renku
     - name: Turn on anonymous notebooks
       env:
@@ -162,37 +172,28 @@ jobs:
         pip install yq
     - name: Test the PR
       env:
-        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RELEASE: ci-${{ github.event.number }}-renku
       run: |
-        export PR_NUMBER=${{ github.event.number }}
-        echo $PR_NUMBER
-        export RENKU_RELEASE="ci-${PR_NUMBER}-renku"
-
-        RENKU_PYTHON_VERSION=v$(cat ./charts/renku/requirements.yaml | yq -r '.dependencies[] | select(.name == "renku-core") | .version')
-        RENKU_PYTHON_COMMIT=$(echo $RENKU_PYTHON_VERSION | grep -o -P '(?<=-)[0-9a-fA-F]+') || true
-        if [ $RENKU_PYTHON_COMMIT ]; then export RENKU_PYTHON_VERSION=$RENKU_PYTHON_COMMIT; fi
-        echo "Passing renku-python version $RENKU_PYTHON_VERSION"
-
-        cd acceptance-tests
-        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --build-arg renku_python_ref=${RENKU_PYTHON_VERSION} sbt
-        docker-compose run -e RENKU_TEST_URL=https://${RENKU_RELEASE}.dev.renku.ch \
-                           -e RENKU_TEST_FULL_NAME="Renku Bot" \
-                           -e RENKU_TEST_EMAIL="renku@datascience.ch" \
-                           -e RENKU_TEST_REGISTER="1" \
-                           -e RENKU_TEST_USERNAME="renku-test" \
-                           -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" \
-                           -e RENKU_TEST_ANON_AVAILABLE="true" sbt
-    - name: Prepare artifact for packaging on failure
+        echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
+        helm test $RELEASE --namespace $RELEASE --timeout 40m --logs
+    - name: Download artifact for packaging on failure
+      env:
+        OS_DEV_ACCESS: ${{ secrets.OS_DEV_ACCESS }}
+        OS_DEV_SECRET: ${{ secrets.OS_DEV_SECRET }}
       if: failure()
       run: |
-        mkdir acceptance-tests/test-artifacts
-        cp acceptance-tests/target/*.png acceptance-tests/test-artifacts 2>/dev/null || :
-        cp acceptance-tests/target/*.log acceptance-tests/test-artifacts 2>/dev/null || :
-        sudo rm -rf acceptance-tests/target/20*/.renku/cache 2>/dev/null || :
-        cp -r acceptance-tests/target/20* acceptance-tests/test-artifacts 2>/dev/null || :
+        sudo wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+        sudo chmod 0755 /usr/local/bin/mc
+        export MC_HOST_bucket="https://${OS_DEV_ACCESS}:${OS_DEV_SECRET}@os.zhdk.cloud.switch.ch"
+        mkdir test-artifacts/
+        mc cp bucket/dev-acceptance-tests-results/tests-artifacts-${GITHUB_SHA}.tgz .
+        mc rm bucket/dev-acceptance-tests-results/tests-artifacts-${GITHUB_SHA}.tgz
+        tar -C test-artifacts/ -xzvf tests-artifacts-${GITHUB_SHA}.tgz
     - name: Upload screenshots on failure
       if: failure()
       uses: actions/upload-artifact@v1
       with:
         name: acceptance-test-artifacts
-        path: acceptance-tests/test-artifacts
+        path: test-artifacts/

--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -30,6 +30,9 @@ RUN python3 -m pip install \
     'seaborn==0.9.0' \
     git+https://github.com/SwissDataScienceCenter/renku-python.git@${renku_python_ref}
 
+RUN wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
+    chmod 0755 /usr/local/bin/mc
+
 ENV DOCKER="1"
 COPY . /tests
 ENTRYPOINT ["/tests/docker-run-tests.sh"]

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -118,7 +118,7 @@ To create a `tests-defaults.conf` file, copy the `tests-defaults.conf.template` 
 | fullname   | RENKU_TEST_FULL_NAME      | user's full name e.g. `Jakub Józef Chrobasik`                    |
 | password   | RENKU_TEST_PASSWORD       | user's password                                                  |
 | provider   | RENKU_TEST_PROVIDER       | if non-empty, use an OpenID provider for auth                    |
-| register   | RENKU_TEST_REGISTER       | if non-empty, an register new user; has precedence over provider |
+| register   | RENKU_TEST_REGISTER       | if non-empty, register a new user; has precedence over provider  |
 | docsrun    | RENKU_TEST_DOCS_RUN       | if non-empty, screenshot for docs during hands-on test           |
 | extant     | RENKU_TEST_EXTANT_PROJECT | if non-empty, an existing project to use for tests               |
 | anon       | RENKU_TEST_ANON_PROJECT   | namespace/name for the project to test anonymously               |

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -9,3 +9,27 @@ fi
 cd /tests
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
+
+TESTS_RC=$?
+
+if [ ! -z $RENKU_TEST_S3_HOST ] && [ $TESTS_RC != 0 ]; then
+  if [ -z $RENKU_TEST_S3_ACCESS_KEY ] || [ -z $RENKU_TEST_S3_SECRET_KEY ] || \
+  [ -z $RENKU_TEST_S3_BUCKET ] || [ -z $RENKU_TEST_S3_FILENAME ]; then
+    echo "[ERROR] To upload the tests to a S3 bucket then\
+    RENKU_TEST_S3_HOST, RENKU_TEST_S3_BUCKET, RENKU_TEST_S3_FILENAME,\
+    RENKU_TEST_S3_ACCESS_KEY and RENKU_TEST_S3_SECRET_KEY\
+    must all be specified as environment variables. Aborting."
+    exit 1
+  fi
+  mkdir test-artifacts
+  cp target/*.png test-artifacts
+  cp target/*.log test-artifacts
+  rm -rf target/20*/.renku/cache
+  cp -r target/20* test-artifacts
+  tar czvf tests-artifacts.tgz test-artifacts
+  mv tests-artifacts.tgz ${RENKU_TEST_S3_FILENAME}.tgz
+
+  export MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}"
+  mc cp ${RENKU_TEST_S3_FILENAME}.tgz bucket/${RENKU_TEST_S3_BUCKET}
+  exit $TESTS_RC
+fi

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AnonEnv.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AnonEnv.scala
@@ -1,30 +1,33 @@
 package ch.renku.acceptancetests.tooling
-
 import java.lang.System.getProperty
-
 import ch.renku.acceptancetests.model.projects.ProjectIdentifier
 import eu.timepit.refined.api.Refined
-
 case class AnonEnvConfig(projectId: ProjectIdentifier, isAvailable: Boolean = false)
 
 /**
   * Configuration for the anonymous environment
   */
 trait AnonEnv extends AcceptanceSpecData {
-
   protected implicit lazy val anonEnvConfig: AnonEnvConfig =
     AnonEnvConfig(anonProjectIdentifier, isAnonEnvAvailable)
-
   protected lazy val anonProjectIdentifier: ProjectIdentifier = {
     Option(getProperty("anon")) orElse sys.env.get("RENKU_TEST_ANON_PROJECT") match {
       case Some(s) =>
-        val projectId = s.split("/").map(_.trim)
-        ProjectIdentifier(Refined.unsafeApply(projectId(0)), Refined.unsafeApply(projectId(1)))
-      case None =>
-        ProjectIdentifier(Refined.unsafeApply("andi"), Refined.unsafeApply("public-test-project"))
+        val projectIdComponents = s.split("/").map(_.trim).toList
+        projectIdComponents match {
+          case username :: tail =>
+            tail.headOption match {
+              case Some(projectName) =>
+                ProjectIdentifier(Refined.unsafeApply(username), Refined.unsafeApply(projectName))
+              case None => defaultProjectIdentifier
+            }
+          case _ => defaultProjectIdentifier
+        }
+      case None => defaultProjectIdentifier
     }
   }
-
+  private val defaultProjectIdentifier =
+    ProjectIdentifier(Refined.unsafeApply("andi"), Refined.unsafeApply("public-test-project"))
   protected lazy val isAnonEnvAvailable: Boolean = {
     val baseUrl = renkuBaseUrl
     Option(getProperty("anonAvail")) orElse sys.env.get("RENKU_TEST_ANON_AVAILABLE") match {
@@ -34,5 +37,4 @@ trait AnonEnv extends AcceptanceSpecData {
         baseUrl.value.value.equals("https://dev.renku.ch")
     }
   }
-
 }

--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.7.4
+version: 0.7.4-340d844

--- a/charts/renku/Chart.yaml
+++ b/charts/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.7.4-340d844
+version: 0.7.4-f2ef7ab

--- a/charts/renku/templates/tests/test-renku.yaml
+++ b/charts/renku/templates/tests/test-renku.yaml
@@ -26,21 +26,29 @@ spec:
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
       - name: RENKU_TEST_PROVIDER
-        value: '{{ .Values.tests.parameters.provider }}'
+        value: '{{ .Values.tests.parameters.provider | default ""}}'
       - name: RENKU_TEST_REGISTER
-        value: '{{ .Values.tests.parameters.testRegister | default "true" }}'
+        value: '{{ .Values.tests.parameters.register | default "" }}'
       - name: RENKU_TEST_DOCS_RUN
         value: '{{ .Values.tests.parameters.docsRun | default "" }}'
       - name: RENKU_TEST_EXTANT_PROJECT
         value: '{{ .Values.tests.parameters.extantProject | default "" }}'
+      {{ if .Values.tests.parameters.anonProject }}
       - name: RENKU_TEST_ANON_PROJECT
-        value: '{{ .Values.tests.parameters.anonProject | default "" }}'
+        value: '{{ .Values.tests.parameters.anonProject }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.anonAvailable }}
       - name: RENKU_TEST_ANON_AVAILABLE
-        value: '{{ .Values.tests.parameters.anonAvailable | default "false" }}'
+        value: '{{ .Values.tests.parameters.anonAvailable }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.batchRemove }}
       - name: RENKU_TEST_BATCH_REMOVE
-        value: '{{ .Values.tests.parameters.batchRemove | default "false"}}'
+        value: '{{ .Values.tests.parameters.batchRemove }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.removePattern }}
       - name: RENKU_TEST_REMOVE_PATTERN
-        value: '{{ .Values.tests.parameters.removePattern | default "" }}'
+        value: '{{ .Values.tests.parameters.removePattern }}'
+      {{ end }}
       - name: RENKU_TEST_S3_HOST
         value: '{{ .Values.tests.resultsS3.host }}'
       - name: RENKU_TEST_S3_BUCKET

--- a/charts/renku/templates/tests/test-renku.yaml
+++ b/charts/renku/templates/tests/test-renku.yaml
@@ -41,6 +41,16 @@ spec:
         value: '{{ .Values.tests.parameters.batchRemove | default "false"}}'
       - name: RENKU_TEST_REMOVE_PATTERN
         value: '{{ .Values.tests.parameters.removePattern | default "" }}'
+      - name: RENKU_TEST_S3_HOST
+        value: '{{ .Values.tests.resultsS3.host }}'
+      - name: RENKU_TEST_S3_BUCKET
+        value: '{{ .Values.tests.resultsS3.bucket }}'
+      - name: RENKU_TEST_S3_FILENAME
+        value: '{{ .Values.tests.resultsS3.filename }}'
+      - name: RENKU_TEST_S3_ACCESS_KEY
+        value: '{{ .Values.tests.resultsS3.accessKey }}'
+      - name: RENKU_TEST_S3_SECRET_KEY
+        value: '{{ .Values.tests.resultsS3.secretKey }}'
     volumeMounts:
       - mountPath: /dev/shm
         name: dshm

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -131,8 +131,8 @@ keycloak:
   ## keycloak admin username/password is supplied.
   initRealm:
     image:
-      repository: renku/init-realm
-      tag: 'latest'
+      repository: degano/init-realm
+      tag: '0.7.4-b5b472d'
 
   ## Skip Keycloak testing when running Helm test
   test:
@@ -595,8 +595,8 @@ notebooks:
 tests:
   enabled: false
   image:
-    repository: renku/tests
-    tag: 'latest'
+    repository: degano/tests
+    tag: '0.7.4-340d844'
   ## User account for running `helm test`
   #parameters:
   #  email: bwayne@example.com

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -596,7 +596,7 @@ tests:
   enabled: false
   image:
     repository: degano/tests
-    tag: '0.7.4-340d844'
+    tag: '0.7.4-f2ef7ab'
   ## User account for running `helm test`
   #parameters:
   #  email: bwayne@example.com

--- a/charts/renku/values.yaml
+++ b/charts/renku/values.yaml
@@ -604,7 +604,7 @@ tests:
   #  fullname: Bruce Wayne
   #  password: IamBatman
   #  provider:
-  #  testRegister: true
+  #  register:
   #  docsRun:
   #  extantProject:
   #  anonProject:


### PR DESCRIPTION
The GH action running the acceptance tests on every PR opened on this repository is now ran through `helm test`.
The values of the chart are updated accordingly.    
The output artifacts of the tests (images and logs) are uploaded temporarily to a SWITCH S3 bucket from the test pod, then downloaded by the GitHub action to be served through the action artifact service (preserving the current behavior).

