### PR TITLE
chore: increase test timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-        helm test renku --namespace renku --timeout 40m --logs
+        helm test renku --namespace renku --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
       uses: ./actions/download-test-artifacts

--- a/.github/workflows/publish-deploy-staging.yml
+++ b/.github/workflows/publish-deploy-staging.yml
@@ -96,7 +96,7 @@ jobs:
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         run: |
           echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-          helm test staging-renku --namespace staging --timeout 40m --logs
+          helm test staging-renku --namespace staging --timeout 80m --logs
       - name: Download artifact for packaging on failure
         if: failure()
         uses: ./actions/download-test-artifacts

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -108,7 +108,7 @@ jobs:
         RENKU_RELEASE: ci-renku-${{ github.event.number }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 40m --logs
+        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
       uses: ./actions/download-test-artifacts

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -196,7 +196,7 @@ You simply need to:
       $ helm test renku \
        --namespace renku \
        --log-file renku-tests.log \
-       --timeout 40m
+       --timeout 80m
 
 5. Post deployment configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is more of a bandaid than a permanent fix. We should consider breaking up the test scenarios into individual k8s jobs: https://github.com/SwissDataScienceCenter/renku/issues/2042

/deploy