### PR TITLE
Make S3 config optional

### DIFF
--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -57,7 +57,7 @@ spec:
       - name: RENKU_TEST_REMOVE_PATTERN
         value: '{{ .Values.tests.parameters.removePattern }}'
       {{ end }}
-      {{ if .Values.tests.tests.resultsS3.enabled }}
+      {{ if .Values.tests.resultsS3.enabled }}
       - name: RENKU_TEST_S3_HOST
         value: '{{ .Values.tests.resultsS3.host }}'
       - name: RENKU_TEST_S3_BUCKET

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -57,6 +57,7 @@ spec:
       - name: RENKU_TEST_REMOVE_PATTERN
         value: '{{ .Values.tests.parameters.removePattern }}'
       {{ end }}
+      {{ if .Values.tests.tests.resultsS3.enabled }}
       - name: RENKU_TEST_S3_HOST
         value: '{{ .Values.tests.resultsS3.host }}'
       - name: RENKU_TEST_S3_BUCKET
@@ -67,6 +68,7 @@ spec:
         value: '{{ .Values.tests.resultsS3.accessKey }}'
       - name: RENKU_TEST_S3_SECRET_KEY
         value: '{{ .Values.tests.resultsS3.secretKey }}'
+      {{ end }}
     volumeMounts:
       - mountPath: /dev/shm
         name: dshm

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -612,7 +612,8 @@ tests:
   #  batchRemove: false
   #  removePattern:
   #  testTarget:
-  #resultsS3:
+  resultsS3:
+    enabled: false
   #  host:
   #  bucket:
   #  filename:


### PR DESCRIPTION
Not all renkulab deployments have the option to configure an S3 bucket, this PR makes this section optional so that these deployments can still benefit from running tests via Helm.

/deploy