### PR TITLE
charts: adapting resource requests for tests

### DIFF
--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -81,10 +81,10 @@ spec:
     resources:
       requests:
         memory: "3G"
-        cpu: "1500m"
+        cpu: "1000m"
         ephemeral-storage: "1G"
       limits:
         memory: "3G"
-        cpu: "1000m"
+        cpu: "1500m"
         ephemeral-storage: "2G"
 {{- end }}

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -80,11 +80,11 @@ spec:
     {{ end }}
     resources:
       requests:
-        memory: "4G"
-        cpu: "2"
+        memory: "3G"
+        cpu: "1500m"
         ephemeral-storage: "1G"
       limits:
-        memory: "4G"
-        cpu: "2"
+        memory: "3G"
+        cpu: "1000m"
         ephemeral-storage: "2G"
 {{- end }}


### PR DESCRIPTION
After merging #2011 the tests run at pretty exactly at 2GB of memory and <= 1 CPU.

/deploy