### PR TITLE
test: update acceptance tests to comply with ui changes for 1229

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
@@ -155,7 +155,7 @@ class ProjectPage(projectSlug: String, namespace: String) extends RenkuPage with
         }
 
         def descriptionField(implicit webDriver: WebDriver): WebElement = eventually {
-          find(cssSelector("textarea#textareatext-area")) getOrElse fail("Description field not found")
+          find(cssSelector("textarea#descriptiontext-area")) getOrElse fail("Description field not found")
         }
 
         def createIssueButton(implicit webDriver: WebDriver): WebElement = eventually {


### PR DESCRIPTION
Tests are failing on https://github.com/SwissDataScienceCenter/renku-ui/pull/1228 partly because of #1229 and partly because of changes for that PR.

This branch can be merged into 1229 that then can be merged into master.