### PR TITLE
feat: use Slack notification action for Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,20 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku: "@master"
-    - name: Notify slack
-      if: success()
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: custom
+        fields: job,ref
+        custom_payload: |
+          {
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_JOB} commit ${process.env.AS_COMMIT}: ${{ job.status }}.`,
+            }]
+          }
       env:
-        RENKU_SLACK_BOT_TOKEN: ${{ secrets.RENKU_SLACK_BOT_TOKEN }}
-      run: |
-        curl -X POST https://slack.com/api/chat.postMessage \
-             -H "Authorization: Bearer $RENKU_SLACK_BOT_TOKEN" \
-             --data "channel=C9U45DL1H" \
-             --data "text=https://dev.renku.ch has been updated! :tada:"
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()
   test:
     runs-on: ubuntu-latest
     needs: deploy
@@ -67,12 +72,17 @@ jobs:
       with:
         name: acceptance-test-artifacts
         path: ${{ github.workspace }}/test-artifacts/
-    - name: Notify slack
-      if: failure()
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: custom
+        fields: job,ref
+        custom_payload: |
+          {
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_JOB} commit ${process.env.AS_COMMIT}: ${{ job.status }}.`,
+            }]
+          }
       env:
-        RENKU_SLACK_BOT_TOKEN: ${{ secrets.RENKU_SLACK_BOT_TOKEN }}
-      run: |
-        curl -X POST https://slack.com/api/chat.postMessage \
-             -H "Authorization: Bearer $RENKU_SLACK_BOT_TOKEN" \
-             --data "channel=C9U45DL1H" \
-             --data "text=Acceptance tests on https://dev.renku.ch failed! :scream_cat:"
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()


### PR DESCRIPTION
Replace direct calls to Slack's API with notification action.

Gives more information, including link to the commit that triggered the workflow.
