### PR TITLE
(chore) fix Renku ingress template

### DIFF
--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -57,7 +57,7 @@ spec:
           service:
             name: {{ $keycloakFullname }}-http
             port:
-              number: {{ $keycloakServicePort }}
+              name: {{ $keycloakServicePort }}
       {{- end }}
       {{- if $gitlabEnabled }}
       - path: /gitlab


### PR DESCRIPTION
The keycloak ingress port is referenced by its name "http" rather
than a number in the default Keycloak Helm Chart Values.

When using Ingress from the stable API the port for the ingress
must be defined as either "number" or "name" fitting the corresponding
types.

This commit changes "number" to "name" for the Keycloak ingress port.

Tested with:
```
helm template renku --validate ./helm-chart/renku -f <values.file.yaml>
```
