### PR TITLE
chore(docs): update CLI and base image upgrade instructions

### DIFF
--- a/docs/how-to-guides/upgrading-renku.rst
+++ b/docs/how-to-guides/upgrading-renku.rst
@@ -18,8 +18,8 @@ needing to change any settings.
 
 .. _renku_cli_upgrade:
 
-Upgrading your image to use the latest ``renku`` CLI version
-------------------------------------------------------------
+Upgrading the renku CLI version used in your sessions
+-----------------------------------------------------
 
 .. note::
 
@@ -28,60 +28,28 @@ Upgrading your image to use the latest ``renku`` CLI version
   for upgrading your local machine's version of ``renku``.
 
 When we release a new version of the ``renku`` CLI, you do have to make some
-(minimal) changes to the ``Dockerfile`` in your project to ensure that the
-Session on RenkuLab will use the image with the correct version.
+(minimal) changes to the ``Dockerfile`` in your project to use it in your interactive
+sessions on RenkuLab.
 
 The version of the ``renku`` CLI is defined in the base image specified in the
-``FROM`` line (usually line 1) of the ``Dockerfile`` in your repo.
+``ARG RENKU_VERSION`` line of the ``Dockerfile`` in your project repo (if you 
+don't see this line in your ``Dockerfile`` your project was made using an older template).
+All you need to do to have a different version of the Renku CLI installed is modify the version 
+on that line and push the change. Once that is done, the image will automatically
+be built as usual and include the new version. 
 
-1. Replace this line with the latest available image for the "flavor" you're using,
-   which you can find by:
+.. _renku_base_image_upgrade:
 
-* checking the `renkulab-docker repo README.md <https://github.com/SwissDataScienceCenter/renkulab-docker/blob/master/README.md>`_
-  for the naming conventions of the "flavor" of image you're updating (e.g. if you're using
-  the "minimal python project", you will look in the ``py`` section)
-* visiting the dockerhub page linked in the naming conventions section in the above ``README``
-* choosing the latest available tagged image
+Upgrading the base image used for interactive sessions
+------------------------------------------------------
 
-Note that the version of the ``renku`` CLI is defined in the image name. For example,
-``renku/renkulab-py:3.7-renku0.10.4-0.6.3`` has CLI version ``0.10.4``. Please choose
-an image with the renku version specified (e.g. ``-renku0.10.4-`` and not ``-renku-``),
-unless you absolutely need the latest development version of ``renku``, since it makes
-debugging and reproducibility much simpler.
-
-2. Push your changes (either from the GitLab editor, or in a running Session), 
-   and start up a new Session from the latest commit to use this new image.
-
-3. When you start to run ``renku`` commands, you might be asked to call ``renku migrate``.
-   This command ensures that the metadata in your project is updated.
-
-Test drive
-^^^^^^^^^^
-
-If you just want to try out the latest version of ``renku`` without building a new
-image yet, you can follow the ``pipx`` installation instructions from
-:ref:`upgrading your local installation <upgrading_local>`. Installing in this way,
-like any other terminal install, will not hold through the next time you launch.
-
-Keep in mind that your project's metadata will be upgraded when you start running
-the new version ``renku`` commands - don't push these changes if you want to revert
-back to an older version.
-
-You should follow the steps in the previous section to swap out the base image
-once you're satisfied with latest ``renku``.
-
-Only updating the renku CLI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you want to use the latest version of ``renku`` but for some reason cannot rebuild
-from scratch the rest of the docker image layers for your project (e.g. dependency issues),
-you can add the ``pipx`` installation from
-:ref:`upgrading your local installation <upgrading_local>` to the end of your ``Dockerfile``;
-e.g. ``RUN pipx install renku==<VERSION> --force``.
-
-When the gitlab CI builds an image using the ``Dockerfile`` in your project, it
-re-uses layers of installs that haven't changed between builds, which speeds up
-the build process. But, when you swap out the base image (as is recommended), all
-of the subsequent layers might need to rebuild.
-
-We still recommend swapping out the base image when possible.
+In addition to updating the CLI version, you may also want to update the base image 
+used for sessions in your project. We periodically release new base images with 
+uprades to underlying libraries and packages. The base image is specified 
+on the ``ARG RENKU_BASE_IMAGE`` line in your ``Dockerfile``, for example it might
+read ``renku/renkulab-py:3.9-0.11.0``. This means that it is a python-based image 
+using Python 3.9 and image release ``0.11.0``. To change it, simply modify the base image
+referenced on that line. For a list of base images see
+`current images <https://github.com/SwissDataScienceCenter/renkulab-docker#current-images>`_.
+Changing the base image does not automatically mean that the Renku CLI version will 
+also change - see the section above for details on how to update it. 


### PR DESCRIPTION
Updates instructions for updating the Renku CLI and base images. 

closes #2441 