### PR TITLE
chore(docs): add graphviz to rtd config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
-
+  apt_packages:
+    - "graphviz"
 sphinx:
   configuration: docs/conf.py
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -127,6 +127,7 @@ OpenID
 openssl
 papermill
 parameterizable
+parametrization
 parametrize
 parametrized
 pipenv


### PR DESCRIPTION
`graphviz` has to be added to the apt configuration of the build environment on RTD in order to build the in-line documentation graphs. 