### PR TITLE
(fix) Use the same labels for post-install jobs as other resources.

### DIFF
--- a/helm-chart/renku/templates/post-install-job-gitlab.yaml
+++ b/helm-chart/renku/templates/post-install-job-gitlab.yaml
@@ -4,9 +4,9 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-post-install-gitlab"
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "renku.chart" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "20"
@@ -16,9 +16,9 @@ spec:
     metadata:
       name: "{{.Release.Name}}-post-install-gitlab"
       labels:
-        heritage: {{.Release.Service | quote }}
-        release: {{.Release.Name | quote }}
-        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
       containers:

--- a/helm-chart/renku/templates/post-install-job-keycloak.yaml
+++ b/helm-chart/renku/templates/post-install-job-keycloak.yaml
@@ -4,9 +4,9 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-post-install-keycloak"
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "renku.chart" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "20"
@@ -16,9 +16,9 @@ spec:
     metadata:
       name: "{{.Release.Name}}-post-install-keycloak"
       labels:
-        heritage: {{.Release.Service | quote }}
-        release: {{.Release.Name | quote }}
-        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
       containers:

--- a/helm-chart/renku/templates/post-install-job-postgres.yaml
+++ b/helm-chart/renku/templates/post-install-job-postgres.yaml
@@ -3,9 +3,9 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-post-install-postgres"
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "renku.chart" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
@@ -15,9 +15,9 @@ spec:
     metadata:
       name: "{{.Release.Name}}-post-install-postgres"
       labels:
-        heritage: {{.Release.Service | quote }}
-        release: {{.Release.Name | quote }}
-        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
/deploy 
This also fixes the problem where a chart name containing a "+" sign (e.g. when deploying a version containing build metadata) would fail to create the post-install jobs.
