### PR TITLE
fix(chart): remove unneeded Jupyterhub auth secret from gitlab post install job

### DIFF
--- a/helm-chart/renku/templates/post-install-job-gitlab.yaml
+++ b/helm-chart/renku/templates/post-install-job-gitlab.yaml
@@ -41,11 +41,6 @@ spec:
               secretKeyRef:
                 name: {{ template "renku.fullname" . }}-gitlab-postgres
                 key: gitlab-postgres-password
-          - name: JUPYTERHUB_AUTH_GITLAB_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "renku.fullname" . }}
-                key: jupyterhub-auth-gitlab-client-secret
           - name: GATEWAY_GITLAB_CLIENT_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
We forgot to clean this up in the repo that introduced amalthea.