### PR TITLE
fix: pip upgrade to fix the problem of CLI version mismatch

### DIFF
--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -25,15 +25,16 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
     wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
     chmod 0755 /usr/local/bin/mc
 
-RUN python3 -m pip install \
-    'papermill==2.1.3' \
-    'requests>=2.20.0' \
-    'jupyterhub==1.1.0' \
-    'nbresuse==0.3.3' \
-    'jupyterlab-git==0.20.0' \
-    'pipx>=0.15.0.0' \
-    'pandas==1.3.0' \
-    'seaborn==0.11.1'
+RUN python3 -m pip install --upgrade 'pip==21.3.1' && \
+    python3 -m pip install \
+      'papermill==2.1.3' \
+      'requests>=2.20.0' \
+      'jupyterhub==1.1.0' \
+      'nbresuse==0.3.3' \
+      'jupyterlab-git==0.20.0' \
+      'pipx>=0.15.0.0' \
+      'pandas==1.3.0' \
+      'seaborn==0.11.1'
 
 ENV DOCKER="1"
 COPY . /tests

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -25,6 +25,7 @@ if [ ! -z $RENKU_TEST_S3_HOST ] && [ $TESTS_RC != 0 ]; then
   cp target/*.png test-artifacts
   cp target/*.log test-artifacts
   rm -rf target/20*/.renku/cache
+  rm -rf target/20*/.gitattributes
   cp -r target/20* test-artifacts
   tar czvf tests-artifacts.tgz test-artifacts
   mv tests-artifacts.tgz ${RENKU_TEST_S3_FILENAME}.tgz

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
@@ -60,7 +60,7 @@ object CliVersion {
     private val validator = raw"\d+\.\d+\.\d+(?:\.post\d+)?\.dev\d+\+g([0-9a-f]{5,40})"
 
     def get(value: String): Option[CliVersion] =
-      Option.when(value.trim matches validator)(new NonReleasedVersion(value.trim.take(24)))
+      Option.when(value.trim matches validator)(new NonReleasedVersion(value.trim))
   }
 }
 


### PR DESCRIPTION
This PR fixes problem of CLI version mismatch that occurs between the core and local to the tests version of Renku.

/deploy