### PR TITLE
chore: prep release 0.12.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
 .. _changelog:
 
+0.12.8
+------
+
+Bugfix release that re-introduces a part of the Renku config that creates auto-saves when sessions crash.
+This is required only for sessions launched prior to 0.12.6 which still may exist in some deployments.
+This part of the config will be fully retired in a later subsequent release.
+
+- `renku-notebooks 1.6.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.6.2>`_
+
 0.12.7
 ------
 

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.12.7
+version: 0.12.8


### PR DESCRIPTION
Another small bugfix release. I removed the old autosave creation script a little too early. This puts it back so that existing sessions which still use the old autosave can successfully create autosaves (if the need arises). 

I have an issue to fully retire the configmap in a later notebooks release.