### PR TITLE
tests: fix tests for reactstrap update

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/TopBar.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/TopBar.scala
@@ -56,7 +56,7 @@ trait TopBar {
     }
 
     def mainNavToggler(implicit webDriver: WebDriver): WebElement = eventually {
-      find(cssSelector("nav.renku-container > button.navbar-toggler"))
+      find(cssSelector("button.navbar-toggler"))
         .getOrElse(fail("Top Right toggler button not found"))
     }
 


### PR DESCRIPTION
Changes necessary to adapt to new version of reactstrap.

This change allowed the tests to pass on https://github.com/SwissDataScienceCenter/renku-ui/pull/1766.