### PR TITLE
fix(helm-chart): fix gitlab registry ingress spec

### DIFF
--- a/helm-chart/gitlab/templates/registry-ingress.yaml
+++ b/helm-chart/gitlab/templates/registry-ingress.yaml
@@ -36,7 +36,7 @@ spec:
           service:
             name: {{ $gitlabFullname }}
             port:
-              port: {{ 8105 }}
+              number: {{ 8105 }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Note that this is already part of the published 0.6.0 gitlab chart.