### PR TITLE
fix(ci): undo recent changes to tag/release numbering

### DIFF
--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -17,13 +17,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - id: get-latest-release-tag
-        uses: pozetroninc/github-action-get-latest-release@v0.6.0
-        with:
-          repository: ${{ github.repository }}
-          excludes: prerelease, draft
+      - uses: WyriHaximus/github-action-get-previous-tag@v1
+        id: get-latest-tag
       - id: get-stable-version
-        run: echo "stable_version=$(echo ${{ steps.get-latest-release-tag.outputs.release }} | cut -d'.' -f1-3)" >> $GITHUB_ENV
+        run: echo "stable_version=$(echo ${{ steps.get-latest-tag.outputs.tag }} | cut -d'.' -f1-3)" >> $GITHUB_ENV
       - uses: actions-ecosystem/action-bump-semver@v1
         id: bump-semver
         with:


### PR DESCRIPTION
This reverts commit 85618992425258f1d0b1dfb96a9da0a385b91ae3.

Undoing it because after this changes the first digit of the pre-release numbering isn't increased anymore. We have to otherwise fix the problems with wrong tags being used as basis for figuring out the right tag after tagging a non-renku chart from this repo.
<img width="758" alt="image" src="https://user-images.githubusercontent.com/13014091/152768345-9989a90e-1ad1-4a28-8b95-51606d2f6b7f.png">
