### PR TITLE
fix(ci): update github token to org secret

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -18,11 +18,11 @@ jobs:
           other_prs=$(curl -s ${renku_repo}/pulls | jq ".[] | select((.head.ref | test(\"auto-update/${pr_repo}\")) and (.head.ref != \"${GITHUB_REF:11}\")) | .number")
           for pr in $other_prs ; do curl -s -H "Authorization: token $GITHUB_TOKEN" -X PATCH -d '{"state": "closed"}' ${renku_repo}/pulls/${pr} ; done
         env:
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
       - name: pull-request-action
         uses: vsoch/pull-request-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
           PULL_REQUEST_BRANCH: "master"
           PULL_REQUEST_BODY: "This is an automated pull request.\n\n/deploy"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.7.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.RENKU_CI_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.RENKUBOT_GITHUB_TOKEN }}"
           MERGE_METHOD: "squash"
           MERGE_DELETE_BRANCH: "true"
           MERGE_LABELS: "automerge,!do-not-merge"

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: "${{ secrets.RENKU_CI_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.RENKUBOT_GITHUB_TOKEN }}"
           PR_FILTER: "labelled"
           PR_LABELS: "autoupdate"
           MERGE_MSG: "Branch was auto-updated."

--- a/.github/workflows/publish-deploy-staging.yml
+++ b/.github/workflows/publish-deploy-staging.yml
@@ -23,7 +23,7 @@ jobs:
           GIT_EMAIL: chart-bot@example.com
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
       - uses: 8398a7/action-slack@v3
         with:
           status: custom

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: TimonVS/pr-labeler-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
I am not sure what is the difference between the `RENKU_CI_TOKEN` and `RENKUBOT_GITHUB_TOKEN` secrets.

But it seems that some of the permissions for `RENKU_CI_TOKEN` have been removed or the token has been fully disabled. Either way it is much nicer to use an org-level secret.

This should probably fix this problem:
https://github.com/SwissDataScienceCenter/renku/runs/4336151543?check_suite_focus=true