### PR TITLE
docs: remove helm2 init command

### DIFF
--- a/docs/how-to-guides/admin/deploying-renku.rst
+++ b/docs/how-to-guides/admin/deploying-renku.rst
@@ -139,7 +139,6 @@ Once all the pieces are in place, you can deploy Renku with the following comman
 
 .. code-block:: console
 
-    $ helm init
     $ helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
     $ helm upgrade --install renku renku/renku \
      --namespace renku \


### PR DESCRIPTION
Helm init is not used anymore in Helm 3. Helm 2 is no longer supported. Therefore the Helm init command should be removed from the documentation.