### PR TITLE
chore: bump renku project templates version

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -404,7 +404,7 @@ ui:
     custom: true
     repositories:
       - url: https://github.com/SwissDataScienceCenter/renku-project-template
-        ref: 0.1.22
+        ref: 0.2.0
         name: Renku
       - url: https://github.com/SwissDataScienceCenter/contributed-project-templates
         ref: 0.2.0


### PR DESCRIPTION
/deploy

This includes the recent fixes to our base-images / templates and should be included in the upcoming Renku release.