### PR TITLE
chore: make auto-PRs based on the master branch

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -24,5 +24,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
-          PULL_REQUEST_BRANCH: "development"
+          PULL_REQUEST_BRANCH: "master"
           PULL_REQUEST_BODY: "This is an automated pull request.\n\n/deploy"


### PR DESCRIPTION
We removed the development branch so that auto-PRs  could be made directly against the master branch. 