### PR TITLE
(feat) GitLab and PostgreSQL upgrades

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -92,14 +92,14 @@ global:
     existingSecretPasswordKey: redis-password
 
     ## Specify the redis host and port. Notice that these settings only affect
-    ## the subcharts which represent the applications which are clients to redis, 
-    ## but not the redis cluster deployment itself. 
+    ## the subcharts which represent the applications which are clients to redis,
+    ## but not the redis cluster deployment itself.
     ## If you're deploying redis through this chart and you want to deviate from
-    ## the defaults, you'll have to match whatever you set here in the non-global 
+    ## the defaults, you'll have to match whatever you set here in the non-global
     ## redis section which defines the actual redis cluster.
     ## The hostname will fall-back to RELEASE-NAME-redis if left empty and the port
     ## will be set to the respective defaults depending on the isSentinel setting.
-    # host: RELEASE-NAME-redis 
+    # host: RELEASE-NAME-redis
     # port: 6379/26379
 
     # Set to true if redis host/port point to a redis sentinel.
@@ -242,7 +242,7 @@ postgresql:
 
   image:
     repository: bitnami/postgresql
-    tag: 11.11.0
+    tag: 12.8.0
 
   persistence:
     ## We use the defaults here, but they will probably be modified for most deployments.
@@ -345,7 +345,7 @@ gitlab:
     # Check out the gitlab docs on upgrading versions - in particular major
     # versions - before changing the image tag.
     #  https://docs.gitlab.com/ce/update/#upgrading-to-a-new-major-version
-    tag: 13.10.4-ce.0
+    tag: 14.4.2-ce.0
 
   ## automatically log in to gitlab
   oauth:

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -6,14 +6,24 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
-## Unreleased (Renku 0.10.2?)
-* NEW - *uiserver* has been added with the required values for the ui-server component.
-* NEW - *global.uiserver.clientSecret* has been added when introducing a new "renku-ui" client application in keycloak. Generate through `openssl rand -hex 32`.
+## Unreleased (Renku 0.11.0)
+* NEW/EDIT *postgresql.persistence.existingClaim* might need to be modified in the course of upgrading your PostgreSQL version. See [these instructions](https://github.com/SwissDataScienceCenter/renku/tree/master/helm-chart/utils/postgres_migrations/version_upgrades/README.md)
+* NEW/EDIT/DELETE *gitlab.image.tag* might have to be adjusted as we do a GitLab major version bump in with this release. See [these instructions](https://github.com/SwissDataScienceCenter/renku/tree/master/helm-chart#upgrading-to-0110)
 
+## Unreleased (Renku 0.10.3)
+* NEW - *uiserver* has been added with the required values for the ui-server component.
+* NEW - *global.uiserver.clientSecret* has been added when introducing a new `renku-ui` client application in keycloak. Generate through `openssl rand -hex 32`.
+
+## Upgrading to Renku 0.10.0 (breaking changes)
+The use of Amalthea and removal of Jupyterhub require some changes.
+This version is not backward compatible with the user sessions from older versions. During the deployment the admin should clean up all remaining user sessions and then deploy this version.
+
+* NEW - *notebooks.amalthea* several new sections have been added to the `values.yaml` file which are required by Amalthea. Please refer to the renku values file for more details.
+* DELETE - *notebooks.jupyter* and all references to Jupyterhub in the values have been removed and are not required anymore.
+* DELETE - anonymous sessions do not require a separate namespace and renku-notebooks deployment, if enabled in the values file they now run in the same namespace as regular user sessions.
 
 ## Upgrading to Renku 0.9.0
 * NEW - *ui.homepage* has been added for customizing the content on the RenkuLab home page. See the values.yml file for more detailed documentation.
-
 
 ## Upgrading to Renku 0.8.4
 * NEW *notebooks.serverDefaults* has been added with default values that will be

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -6,13 +6,18 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
-## Unreleased (Renku 0.11.0)
+## Upgrading to Renku 0.11.0
 * NEW/EDIT *postgresql.persistence.existingClaim* might need to be modified in the course of upgrading your PostgreSQL version. See [these instructions](https://github.com/SwissDataScienceCenter/renku/tree/master/helm-chart/utils/postgres_migrations/version_upgrades/README.md)
 * NEW/EDIT/DELETE *gitlab.image.tag* might have to be adjusted as we do a GitLab major version bump in with this release. See [these instructions](https://github.com/SwissDataScienceCenter/renku/tree/master/helm-chart#upgrading-to-0110)
 
-## Unreleased (Renku 0.10.3)
+## Upgrading to Renku 0.10.3
+* NEW - *redis-password* Generate through `openssl rand -hex 32`.
+
+## Upgrading to Renku 0.10.2
 * NEW - *uiserver* has been added with the required values for the ui-server component.
 * NEW - *global.uiserver.clientSecret* has been added when introducing a new `renku-ui` client application in keycloak. Generate through `openssl rand -hex 32`.
+* NEW - *notebooks.amalthea.resourceUsageCheck.enabled* needs to be set to false for the time being.
+* NEW - *notebooks.sessionTolerations* and *notebooks.sessionAffinity* is now configurable in order to have user session dedicated nodes.
 
 ## Upgrading to Renku 0.10.0 (breaking changes)
 The use of Amalthea and removal of Jupyterhub require some changes.


### PR DESCRIPTION
Values and instructions updates to support GitLab `14` and PostgreSQL `12` in renku `0.11.0`.
To be merged after next renku bugfix release and after upgrades are applied on dev.

This has been tested on renkulab-test using renkulab.io's snapshots.