### PR TITLE
feat: run Helm test for Renku CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_ANONYMOUS_SESSIONS: true
         RENKU_TESTS_ENABLED: true
+        TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku: "@master"
     - name: Notify slack
       if: success()
@@ -49,29 +50,25 @@ jobs:
     needs: deploy
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        sudo apt-get update -y && sudo apt-get install -y grep
-        pip install yq
     - name: Test
       env:
-        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
       run: |
-        RENKU_PYTHON_VERSION=v$(cat ./helm-chart/renku/requirements.yaml | yq -r '.dependencies[] | select(.name == "renku-core") | .version')
-        RENKU_PYTHON_COMMIT=$(echo $RENKU_PYTHON_VERSION | grep -o -P '(?<=-)[0-9a-fA-F]+') || true
-        if [ $RENKU_PYTHON_COMMIT ]; then export RENKU_PYTHON_VERSION=$RENKU_PYTHON_COMMIT; fi
-        echo "Passing renku-python version $RENKU_PYTHON_VERSION"
-
-        cd acceptance-tests
-        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --build-arg renku_python_ref=${RENKU_PYTHON_VERSION} sbt
-        docker-compose run -e RENKU_TEST_URL=https://dev.renku.ch \
-                           -e RENKU_TEST_FULL_NAME="Renku Bot" \
-                           -e RENKU_TEST_EMAIL="renku@datascience.ch" \
-                           -e RENKU_TEST_USERNAME="renku-test" \
-                           -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" sbt
+        echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
+        helm test renku --namespace renku --timeout 40m --logs
+    - name: Download artifact for packaging on failure
+      if: failure()
+      uses: ./actions/download-test-artifacts
+      env:
+        RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+        TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
+    - name: Upload screenshots on failure
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: acceptance-test-artifacts
+        path: ${{ github.workspace }}/test-artifacts/
     - name: Notify slack
       if: failure()
       env:
@@ -81,20 +78,6 @@ jobs:
              -H "Authorization: Bearer $RENKU_SLACK_BOT_TOKEN" \
              --data "channel=C9U45DL1H" \
              --data "text=Acceptance tests on https://dev.renku.ch failed! :scream_cat:"
-    - name: Prepare artifact for packaging on failure
-      if: failure()
-      run: |
-        mkdir acceptance-tests/test-artifacts
-        cp acceptance-tests/target/*.png acceptance-tests/test-artifacts 2>/dev/null || :
-        cp acceptance-tests/target/*.log acceptance-tests/test-artifacts 2>/dev/null || :
-        sudo rm -rf acceptance-tests/target/20*/.renku/cache 2>/dev/null || :
-        cp -r acceptance-tests/target/20* acceptance-tests/test-artifacts 2>/dev/null || :
-    - name: Upload screenshots on failure
-      if: failure()
-      uses: actions/upload-artifact@v1
-      with:
-        name: test-artifacts
-        path: acceptance-tests/test-artifacts
   chart:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
When running the deploy action for Renku, use helm test to pilot the acceptance test instead of docker-compose.

Depends on swissdatasciencecenter/ops-dev.renku.ch#121

closes #1944 