### PR TITLE
chore: updates for 0.9.3 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
 0.9.2
 -----
 
+Improvements
+~~~~~~~~~~~~
+
+* **UI**: more persistent notifications for maintenance or downtime
+
+0.9.2
+-----
+
 This is a bugfix release that includes various minor fixes: templates and core use a new bugfix CLI version, as well as other fixes for external to SDSC deployments and improved login style.
 
 Improvements

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.9.2
+version: 0.9.3

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 1.0.1
+  version: 1.0.2
 - name: renku-ui-server
   alias: uiserver
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"


### PR DESCRIPTION
Prep for the 0.9.3 release that allows for better notifications from status page to be displayed in the ui.

/deploy