### PR TITLE
chore: notebooks 1.5.0, UI 2.1.0 release

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/ProjectPage.scala
@@ -331,7 +331,7 @@ class ProjectPage(val projectSlug: String, val namespace: String)
     }
 
     def maybeButtonHideBranch(implicit webDriver: WebDriver): Option[WebElement] = eventually {
-      findAll(cssSelector("div.mb-3 > button")).find(_.text.startsWith("Hide branch"))
+      findAll(cssSelector("div.mb-3 > button")).find(_.text.startsWith("Hide advanced settings"))
     }
 
     private def maybeImageReadyBadge(implicit webDriver: WebDriver): Option[WebBrowser.Element] =

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -6,15 +6,15 @@ dependencies:
 - name: renku-ui
   alias: ui
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 2.0.2
+  version: 2.1.0
 - name: renku-ui-server
   alias: uiserver
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 2.0.2
+  version: 2.1.0
 - name: renku-notebooks
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 1.4.1
+  version: 1.5.0
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"


### PR DESCRIPTION
So chartpress has a bug where it labels the image wrong when you update a branch in a PR.

To avoid this bug I had to reopen the PR so that it does not need to be updated against master.

/deploy #persist