### PR TITLE
(feat) Build and push container images

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -1,0 +1,102 @@
+name: Build and publish container images
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - acceptance-tests/**
+      - certificates/**
+      - scripts/init-realm/**
+  workflow_dispatch:
+
+jobs:
+  acceptance-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./acceptance-tests/
+          push: true
+          tags: renku/tests:latest
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: job,commit
+          custom_payload: |
+            {
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_JOB} commit ${process.env.AS_COMMIT}: ${{ job.status }}.`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()
+  certificates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./certificates/
+          push: true
+          tags: renku/certificates:latest
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: job,commit
+          custom_payload: |
+            {
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_JOB} commit ${process.env.AS_COMMIT}: ${{ job.status }}.`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()
+  init-realm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./scripts/init-realm/
+          push: true
+          tags: renku/init-realm:latest
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: job,commit
+          custom_payload: |
+            {
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_JOB} commit ${process.env.AS_COMMIT}: ${{ job.status }}.`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()


### PR DESCRIPTION
Create CD job to build and publish the container images for acceptance-tests, init-realm and certificates when they change any time a commit is merged in the master branch.

This CD job allows to deploy the Renku chart directly from this Git repository (e.g. skipping the chart repository) for those instances that want to deploy the tip of the master branch of Renku (e.g. dev.renku.ch).

Part of swissdatasciencecenter/terraform-renku#139.
