### PR TITLE
feat: run GH actions acceptance tests through Helm test

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -74,9 +74,7 @@ jobs:
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
-        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_ANONYMOUS_SESSIONS: true
-        RENKU_TESTS_ENABLED: true
+        TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku: "@${{ github.head_ref }}"
     - name: Check existing renkubot comment
       if: needs.check-deploy.outputs.pr-contains-string == 'true'
@@ -107,43 +105,38 @@ jobs:
       run: |
         sudo apt-get update -y && sudo apt-get install -y grep
         pip install yq
+        sudo wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+        sudo chmod 0755 /usr/local/bin/mc
     - name: Test the PR
       if: needs.check-deploy.outputs.pr-contains-string == 'true'
       env:
-        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RENKU_RELEASE: ci-renku-${{ github.event.number }}
       run: |
-        export PR_NUMBER=${{ github.event.number }}
-        echo $PR_NUMBER
-        export RENKU_RELEASE="ci-renku-${PR_NUMBER}"
-
-        RENKU_PYTHON_VERSION=v$(cat ./helm-chart/renku/requirements.yaml | yq -r '.dependencies[] | select(.name == "renku-core") | .version')
-        RENKU_PYTHON_COMMIT=$(echo $RENKU_PYTHON_VERSION | grep -o -P '(?<=-)[0-9a-fA-F]+') || true
-        if [ $RENKU_PYTHON_COMMIT ]; then export RENKU_PYTHON_VERSION=$RENKU_PYTHON_COMMIT; fi
-        echo "Passing renku-python version $RENKU_PYTHON_VERSION"
-
-        cd acceptance-tests
-        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --build-arg renku_python_ref=${RENKU_PYTHON_VERSION} sbt
-        docker-compose run -e RENKU_TEST_URL=https://${RENKU_RELEASE}.dev.renku.ch \
-                           -e RENKU_TEST_FULL_NAME="Renku Bot" \
-                           -e RENKU_TEST_EMAIL="renku@datascience.ch" \
-                           -e RENKU_TEST_REGISTER="1" \
-                           -e RENKU_TEST_USERNAME="renku-test" \
-                           -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" \
-                           -e RENKU_TEST_ANON_AVAILABLE="true" sbt
-    - name: Prepare artifact for packaging on failure
+        echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
+        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 40m --logs
+    - name: Download artifact for packaging on failure
+      env:
+        RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+        TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
       if: failure()
       run: |
-        mkdir acceptance-tests/test-artifacts
-        cp acceptance-tests/target/*.png acceptance-tests/test-artifacts 2>/dev/null || :
-        cp acceptance-tests/target/*.log acceptance-tests/test-artifacts 2>/dev/null || :
-        sudo rm -rf acceptance-tests/target/20*/.renku/cache 2>/dev/null || :
-        cp -r acceptance-tests/target/20* acceptance-tests/test-artifacts 2>/dev/null || :
+        printf "%s" "$RENKU_VALUES" > values.yaml
+        export S3_HOST=$(yq '.tests.resultsS3.host' values.yaml -r)
+        export S3_ACCESS=$(yq '.tests.resultsS3.accessKey' values.yaml -r)
+        export S3_SECRET=$(yq '.tests.resultsS3.secretKey' values.yaml -r)
+        export MC_HOST_bucket="https://${S3_ACCESS}:${S3_SECRET}@${S3_HOST}"
+        mkdir test-artifacts/
+        mc cp bucket/dev-acceptance-tests-results/$TEST_ARTIFACTS_PATH.tgz .
+        mc rm bucket/dev-acceptance-tests-results/$TEST_ARTIFACTS_PATH.tgz
+        tar -C test-artifacts/ -xzvf $TEST_ARTIFACTS_PATH.tgz
     - name: Upload screenshots on failure
       if: failure()
       uses: actions/upload-artifact@v1
       with:
         name: acceptance-test-artifacts
-        path: acceptance-tests/test-artifacts
+        path: test-artifacts/
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-20.04

--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -16,7 +16,9 @@ RUN mkdir -p /usr/share/man/man1 && \
     wget --quiet -O - "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get update && \
     apt-get install -y openjdk-11-jdk sbt && \
-    rm -rf /var/cache/apt
+    rm -rf /var/cache/apt && \
+    wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
+    chmod 0755 /usr/local/bin/mc
 
 ARG renku_python_ref=master
 RUN python3 -m pip install \

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -118,7 +118,7 @@ To create a `tests-defaults.conf` file, copy the `tests-defaults.conf.template` 
 | fullname   | RENKU_TEST_FULL_NAME      | user's full name e.g. `Jakub Józef Chrobasik`                    |
 | password   | RENKU_TEST_PASSWORD       | user's password                                                  |
 | provider   | RENKU_TEST_PROVIDER       | if non-empty, use an OpenID provider for auth                    |
-| register   | RENKU_TEST_REGISTER       | if non-empty, an register new user; has precedence over provider |
+| register   | RENKU_TEST_REGISTER       | if non-empty, register a new user; has precedence over provider  |
 | docsrun    | RENKU_TEST_DOCS_RUN       | if non-empty, screenshot for docs during hands-on test           |
 | extant     | RENKU_TEST_EXTANT_PROJECT | if non-empty, an existing project to use for tests               |
 | anon       | RENKU_TEST_ANON_PROJECT   | namespace/name for the project to test anonymously               |

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -9,3 +9,27 @@ fi
 cd /tests
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
+
+TESTS_RC=$?
+
+if [ ! -z $RENKU_TEST_S3_HOST ] && [ $TESTS_RC != 0 ]; then
+  if [ -z $RENKU_TEST_S3_ACCESS_KEY ] || [ -z $RENKU_TEST_S3_SECRET_KEY ] || \
+  [ -z $RENKU_TEST_S3_BUCKET ] || [ -z $RENKU_TEST_S3_FILENAME ]; then
+    echo "[ERROR] To upload the tests to a S3 bucket then\
+    RENKU_TEST_S3_HOST, RENKU_TEST_S3_BUCKET, RENKU_TEST_S3_FILENAME,\
+    RENKU_TEST_S3_ACCESS_KEY and RENKU_TEST_S3_SECRET_KEY\
+    must all be specified as environment variables. Aborting."
+    exit 1
+  fi
+  mkdir test-artifacts
+  cp target/*.png test-artifacts
+  cp target/*.log test-artifacts
+  rm -rf target/20*/.renku/cache
+  cp -r target/20* test-artifacts
+  tar czvf tests-artifacts.tgz test-artifacts
+  mv tests-artifacts.tgz ${RENKU_TEST_S3_FILENAME}.tgz
+
+  export MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}"
+  mc cp ${RENKU_TEST_S3_FILENAME}.tgz bucket/${RENKU_TEST_S3_BUCKET}
+  exit $TESTS_RC
+fi

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
@@ -31,7 +31,7 @@ trait AcceptanceSpec
       case Some(_) =>
         new ChromeDriver(
           new ChromeDriverService.Builder().withWhitelistedIps("127.0.0.1").build,
-          new ChromeOptions().addArguments("--no-sandbox", "--headless")
+          new ChromeOptions().addArguments("--no-sandbox", "--headless", "--disable-gpu")
         )
       case None =>
         Chrome.webDriver

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AnonEnv.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AnonEnv.scala
@@ -1,30 +1,33 @@
 package ch.renku.acceptancetests.tooling
-
 import java.lang.System.getProperty
-
 import ch.renku.acceptancetests.model.projects.ProjectIdentifier
 import eu.timepit.refined.api.Refined
-
 case class AnonEnvConfig(projectId: ProjectIdentifier, isAvailable: Boolean = false)
 
 /**
   * Configuration for the anonymous environment
   */
 trait AnonEnv extends AcceptanceSpecData {
-
   protected implicit lazy val anonEnvConfig: AnonEnvConfig =
     AnonEnvConfig(anonProjectIdentifier, isAnonEnvAvailable)
-
   protected lazy val anonProjectIdentifier: ProjectIdentifier = {
     Option(getProperty("anon")) orElse sys.env.get("RENKU_TEST_ANON_PROJECT") match {
       case Some(s) =>
-        val projectId = s.split("/").map(_.trim)
-        ProjectIdentifier(Refined.unsafeApply(projectId(0)), Refined.unsafeApply(projectId(1)))
-      case None =>
-        ProjectIdentifier(Refined.unsafeApply("andi"), Refined.unsafeApply("public-test-project"))
+        val projectIdComponents = s.split("/").map(_.trim).toList
+        projectIdComponents match {
+          case username :: tail =>
+            tail.headOption match {
+              case Some(projectName) =>
+                ProjectIdentifier(Refined.unsafeApply(username), Refined.unsafeApply(projectName))
+              case None => defaultProjectIdentifier
+            }
+          case _ => defaultProjectIdentifier
+        }
+      case None => defaultProjectIdentifier
     }
   }
-
+  private val defaultProjectIdentifier =
+    ProjectIdentifier(Refined.unsafeApply("andi"), Refined.unsafeApply("public-test-project"))
   protected lazy val isAnonEnvAvailable: Boolean = {
     val baseUrl = renkuBaseUrl
     Option(getProperty("anonAvail")) orElse sys.env.get("RENKU_TEST_ANON_AVAILABLE") match {
@@ -34,5 +37,4 @@ trait AnonEnv extends AcceptanceSpecData {
         baseUrl.value.value.equals("https://dev.renku.ch")
     }
   }
-
 }

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -25,22 +25,48 @@ spec:
         value: '{{ .Values.tests.parameters.fullname }}'
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
+      {{ if .Values.tests.parameters.provider }}
       - name: RENKU_TEST_PROVIDER
         value: '{{ .Values.tests.parameters.provider }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.register }}
       - name: RENKU_TEST_REGISTER
-        value: '{{ .Values.tests.parameters.testRegister | default "true" }}'
+        value: '{{ .Values.tests.parameters.register }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.docsRun }}
       - name: RENKU_TEST_DOCS_RUN
-        value: '{{ .Values.tests.parameters.docsRun | default "" }}'
+        value: '{{ .Values.tests.parameters.docsRun }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.extantProject }}
       - name: RENKU_TEST_EXTANT_PROJECT
-        value: '{{ .Values.tests.parameters.extantProject | default "" }}'
+        value: '{{ .Values.tests.parameters.extantProject }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.anonProject }}
       - name: RENKU_TEST_ANON_PROJECT
-        value: '{{ .Values.tests.parameters.anonProject | default "" }}'
+        value: '{{ .Values.tests.parameters.anonProject }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.anonAvailable }}
       - name: RENKU_TEST_ANON_AVAILABLE
-        value: '{{ .Values.tests.parameters.anonAvailable | default "false" }}'
+        value: '{{ .Values.tests.parameters.anonAvailable }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.batchRemove }}
       - name: RENKU_TEST_BATCH_REMOVE
-        value: '{{ .Values.tests.parameters.batchRemove | default "false"}}'
+        value: '{{ .Values.tests.parameters.batchRemove }}'
+      {{ end }}
+      {{ if .Values.tests.parameters.removePattern }}
       - name: RENKU_TEST_REMOVE_PATTERN
-        value: '{{ .Values.tests.parameters.removePattern | default "" }}'
+        value: '{{ .Values.tests.parameters.removePattern }}'
+      {{ end }}
+      - name: RENKU_TEST_S3_HOST
+        value: '{{ .Values.tests.resultsS3.host }}'
+      - name: RENKU_TEST_S3_BUCKET
+        value: '{{ .Values.tests.resultsS3.bucket }}'
+      - name: RENKU_TEST_S3_FILENAME
+        value: '{{ .Values.tests.resultsS3.filename }}'
+      - name: RENKU_TEST_S3_ACCESS_KEY
+        value: '{{ .Values.tests.resultsS3.accessKey }}'
+      - name: RENKU_TEST_S3_SECRET_KEY
+        value: '{{ .Values.tests.resultsS3.secretKey }}'
     volumeMounts:
       - mountPath: /dev/shm
         name: dshm
@@ -52,7 +78,9 @@ spec:
       requests:
         memory: "4G"
         cpu: "2"
+        ephemeral-storage: "1G"
       limits:
         memory: "4G"
         cpu: "2"
+        ephemeral-storage: "2G"
 {{- end }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -604,7 +604,7 @@ tests:
   #  fullname: Bruce Wayne
   #  password: IamBatman
   #  provider:
-  #  testRegister: true
+  #  register:
   #  docsRun:
   #  extantProject:
   #  anonProject:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line_length = 120


### PR DESCRIPTION
The CI acceptance tests are ran through Helm test. As the tests run in the deployment cluster (rather than the GH action     container) if any test fails the results are packaged, passed into an intermediate S3 bucket in SWITCH engine and then    downloaded in the GH action to be served as an artifact as usual.

Fix #1762.


/deploy