### PR TITLE
chore: fix acceptance tests to accept X.Y.Z.postN version

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
@@ -42,7 +42,7 @@ object CliVersion {
 
   final class ReleasedVersion private (val value: String) extends CliVersion
   object ReleasedVersion {
-    private val validator = raw"\d+\.\d+\.\d+(\.dev\d+)?"
+    private val validator = raw"\d+\.\d+\.\d+(\.post\d+)?(\.dev\d+)?"
 
     def get(value: String): Option[CliVersion] =
       Option.when(value.trim matches validator)(new ReleasedVersion(value.trim))
@@ -57,7 +57,7 @@ object CliVersion {
   }
 
   object NonReleasedVersion {
-    private val validator = raw"\d+\.\d+\.\d+\.dev\d+\+g([0-9a-f]{5,40})"
+    private val validator = raw"\d+\.\d+\.\d+(?:\.post\d+)?\.dev\d+\+g([0-9a-f]{5,40})"
 
     def get(value: String): Option[CliVersion] =
       Option.when(value.trim matches validator)(new NonReleasedVersion(value.trim))


### PR DESCRIPTION
With 0.16.1.post1 we released a version that isn't compatible with the acceptance test regex, this fixes that.