### PR TITLE
chore: remove Jupyterhub from helpers helm chart file

### DIFF
--- a/helm-chart/renku/templates/_helpers.tpl
+++ b/helm-chart/renku/templates/_helpers.tpl
@@ -65,10 +65,6 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "uiserver" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "jupyterhub.fullname" -}}
-{{- printf "%s-%s" .Release.Name "jupyterhub" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "notebooks.fullname" -}}
 {{- printf "%s-%s" .Release.Name "notebooks" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
This change was removed from the documentation update (#2319) and moved here.