### PR TITLE
chore: update docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ ipython-genutils==0.2.0
 ipython==6.4.0
 jedi==0.12.1
 jinja2==2.10.1
-markupsafe==1.0
+markupsafe==1.1.1
 packaging==17.1
 parso==0.3.0
 pexpect==4.6.0; sys_platform != 'win32'


### PR DESCRIPTION
`markupsafe@v1.0` had a problem with the latest `setuptools` preventing the docs from building properly. 