### PR TITLE
chore: bump gitlab chart version

### DIFF
--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.5.2
+version: 0.6.0

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 0.9.5
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.5.2
+  version: 0.6.0
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph


### PR DESCRIPTION
Note: deploying won't help here as our CI deployments do not include gitlab. However, the gitlab chart 0.6.0 got properly published and doesn't use the beta API anymore in its ingress template.