### PR TITLE
(feat) Publish Helm chart on all merges to master.

### DIFF
--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -1,0 +1,56 @@
+name: Publish all merges to master
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - helm-chart/**
+      - scripts/**
+      - acceptance-tests/**
+      - .github/**
+  workflow_dispatch:
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: prepatch
+      - id: set-version
+        run: echo "publish_version=${{ steps.bump-semver.outputs.new_version }}.$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.3.0
+        env:
+          CHART_DIR: helm-chart/
+          CHART_TAG: "--tag ${{env.publish_version}}"
+          CHART_NAME: renku
+          GIT_USER: renku-bot
+          GIT_EMAIL: renku@datascience.ch
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: job,ref
+          custom_payload: |
+            {
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_JOB} version ${{ env.publish_version }}: ${{ job.status }}.`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ env.publish_version }}
+          message: "${{ env.publish_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
When a PR is merged to the master branch a chart is also published, the version is set to `x.y.z+1-n+1` where `x.y.z` is the latest stable release of Renku and `n` is the latest version created by the job introduced in this PR. If an earlier pre-release version does not exists then it is set to 0.

The workflow also pushes the tag of the just created pre-release, this is necessary for the following workflows to assign the correct, increasing, pre-release number.

The new workflow duplicates somewhat `publish-deploy-staging`, however, at a later time I will take care of consolidating the two, when Staging will also be deployed through Flux.

This supercede #2376.
