### PR TITLE
chore:  prep release 0.12.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
 .. _changelog:
 
+0.12.6
+------
+
+Bugfix release fixing an issue where image availability was incorrectly reported if a pinned image 
+was used for interactive sessions. 
+
+- `renku-notebooks 1.6.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.6.0>`_
+- `renku-ui 2.1.2 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/2.1.2>`_
+
 0.12.5
 ------
 

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.12.5
+version: 0.12.6


### PR DESCRIPTION
Release 0.12.6 to fix the pinned image check issue. 