### PR TITLE
fix: update Helm stable URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         CD_VALUES: ${{ secrets.CD_VALUES }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-        helm repo add stable 	https://kubernetes-charts.storage.googleapis.com
+        helm repo add stable https://charts.helm.sh/stable
         helm repo add codecentric https://codecentric.github.io/helm-charts
         helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
         helm repo add gitlab https://charts.gitlab.io/
@@ -142,7 +142,7 @@ jobs:
           git config --global user.email renku@datascience.ch
       - name: update and test chart
         env:
-          HELM_URL: https://storage.googleapis.com/kubernetes-helm
+          HELM_URL: https://charts.helm.sh/stable
           HELM_TGZ: helm-v2.16.1-linux-amd64.tar.gz
           TEMP_DIR: ${{ runner.temp }}
         run: |

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -93,7 +93,7 @@ jobs:
         CI_PROJECT_ID: ${{ secrets.CI_PROJECT_ID }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-        helm repo add stable 	https://kubernetes-charts.storage.googleapis.com
+        helm repo add stable https://charts.helm.sh/stable
         helm repo add codecentric https://codecentric.github.io/helm-charts
         helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
         helm repo add gitlab https://charts.gitlab.io/

--- a/actions/publish-chart/README.md
+++ b/actions/publish-chart/README.md
@@ -36,5 +36,5 @@ You can set these environment variables:
 | GIT_EMAIL     | None | Yes |
 | GIT_USER      | None | Yes |
 | GITHUB_TOKEN  | None | Yes |
-| HELM_URL      | https://charts.helm.sh/stable | No |
-| HELM_TGZ      | helm-v2.16.1-linux-amd64.tar.gz | No |
+| HELM_URL      | https://storage.googleapis.com/kubernetes-helm | No |
+| HELM_TGZ      | helm-v2.17.0-linux-amd64.tar.gz | No |

--- a/actions/publish-chart/README.md
+++ b/actions/publish-chart/README.md
@@ -36,5 +36,5 @@ You can set these environment variables:
 | GIT_EMAIL     | None | Yes |
 | GIT_USER      | None | Yes |
 | GITHUB_TOKEN  | None | Yes |
-| HELM_URL      | https://storage.googleapis.com/kubernetes-helm | No |
+| HELM_URL      | https://charts.helm.sh/stable | No |
 | HELM_TGZ      | helm-v2.16.1-linux-amd64.tar.gz | No |

--- a/actions/publish-chart/publish-chart.sh
+++ b/actions/publish-chart/publish-chart.sh
@@ -24,8 +24,8 @@ fi
 
 # configure variables
 CHART_PATH=${CHART_PATH:=helm-chart/$(echo $GITHUB_REPOSITORY | cut -d/ -f2)}
-HELM_URL=${HELM_URL:=https://charts.helm.sh/stable}
-HELM_TGZ=${HELM_TGZ:=helm-v2.16.1-linux-amd64.tar.gz}
+HELM_URL=${HELM_URL:=https://storage.googleapis.com/kubernetes-helm}
+HELM_TGZ=${HELM_TGZ:=helm-v2.17.0-linux-amd64.tar.gz}
 
 # install helm
 mkdir -p /tmp/helm

--- a/actions/publish-chart/publish-chart.sh
+++ b/actions/publish-chart/publish-chart.sh
@@ -24,7 +24,7 @@ fi
 
 # configure variables
 CHART_PATH=${CHART_PATH:=helm-chart/$(echo $GITHUB_REPOSITORY | cut -d/ -f2)}
-HELM_URL=${HELM_URL:=https://storage.googleapis.com/kubernetes-helm}
+HELM_URL=${HELM_URL:=https://charts.helm.sh/stable}
 HELM_TGZ=${HELM_TGZ:=helm-v2.16.1-linux-amd64.tar.gz}
 
 # install helm

--- a/actions/update-component-version/README.md
+++ b/actions/update-component-version/README.md
@@ -29,5 +29,3 @@ You can set these environment variables:
 | UPSTREAM_REPO | SwissDataScienceCenter/renku |
 | GIT_EMAIL     | renku@datascience.ch |
 | GIT_USER      | Renku Bot |
-| HELM_URL      | https://charts.helm.sh/stable |
-| HELM_TGZ      | helm-v2.16.1-linux-amd64.tar.gz |

--- a/actions/update-component-version/README.md
+++ b/actions/update-component-version/README.md
@@ -29,5 +29,5 @@ You can set these environment variables:
 | UPSTREAM_REPO | SwissDataScienceCenter/renku |
 | GIT_EMAIL     | renku@datascience.ch |
 | GIT_USER      | Renku Bot |
-| HELM_URL      | https://storage.googleapis.com/kubernetes-helm |
+| HELM_URL      | https://charts.helm.sh/stable |
 | HELM_TGZ      | helm-v2.16.1-linux-amd64.tar.gz |


### PR DESCRIPTION
Helm stable repository has officially moved to https://charts.helm.sh/stable , this PR updates the old deprecated URL in this repository github actions.