### PR TITLE
chore: update the auto pr workflow

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -25,3 +25,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
           PULL_REQUEST_BRANCH: "development"
+          PULL_REQUEST_BODY: "This is an automated pull request.\n\n/deploy"


### PR DESCRIPTION
This updates the automatic PR workflow such that it adds `/deploy` in the PR body to ensure that deployment + tests run. 