### PR TITLE
chore: do not limit acceptance test pods

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -82,7 +82,7 @@ jobs:
           RENKU_ANONYMOUS_SESSIONS: true
           RENKU_RELEASE: ci-renku-${{ github.event.number }}
           RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
-          RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+          RENKU_VALUES: ${{ secrets.CI_VALUES_FOR_TESTING_RESOURCE_SETTINGS }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
           RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -82,7 +82,7 @@ jobs:
           RENKU_ANONYMOUS_SESSIONS: true
           RENKU_RELEASE: ci-renku-${{ github.event.number }}
           RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
-          RENKU_VALUES: ${{ secrets.CI_VALUES_FOR_TESTING_RESOURCE_SETTINGS }}
+          RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
           RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -652,7 +652,7 @@ tests:
   resources:
     requests:
       memory: "3G"
-      cpu: "1500m"
+      cpu: "500m"
       ephemeral-storage: "3G"
   ## User account for running `helm test`
   #parameters:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -654,10 +654,6 @@ tests:
       memory: "3G"
       cpu: "1500m"
       ephemeral-storage: "3G"
-    limits:
-      memory: "3G"
-      cpu: "1500m"
-      ephemeral-storage: "3G"
   ## User account for running `helm test`
   #parameters:
   #  email: bwayne@example.com


### PR DESCRIPTION
Limits on acceptance test pods seem to introduce throttling and/or container restarts. Remove the limits to see if this might resolve some of the test failures. 

This PR is testing the resource request value changes proposed here: https://github.com/SwissDataScienceCenter/ops-dev.renku.ch/pull/194

/deploy