### PR TITLE
chore: add a swagger UI

### DIFF
--- a/helm-chart/renku/templates/_keycloak-clients-users.tpl
+++ b/helm-chart/renku/templates/_keycloak-clients-users.tpl
@@ -49,6 +49,32 @@ Define clients and users for Keycloak
         "userinfo.token.claim": false
       }
     }]
+  },
+  {
+    "clientId": "swagger",
+    "publicClient": true,
+    "baseUrl": "{{ template "http" . }}://{{ .Values.global.renku.domain }}",
+    "redirectUris": [
+        "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
+    ],
+    "webOrigins": [
+        "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
+    ],
+    "attributes": {
+        "pkce.code.challenge.method": "S256"
+    },
+    "protocolMappers": [{
+      "name": "renku audience for the swagger UI",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "consentRequired": false,
+      "config": {
+        "included.client.audience": "renku",
+        "id.token.claim": false,
+        "access.token.claim": true,
+        "userinfo.token.claim": false
+      }
+    }]
   }
 
   {{- if .Values.gitlab.enabled -}}

--- a/helm-chart/renku/templates/_keycloak-clients-users.tpl
+++ b/helm-chart/renku/templates/_keycloak-clients-users.tpl
@@ -30,7 +30,7 @@ Define clients and users for Keycloak
     {
     "clientId": "renku-cli",
     "baseUrl": "{{ template "http" . }}://{{ .Values.global.renku.domain }}",
-    "secret": "{{ required "Fill in .Values.global.gateway.clientSecret with `uuidgen -r`" .Values.global.gateway.cliClientSecret }}",
+    "secret": "{{ required "Fill in .Values.global.gateway.cliClientSecret with `uuidgen -r`" .Values.global.gateway.cliClientSecret }}",
     "redirectUris": [
         "{{ template "http" . }}://{{ .Values.global.renku.domain }}/*"
     ],

--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -19,6 +19,7 @@
 {{- $jenaFullname := include "jena.fullname" . -}}
 {{- $jenaServicePort := .Values.graph.jena.service.port -}}
 {{- end }}
+{{- $swaggerEnabled := .Values.swagger.enabled -}}
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
@@ -91,9 +92,11 @@ spec:
           serviceName: {{ $knowledgeGraphFullname }}
           servicePort: 80
       {{- end }}
+      {{- if $swaggerEnabled }}
       - path: /swagger
         backend:
           serviceName: {{ $renkuFullname }}-swagger
           servicePort: 80
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -14,6 +14,7 @@
 {{- $graphEnabled := .Values.graph.enabled -}}
 {{- $webhookServiceFullname := include "webhookService.fullname" . -}}
 {{- $knowledgeGraphFullname := include "knowledgeGraph.fullname" . -}}
+{{- $renkuFullname := include "renku.fullname" . -}}
 {{- if $graphEnabled }}
 {{- $jenaFullname := include "jena.fullname" . -}}
 {{- $jenaServicePort := .Values.graph.jena.service.port -}}
@@ -90,5 +91,9 @@ spec:
           serviceName: {{ $knowledgeGraphFullname }}
           servicePort: 80
       {{- end }}
+      - path: /swagger
+        backend:
+          serviceName: {{ $renkuFullname }}-swagger
+          servicePort: 80
   {{- end }}
 {{- end }}

--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.swagger.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "renku.fullname" . }}-swagger
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -48,20 +49,6 @@ spec:
             httpGet:
               path: /swagger
               port: http
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -77,3 +64,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "renku.name" . }}-swagger
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "renku.fullname" . }}-swagger
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "renku.name" . }}-swagger
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "renku.name" . }}-swagger
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: swagger
+          image: swaggerapi/swagger-ui
+          env:
+            - name: BASE_URL
+              value: /swagger
+            - name: URL
+              value: /api/renku/openapi.json
+            - name: OAUTH2_REDIRECT_URL
+              value: https://{{ .Values.global.renku.domain }}/swagger/oauth2-redirect.html
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /swagger
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /swagger
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "renku.fullname" . }}-swagger
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "renku.name" . }}-swagger
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -30,6 +30,12 @@ spec:
                 ]
             - name: OAUTH2_REDIRECT_URL
               value: https://{{ .Values.global.renku.domain }}/swagger/oauth2-redirect.html
+            - name: OAUTH_USE_PKCE
+              value: "true"
+            - name: OAUTH_CLIENT_ID
+              value: "swagger"
+            - name: OAUTH_CLIENT_SECRET
+              value: ""
           ports:
             - name: http
               containerPort: 8080

--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -22,8 +22,12 @@ spec:
           env:
             - name: BASE_URL
               value: /swagger
-            - name: URL
-              value: /api/renku/spec.json
+            - name: URLS
+              value: >
+                [
+                  {"url": "/api/renku/spec.json", "name": "core service"},
+                  {"url": "/jupyterhub/services/notebooks/api/v1/spec", "name": "notebooks service"}
+                ]
             - name: OAUTH2_REDIRECT_URL
               value: https://{{ .Values.global.renku.domain }}/swagger/oauth2-redirect.html
           ports:

--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -23,7 +23,7 @@ spec:
             - name: BASE_URL
               value: /swagger
             - name: URL
-              value: /api/renku/openapi.json
+              value: /api/renku/spec.json
             - name: OAUTH2_REDIRECT_URL
               value: https://{{ .Values.global.renku.domain }}/swagger/oauth2-redirect.html
           ports:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -658,3 +658,7 @@ core:
 
     ## Default clone depth
     # projectCloneDepth: 1
+
+## Configuration for the Swagger-UI available at <renku-domain>/swagger
+swagger:
+  enabled: true


### PR DESCRIPTION
This PR adds a swagger UI to the renku deployment to allow testing of API endpoints directly in a live deployment. 

It configures the core and notebooks service specs to be shown - each can be selected via a drop-down. 

### Authentication

Some endpoints (e.g. those of the core service) receive tokens via the gateway. The core service api spec is configured for login via Keycloak - this will retrieve a JWT token to inject into the requests that get routed through the gateway. You must also log in to the renku instance you are testing so that the gateway there has actual tokens to send (the login in swagger doesn't do this for you). For endpoints that do not go through the gateway the spec should define the proper authorization methods (e.g. an API token). 

You can access the api docs under https://ci-renku-2091.dev.renku.ch/swagger

/deploy renku-core=@2029-api-docs #notest