### PR TITLE
Acceptance tess: fix authorize selector

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/LoginPage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/LoginPage.scala
@@ -127,7 +127,7 @@ object AuthorizeApplicationPage
   def authorizeButton(implicit webDriver: WebDriver): WebElement = eventually {
     find(
       cssSelector(
-        "#content-body > main > div > div > div.modal-body > div > form:nth-child(2) > input.btn.btn-success.prepend-left-10"
+        "input[data-qa-selector='authorization_button']"
       )
     ) getOrElse fail("Authorize button not found")
   }


### PR DESCRIPTION
Fixes the selector for both old and new GitLab versions in our acceptance tests :crossed_fingers: 

/deploy