### PR TITLE
feat: renku login support (always forward gitlab to gateway)

### DIFF
--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -52,12 +52,10 @@ spec:
           serviceName: {{ $keycloakFullname }}-http
           servicePort: {{ $keycloakServicePort }}
       {{- end }}
-      {{- if $gitlabEnabled }}
       - path: /gitlab
         backend:
-          serviceName: {{ $gitlabFullname }}
-          servicePort: {{ $gitlabServicePort }}
-      {{- end }}
+          serviceName: {{ $gatewayFullname }}
+          servicePort: {{ $gatewayServicePort }}
       - path: /jupyterhub
         backend:
           serviceName: proxy-public


### PR DESCRIPTION
To authenticate git requests from CLI, we need to forward all request that go to `/gitlab` to the gateway.

Fixes: https://github.com/SwissDataScienceCenter/renku-python/issues/677