### PR TITLE
chore: additional values for pr deploy

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -52,6 +52,7 @@ jobs:
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
+      extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
@@ -89,6 +90,7 @@ jobs:
         renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
         renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
         renku_ui: "${{ needs.check-deploy.outputs.renku-ui }}"
+        extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
     - name: Check existing renkubot comment
       if: needs.check-deploy.outputs.pr-contains-string == 'true'
       uses: peter-evans/find-comment@v1

--- a/actions/check-pr-description/action.yaml
+++ b/actions/check-pr-description/action.yaml
@@ -30,7 +30,7 @@ outputs:
     description: renku-ui reference as specified in the command string
     value: ${{ steps.check-string.outputs.renku-ui }}
   extra-values:
-    description: extra values passed to helm
+    description: extra values passed to helm, separate multiple values with commas: key1=val1,key2=val2
     value: ${{ steps.check-string.outputs.extra-values }}
   test-enabled:
     description: whether the tests should run or not

--- a/actions/check-pr-description/action.yaml
+++ b/actions/check-pr-description/action.yaml
@@ -29,6 +29,9 @@ outputs:
   renku-ui:
     description: renku-ui reference as specified in the command string
     value: ${{ steps.check-string.outputs.renku-ui }}
+  extra-values:
+    description: extra values passed to helm
+    value: ${{ steps.check-string.outputs.extra-values }}
   test-enabled:
     description: whether the tests should run or not
     value: ${{ steps.check-string.outputs.test-enabled }}
@@ -80,6 +83,11 @@ runs:
             match="#notest"
             if [[ $command =~ $match ]]; then
               test_enabled=false
+            fi
+            match="extra-values=(\S*)"
+            if [[ $command =~ $match ]]; then
+              echo "extra values: ${BASH_REMATCH[1]}"
+              echo "::set-output name=extra-values::${BASH_REMATCH[1]}"
             fi
           else
             echo "No command found"

--- a/actions/check-pr-description/action.yaml
+++ b/actions/check-pr-description/action.yaml
@@ -30,7 +30,7 @@ outputs:
     description: renku-ui reference as specified in the command string
     value: ${{ steps.check-string.outputs.renku-ui }}
   extra-values:
-    description: extra values passed to helm, separate multiple values with commas: key1=val1,key2=val2
+    description: "extra values passed to helm; separate multiple values with commas: key1=val1,key2=val2"
     value: ${{ steps.check-string.outputs.extra-values }}
   test-enabled:
     description: whether the tests should run or not


### PR DESCRIPTION
allows specifying additional values to be passed to a custom deployment via the `extra-values` option:


/deploy renku-ui=0.11.x extra-values=ui.canary.enabled=true,ui.canary.image.repository=renku/renku-ui,ui.canary.image.tag=0.11.11-n044.hbfc2e2b