### PR TITLE
chore: add the renku-python api docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,10 @@ exclude_patterns += [
 ]
 
 exclude_patterns += [
-    str(p) for p in Path("renku-python").rglob("*.rst") if p not in {Path("renku-python/docs/reference/commands.rst")}
+    str(p) for p in Path("renku-python").rglob("*.rst") if p not in {
+        Path("renku-python/docs/reference/commands.rst"),
+        Path("renku-python/docs/api.rst")
+    }
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,3 +9,4 @@ Reference
     Services <services/index>
     Templates <templates>
     Renku CLI commands <../renku-python/docs/reference/commands>
+    Renku Python API <../renku-python/docs/api>


### PR DESCRIPTION
The renku python api docs were dropped accidentally. This PR adds them to the `Reference` section.