### PR TITLE
Prepare for 0.10.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,12 @@
 ------
 
 This is a bugfix release that contains a fix for launching R sessions with our newest component that manages user sessions (Amalthea).
-See `renku-notebooks 1.1.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.1.1>__` and `amalthea 0.1.3 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.1.3>__` for more details.
+See `renku-notebooks 1.1.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.1.1>`__ and `amalthea 0.1.3 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.1.3>`__ for more details.
+
+Improvements
+~~~~~~~~~~~~
+
+Our documentation has been restructured, now articles are reorganized into ``Tutorials``, ``How-to guides``, ``Topic Guides`` and ``Reference`` (see `#2191 <https://github.com/SwissDataScienceCenter/renku/pull/2191>`__).
 
 0.10.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 .. _changelog:
 
+0.10.1
+------
+
+This is a bugfix release that contains a fix for launching R sessions with our newest component that manages user sessions (Amalthea).
+See `renku-notebooks 1.1.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.1.1>__` and `amalthea 0.1.3 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.1.3>__` for more details.
+
 0.10.0
 ------
 

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.10.0
+version: 0.10.1


### PR DESCRIPTION
Updates for `0.10.1` bug fix release.

(not deploying since all component versions stay the same as the head of master)