### PR TITLE
document __renku_version__ template parameter

### DIFF
--- a/docs/user/templates.rst
+++ b/docs/user/templates.rst
@@ -318,6 +318,7 @@ renku-specific variables that are always available in templates, namely:
   special characters) as used in Gitlab and URLs.
 * ``__project_slug__``: The project slug (``<namespace>/<sanitized project
   name>``) (only set when creating a project online in renkulab).
+* ``__renku_version__``: Renku version to be used for the project.
 
 
 Use custom template repositories


### PR DESCRIPTION
Updates documentation with new template variable `__renku_version__`.

fix #2153 
Depends on SwissDataScienceCenter/renku-python#2145