### PR TITLE
chart: bump memory request and limit for tests

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@213fe75
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-docs:

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -80,11 +80,11 @@ spec:
     {{ end }}
     resources:
       requests:
-        memory: "4G"
+        memory: "5G"
         cpu: "2"
         ephemeral-storage: "1G"
       limits:
-        memory: "4G"
+        memory: "5G"
         cpu: "2"
         ephemeral-storage: "2G"
 {{- end }}


### PR DESCRIPTION
Increasing the memory for acceptance tests as a bandaid until https://github.com/SwissDataScienceCenter/renku/issues/2010 is resolved.

/deploy