### PR TITLE
ci: run deploy and test on edit

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -6,6 +6,7 @@ on:
     - synchronize
     - reopened
     - closed
+    - edited
 
 jobs:
   cleanup-previous-runs:


### PR DESCRIPTION
This would run the action when editing the post -- e.g when adding `/deploy` to run the acceptance tests.