### PR TITLE
tests: fix code for finding the hide advanced settings link

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
@@ -331,7 +331,7 @@ class ProjectPage(val projectSlug: String, val namespace: String)
     }
 
     def maybeButtonHideBranch(implicit webDriver: WebDriver): Option[WebElement] = eventually {
-      findAll(cssSelector("div.mb-3 > button")).find(_.text.startsWith("Hide branch"))
+      findAll(cssSelector("div.mb-3 > button")).find(_.text.startsWith("Hide advanced settings"))
     }
 
     private def maybeImageReadyBadge(implicit webDriver: WebDriver): Option[WebBrowser.Element] =


### PR DESCRIPTION
The text for the "hide advanced settings" link in sessions changed (was previously "hide branches").