### PR TITLE
chore(test): add new test and cleanup actions

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.3.2
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.0
         env:
           CHART_DIR: helm-chart/
           CHART_NAME: renku

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.1
         env:
           CHART_DIR: helm-chart/
           CHART_NAME: renku

--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -28,7 +28,7 @@ jobs:
           level: prerelease
       - id: set-version
         run: echo "publish_version=${{ steps.bump-semver.outputs.new_version }}.$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.3.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.0
         env:
           CHART_DIR: helm-chart/
           CHART_TAG: "--tag ${{env.publish_version}}"

--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -28,7 +28,7 @@ jobs:
           level: prerelease
       - id: set-version
         run: echo "publish_version=${{ steps.bump-semver.outputs.new_version }}.$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.4.1
         env:
           CHART_DIR: helm-chart/
           CHART_TAG: "--tag ${{env.publish_version}}"

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -55,10 +55,11 @@ jobs:
       renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
+      persist: ${{ steps.deploy-comment.outputs.persist }}
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.3.2
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@test-and-cleanup-action
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.4.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.4.1
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.4.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.4.1
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -116,7 +116,7 @@ jobs:
     if: github.event.action != 'closed'
     needs: [check-deploy, deploy-pr]
     steps:
-    - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.4.0
+    - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.4.1
       with:
         renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         renku-release: ci-renku-${{ github.event.number }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: renku teardown
-      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.4.0
+      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.4.1
       env:
         HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -123,6 +123,7 @@ jobs:
         gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
         persist: "${{ needs.check-deploy.outputs.persist }}"
         ci-renku-values: ${{ secrets.CI_RENKU_VALUES }}
+        test-timeout-mins: "80"
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-20.04

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -115,7 +115,6 @@ jobs:
     if: github.event.action != 'closed'
     needs: [check-deploy, deploy-pr]
     steps:
-      - uses: actions/checkout@v2
       - name: Test the PR
         if: "needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'"
         env:
@@ -123,8 +122,8 @@ jobs:
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           RENKU_RELEASE: ci-renku-${{ github.event.number }}
         run: |
-          echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-          helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
+          echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config && chmod 400 renkubot-kube.config
+          helm --kubeconfig renkubot-kube.config test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
       - name: Download artifact for packaging on failure
         if: failure()
         uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.3.2

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -134,3 +134,4 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         MAX_AGE_SECONDS: 0
+        DELETE_NAMESPACE: "true"

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@test-and-cleanup-action
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.4.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.3.2
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.4.0
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -116,7 +116,7 @@ jobs:
     if: github.event.action != 'closed'
     needs: [check-deploy, deploy-pr]
     steps:
-    - uses: SwissDataScienceCenter/renku-actions/test-renku@test-and-cleanup-action
+    - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.4.0
       with:
         renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         renku-release: ci-renku-${{ github.event.number }}
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: renku teardown
-      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@test-and-cleanup-action
+      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.4.0
       env:
         HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -111,40 +111,25 @@ jobs:
             You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
 
   test-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.action != 'closed'
     needs: [check-deploy, deploy-pr]
     steps:
-      - name: Test the PR
-        if: "needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'"
-        env:
-          KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
-          RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-          RENKU_RELEASE: ci-renku-${{ github.event.number }}
-        run: |
-          echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config && chmod 400 renkubot-kube.config
-          helm --kubeconfig renkubot-kube.config test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
-      - name: Download artifact for packaging on failure
-        if: failure()
-        uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.3.2
-        env:
-          RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
-          TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
-      - name: Upload screenshots on failure
-        if: failure()
-        uses: actions/upload-artifact@v1
-        with:
-          name: acceptance-test-artifacts
-          path: ${{ github.workspace }}/test-artifacts/
+    - uses: SwissDataScienceCenter/renku-actions/test-renku@test-and-cleanup-action
+      with:
+        renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        renku-release: ci-renku-${{ github.event.number }}
+        gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
+        persist: "${{ needs.check-deploy.outputs.persist }}"
+        ci-renku-values: ${{ secrets.CI_RENKU_VALUES }}
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/teardown-renku@v0.3.2
-        env:
-          GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
-          KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-          RENKU_RELEASE: ci-renku-${{ github.event.number }}
-          RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+    - name: renku teardown
+      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@test-and-cleanup-action
+      env:
+        HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
+        GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        MAX_AGE_SECONDS: 0

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -26,6 +26,7 @@ if [ ! -z $RENKU_TEST_S3_HOST ]; then
   MIRROR_JOB_ID=$(echo $!)
 fi
 
+
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$(echo $!)

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -30,6 +30,7 @@ fi
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$?
+TESTS_RC=1
 echo "Tests completed with exit code $TESTS_RC"
 
 # cleanup the background mirroring job

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -7,12 +7,10 @@ else
 fi
 
 cd /tests
-echo "Target: " $TARGET
-sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
+mkdir -p target
 
-TESTS_RC=$?
 
-if [ ! -z $RENKU_TEST_S3_HOST ] && [ $TESTS_RC != 0 ]; then
+if [ ! -z $RENKU_TEST_S3_HOST ]; then
   if [ -z $RENKU_TEST_S3_ACCESS_KEY ] || [ -z $RENKU_TEST_S3_SECRET_KEY ] || \
   [ -z $RENKU_TEST_S3_BUCKET ] || [ -z $RENKU_TEST_S3_FILENAME ]; then
     echo "[ERROR] To upload the tests to a S3 bucket then\
@@ -21,16 +19,24 @@ if [ ! -z $RENKU_TEST_S3_HOST ] && [ $TESTS_RC != 0 ]; then
     must all be specified as environment variables. Aborting."
     exit 1
   fi
-  mkdir test-artifacts
-  cp target/*.png test-artifacts
-  cp target/*.log test-artifacts
-  rm -rf target/20*/.renku/cache
-  rm -rf target/20*/.gitattributes
-  cp -r target/20* test-artifacts
-  tar czvf tests-artifacts.tgz test-artifacts
-  mv tests-artifacts.tgz ${RENKU_TEST_S3_FILENAME}.tgz
+  # mirror the test results folder in the background
+  # the sleep command ensures the tests have started before mirroring starts
+  sleep 60 && MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc mirror --overwrite --remove --watch --exclude "scala*/*" --exclude "streams/*" --exclude "task-temp-directory/*" --exclude "global-logging/*"  --exclude "target/20*/.gitattributes" --exclude "target/20*/.renku/cache" target bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/ 2> /dev/null 1> /dev/null &
+  MIRROR_JOB_ID=$(echo $!)
+fi
 
-  export MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}"
-  mc cp ${RENKU_TEST_S3_FILENAME}.tgz bucket/${RENKU_TEST_S3_BUCKET}
-  exit $TESTS_RC
+echo "Target: " $TARGET
+sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
+TESTS_RC=$?
+
+# cleanup the background mirroring job
+if [ ! -z $MIRROR_JOB_ID ]
+then
+  kill -15 $MIRROR_JOB_ID
+fi
+
+# if tests pass then remove the bucket
+if [ $TESTS_RC -eq 0 ]
+then
+  MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc rm --recursive --force bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/
 fi

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -43,4 +43,4 @@ then
   MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc rm --recursive --force bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/
 fi
 
-exit TESTS_RC
+exit $TESTS_RC

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -27,17 +27,19 @@ fi
 
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
-TESTS_RC=$?
+TESTS_RC=$(echo $!)
 
 # cleanup the background mirroring job
 if [ ! -z $MIRROR_JOB_ID ]
 then
+  echo "Terminating test artifacts background mirroring job."
   kill -15 $MIRROR_JOB_ID
 fi
 
 # if tests pass then remove the bucket
 if [ $TESTS_RC -eq 0 ]
 then
+  echo "The tests PASSED with return code $TESTS_RC, removing the test artifacts at $RENKU_TEST_S3_BUCKET/$RENKU_TEST_S3_FILENAME."
   MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc rm --recursive --force bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/
 fi
 

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/bash
 
 if [ "$#" -lt "1" ]; then
   TARGET="test"
@@ -28,6 +28,7 @@ fi
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$(echo $!)
+echo "Tests completed with exit code $TESTS_RC"
 
 # cleanup the background mirroring job
 if [ ! -z $MIRROR_JOB_ID ]

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -29,7 +29,7 @@ fi
 
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
-TESTS_RC=$(echo $!)
+TESTS_RC=$?
 echo "Tests completed with exit code $TESTS_RC"
 
 # cleanup the background mirroring job

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -29,7 +29,6 @@ fi
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$?
-TESTS_RC=1
 echo "Tests completed with exit code $TESTS_RC"
 
 # cleanup the background mirroring job

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -26,7 +26,6 @@ if [ ! -z $RENKU_TEST_S3_HOST ]; then
   MIRROR_JOB_ID=$(echo $!)
 fi
 
-
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$(echo $!)

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -40,3 +40,5 @@ if [ $TESTS_RC -eq 0 ]
 then
   MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc rm --recursive --force bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/
 fi
+
+exit TESTS_RC

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [ "$#" -lt "1" ]; then
   TARGET="test"

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -21,6 +21,7 @@ if [ ! -z $RENKU_TEST_S3_HOST ]; then
   fi
   # mirror the test results folder in the background
   # the sleep command ensures the tests have started before mirroring starts
+  echo "Will upload test artefacts from target to https://XXXX:XXXX@${RENKU_TEST_S3_HOST} bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}"
   sleep 60 && MC_HOST_bucket="https://${RENKU_TEST_S3_ACCESS_KEY}:${RENKU_TEST_S3_SECRET_KEY}@${RENKU_TEST_S3_HOST}" mc mirror --overwrite --remove --watch --exclude "scala*/*" --exclude "streams/*" --exclude "task-temp-directory/*" --exclude "global-logging/*"  --exclude "target/20*/.gitattributes" --exclude "target/20*/.renku/cache" target bucket/${RENKU_TEST_S3_BUCKET}/${RENKU_TEST_S3_FILENAME}/ 2> /dev/null 1> /dev/null &
   MIRROR_JOB_ID=$(echo $!)
 fi

--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -26,7 +26,6 @@ if [ ! -z $RENKU_TEST_S3_HOST ]; then
   MIRROR_JOB_ID=$(echo $!)
 fi
 
-
 echo "Target: " $TARGET
 sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
 TESTS_RC=$?


### PR DESCRIPTION
/deploy #persist

Implements the new test and cleanup actions from https://github.com/SwissDataScienceCenter/renku-actions/pull/16

And also adds continuous mirroring of the acceptance tests artefacts to S3. This way even if the tests timeout or crash or whatever there will always be some artifacts that can be uploaded/added to the github workflow.

In the case when the test artefacts are added to S3 only once the tests are complete there were issues because if the tests time out or crash in some weird way then the artefacts are not uploaded and cannot be found on the github workflow. This should avoid a lot of those scenarios.
