### PR TITLE
ci: fix renku-ui-server in the deploy action

### DIFF
--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -126,7 +126,15 @@ def configure_requirements(tempdir, reqs, component_versions):
                 if dep["name"] == component.replace("_", "-"):
                     dep["version"] = req.version
                     dep["repository"] = req.helm_repo
+                    if dep["name"] == "renku-ui":
+                        renku_ui_version = req.version
+                        renku_ui_repository = req.helm_repo
                     continue
+    # keep renku-ui-server version aligned with renku-ui
+    for dep in reqs["dependencies"]:
+        if dep["name"] == "renku-ui-server":
+            dep["version"] = renku_ui_version
+            dep["repository"] = renku_ui_repository
     return reqs
 
 

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -64,11 +64,13 @@ class RenkuRequirement(object):
             return f"file://{self.tempdir}/{self.repo}/helm-chart/{self.component}"
         return "https://swissdatasciencecenter.github.io/helm-charts/"
 
-    # handle the special case of renku-python
+    # handle the special case of renku-python and renku-ui-server
     @property
     def repo(self):
         if self.component == "renku-core":
             return "renku-python"
+        if self.component == "renku-ui-server":
+            return "renku-ui"
         return self.component
 
     @property
@@ -126,16 +128,16 @@ def configure_requirements(tempdir, reqs, component_versions):
                 if dep["name"] == component.replace("_", "-"):
                     dep["version"] = req.version
                     dep["repository"] = req.helm_repo
-                    if dep["name"] == "renku-ui":
-                        renku_ui_version = req.version
-                        renku_ui_repository = req.helm_repo
+                    # if dep["name"] == "renku-ui":
+                    #     renku_ui_version = req.version
+                    #     renku_ui_repository = req.helm_repo
                     continue
     # keep renku-ui-server version aligned with renku-ui
-    for dep in reqs["dependencies"]:
-        if dep["name"] == "renku-ui-server":
-            dep["version"] = renku_ui_version
-            dep["repository"] = renku_ui_repository
-    return reqs
+    # for dep in reqs["dependencies"]:
+    #     if dep["name"] == "renku-ui-server":
+    #         dep["version"] = renku_ui_version
+    #         dep["repository"] = renku_ui_repository
+    # return reqs
 
 
 if __name__ == "__main__":
@@ -192,6 +194,9 @@ if __name__ == "__main__":
     print("DEBUG: component_versions")
     pprint.pp(component_versions)
     # print("DEBUG FINISHED")
+    # keep renku-ui-server version aligned with renku-ui
+    if component_versions["renku-ui"] and not component_versions["renku-ui-server"]:
+        component_versions["renku-ui-server"] = component_versions["renku-ui"]
     reqs = configure_requirements(tempdir, reqs, component_versions)
     print("DEBUG: reqs")
     pprint.pp(reqs)

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -128,15 +128,7 @@ def configure_requirements(tempdir, reqs, component_versions):
                 if dep["name"] == component.replace("_", "-"):
                     dep["version"] = req.version
                     dep["repository"] = req.helm_repo
-                    # if dep["name"] == "renku-ui":
-                    #     renku_ui_version = req.version
-                    #     renku_ui_repository = req.helm_repo
                     continue
-    # keep renku-ui-server version aligned with renku-ui
-    # for dep in reqs["dependencies"]:
-    #     if dep["name"] == "renku-ui-server":
-    #         dep["version"] = renku_ui_version
-    #         dep["repository"] = renku_ui_repository
     return reqs
 
 
@@ -186,20 +178,12 @@ if __name__ == "__main__":
         reqs = yaml.load(f, Loader=yaml.SafeLoader)
 
     ## 2. set the chosen versions in the requirements.yaml file
-    #if dep["name"].replace("_", "-") == "renku-ui":
-    print("DEBUG: tempdir")
-    pprint.pp(tempdir)
-    print("DEBUG: reqs")
-    pprint.pp(reqs)
-    print("DEBUG: component_versions")
-    pprint.pp(component_versions)
-    # print("DEBUG FINISHED")
+
     # keep renku-ui-server version aligned with renku-ui
     if component_versions["renku_ui"] and not component_versions["renku_ui_server"]:
         component_versions["renku_ui_server"] = component_versions["renku_ui"]
+
     reqs = configure_requirements(tempdir, reqs, component_versions)
-    print("DEBUG: reqs")
-    pprint.pp(reqs)
 
     with open(reqs_path, "w") as f:
         yaml.dump(reqs, f)

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -137,7 +137,7 @@ def configure_requirements(tempdir, reqs, component_versions):
     #     if dep["name"] == "renku-ui-server":
     #         dep["version"] = renku_ui_version
     #         dep["repository"] = renku_ui_repository
-    # return reqs
+    return reqs
 
 
 if __name__ == "__main__":

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -119,7 +119,6 @@ def configure_requirements(tempdir, reqs, component_versions):
         if version:
             # form and setup the requirement
             req = RenkuRequirement(component.replace("_", "-"), version, tempdir)
-            pprint.pp(req)
             if req.ref:
                 req.setup()
                 # replace the requirement
@@ -177,7 +176,17 @@ if __name__ == "__main__":
         reqs = yaml.load(f, Loader=yaml.SafeLoader)
 
     ## 2. set the chosen versions in the requirements.yaml file
+    #if dep["name"].replace("_", "-") == "renku-ui":
+    print("DEBUG: tempdir")
+    pprint.pp(tempdir)
+    print("DEBUG: reqs")
+    pprint.pp(reqs)
+    print("DEBUG: component_versions")
+    pprint.pp(component_versions)
+    # print("DEBUG FINISHED")
     reqs = configure_requirements(tempdir, reqs, component_versions)
+    print("DEBUG: reqs")
+    pprint.pp(reqs)
 
     with open(reqs_path, "w") as f:
         yaml.dump(reqs, f)

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -195,8 +195,8 @@ if __name__ == "__main__":
     pprint.pp(component_versions)
     # print("DEBUG FINISHED")
     # keep renku-ui-server version aligned with renku-ui
-    if component_versions["renku-ui"] and not component_versions["renku-ui-server"]:
-        component_versions["renku-ui-server"] = component_versions["renku-ui"]
+    if component_versions["renku_ui"] and not component_versions["renku_ui_server"]:
+        component_versions["renku_ui_server"] = component_versions["renku_ui"]
     reqs = configure_requirements(tempdir, reqs, component_versions)
     print("DEBUG: reqs")
     pprint.pp(reqs)

--- a/actions/deploy-renku/deploy-dev-renku.py
+++ b/actions/deploy-renku/deploy-dev-renku.py
@@ -119,6 +119,7 @@ def configure_requirements(tempdir, reqs, component_versions):
         if version:
             # form and setup the requirement
             req = RenkuRequirement(component.replace("_", "-"), version, tempdir)
+            pprint.pp(req)
             if req.ref:
                 req.setup()
                 # replace the requirement


### PR DESCRIPTION
This PR fixes the repo references for the ui-server component and it keeps the target version aligned with the UI component unless anything different id explicitly defined.

P.S. sorry for the messy commit history, I'll squash while merging :grin: 

/deploy renku-ui=1092-uiserver-autoscaling