### PR TITLE
fix: anonymous and unprivileged env specs more reliable

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/AnonymousEnvironmentSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/AnonymousEnvironmentSpec.scala
@@ -21,10 +21,17 @@ package ch.renku.acceptancetests
 import ch.renku.acceptancetests.tooling.{AcceptanceSpec, AnonEnv}
 import ch.renku.acceptancetests.workflows._
 
-class AnonymousEnvironmentSpec extends AcceptanceSpec with AnonEnv with Login {
+class AnonymousEnvironmentSpec extends AcceptanceSpec with Project with AnonEnv with Login {
 
   Scenario("User can launch session") {
-    `launch anonymous session`(anonEnvConfig)
-      .map(_ => `stop session`(anonEnvConfig.projectId))
+
+    `log in to Renku`
+
+    `create, continue or open a project`
+
+    `log out of Renku`
+
+    `launch anonymous session`(projectPage, projectDetails)
+      .map(_ => `stop session`(projectPage))
   }
 }

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/UnprivilegedEnvironmentSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/UnprivilegedEnvironmentSpec.scala
@@ -25,8 +25,7 @@ class UnprivilegedEnvironmentSpec extends AcceptanceSpec with AnonEnv with Login
 
   Scenario("User can launch unprivileged session") {
     `log in to Renku`
-    `launch unprivileged session`
-    `stop session`(anonEnvConfig.projectId)
+    `launch unprivileged session`.foreach(projectPage => `stop session`(projectPage))
     `log out of Renku`
   }
 }


### PR DESCRIPTION
This change aims to make the specs verifying Anonymous and Unprivileged environments to be more reliable and not to fail when the configured project does not exist on the deployment where the tests are run.

/deploy