### PR TITLE
fix: free-text DS search to wait for UI cache to catch up

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/FreeTextDatasetSearchSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/FreeTextDatasetSearchSpec.scala
@@ -49,9 +49,11 @@ class FreeTextDatasetSearchSpec
     `search for dataset with phrase`(commonWord, orderBy = Title)
 
     Then("the expected datasets should be shown")
-    val expectedDatasets  = List(dataset1Name, dataset2Name).sorted.map(_.toString).reverse
-    val foundDatasetLinks = DatasetsPage.searchResultLinks.map(_.getText)
-    foundDatasetLinks.filter(expectedDatasets.contains) shouldBe expectedDatasets
+    val expectedDatasets = List(dataset1Name, dataset2Name).sorted.map(_.toString).reverse
+    `try few times before giving up` { _ =>
+      val foundDatasetLinks = DatasetsPage.searchResultLinks.map(_.getText)
+      foundDatasetLinks.filter(expectedDatasets.contains) shouldBe expectedDatasets
+    }
 
     `log out of Renku`
   }


### PR DESCRIPTION
It happens sometimes that our tests fail as they cannot find the expected values on the UI. In some cases it's might be caused by the UI cache holding stale values. A simple retry was proven to work in other places in the past.

/deploy