### PR TITLE
feat: tests to set-up user creds in GitLab if missing

### DIFF
--- a/acceptance-tests/src/test/resources/logback.xml
+++ b/acceptance-tests/src/test/resources/logback.xml
@@ -5,7 +5,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>[%level] %message%n</pattern>
+            <pattern>%d{HH:mm:ss} [%level] %message%n</pattern>
         </encoder>
     </appender>
 

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/GitLabUserProfilePage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/GitLabUserProfilePage.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.renku.acceptancetests.pages
+import org.openqa.selenium.{WebDriver, WebElement}
+import org.scalatestplus.selenium.WebBrowser.{cssSelector, find}
+
+object GitLabUserProfilePage extends GitLabPage(path = "/-/profile", title = "Edit Profile · User Settings · GitLab") {
+
+  override def pageReadyElement(implicit webDriver: WebDriver): Option[WebElement] = statusInput
+
+  private def statusInput(implicit webDriver: WebDriver) =
+    find(cssSelector(s"input#js-status-message-field"))
+
+  def passwordsMenuItem(implicit webDriver: WebDriver): WebElement =
+    find(cssSelector(s"a[href='/gitlab/-/profile/password/edit']"))
+      .getOrElse(fail("Menu 'Passwords' not found"))
+
+  object Password {
+
+    def newPasswordInput(implicit webDriver: WebDriver): WebElement =
+      find(cssSelector(s"input#user_new_password"))
+        .getOrElse(fail("'New password' input not found"))
+
+    def passwordConfirmationInput(implicit webDriver: WebDriver): WebElement =
+      find(cssSelector(s"input#user_password_confirmation"))
+        .getOrElse(fail("'Password confirmation' input not found"))
+
+    def saveButton(implicit webDriver: WebDriver): WebElement =
+      find(cssSelector(s"input[type=submit]"))
+        .getOrElse(fail("'Password confirmation' input not found"))
+  }
+}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/GitLabWelcomePage.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/GitLabWelcomePage.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.renku.acceptancetests.pages
+import ch.renku.acceptancetests.model.users.UserCredentials
+import org.openqa.selenium.interactions.Actions
+import org.openqa.selenium.{WebDriver, WebElement}
+import org.scalatestplus.selenium.WebBrowser.{cssSelector, find}
+
+object GitLabWelcomePage extends GitLabPage(path = "", title = "Projects · Dashboard · GitLab") {
+
+  override def pageReadyElement(implicit webDriver: WebDriver): Option[WebElement] = menuDropDown
+
+  def menuDropDown(implicit webDriver: WebDriver) = find(cssSelector(s"a[href='#']"))
+
+  def `click on the User Settings dropdown`(implicit userCredentials: UserCredentials, webDriver: WebDriver): Unit =
+    new Actions(webDriver)
+      .moveToElement(userSettingsDropDown)
+      .click()
+      .build()
+      .perform();
+
+  private def userSettingsDropDown(implicit userCredentials: UserCredentials, webDriver: WebDriver) =
+    find(cssSelector(s"a[href='/gitlab/${userCredentials.username}']"))
+      .getOrElse(fail("Top right 'User Settings' button not found"))
+
+  def editProfileMenuOption(implicit webDriver: WebDriver) =
+    find(cssSelector(s"a[href='/gitlab/-/profile']"))
+      .getOrElse(fail("'Edit profile' menu option not found"))
+}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/Page.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/Page.scala
@@ -37,8 +37,6 @@ abstract class Page[Url <: BaseUrl](val path: String, val title: String)
     with Eventually
     with AcceptanceSpecPatience {
 
-  require(path.trim.nonEmpty, s"$getClass cannot have empty path")
-  require(path startsWith "/", s"$getClass path has to start with '/'")
   require(title.trim.nonEmpty, s"$getClass cannot have empty title")
 
   def pageReadyElement(implicit webDriver: WebDriver): Option[WebElement]

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/TopBar.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/pages/TopBar.scala
@@ -39,6 +39,22 @@ trait TopBar {
       find(cssSelector("#plus-dropdown")) getOrElse fail("Top Right '+' not found")
     }
 
+    def `click on GitLab dropdown`(implicit webDriver: WebDriver): Unit = eventually {
+      val button =
+        find(cssSelector("#gitLabDropdownToggle"))
+          .getOrElse(fail("Top 'GitLab' button not found"))
+
+      new Actions(webDriver)
+        .moveToElement(button)
+        .click()
+        .build()
+        .perform();
+    }
+
+    def gitLabMenuItem(implicit webDriver: WebDriver): WebElement = eventually {
+      find(cssSelector(s"a[href*='/gitlab']")) getOrElse fail("GitLab menu item not found")
+    }
+
     def projectOption(implicit webDriver: WebDriver): WebElement = eventually {
       find(cssSelector("#navbar-project-new")) getOrElse fail("Project option not found")
     }

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/AcceptanceSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest._
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should
 import org.scalatestplus.selenium.WebBrowser
-// import org.openqa.selenium
 
 trait AcceptanceSpec
     extends AnyFeatureSpec
@@ -44,7 +43,6 @@ trait AcceptanceSpec
   protected implicit val browser: AcceptanceSpec = this
 
   implicit lazy val webDriver: WebDriver = startWebDriver
-  // webDriver.manage().window().setSize(new selenium.Dimension(1920, 1600))
 
   protected implicit val docsScreenshots: DocsScreenshots = DocsScreenshots(this, webDriver)
 

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/GitLabCredentials.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/GitLabCredentials.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.renku.acceptancetests.workflows
+
+import ch.renku.acceptancetests.pages.{GitLabUserProfilePage, GitLabWelcomePage, WelcomePage}
+import ch.renku.acceptancetests.tooling.AcceptanceSpec
+
+import scala.concurrent.duration._
+
+trait GitLabCredentials {
+  self: Login with AcceptanceSpec =>
+
+  def `verify user has GitLab credentials`: Unit =
+    userCredentials.maybeGitLabAccessToken match {
+      case Some(_) => ()
+      case _ =>
+        if (`check user has credentials`) ()
+        else `add user credentials`
+    }
+
+  private def `add user credentials` = {
+    verify browserSwitchedTo WelcomePage
+
+    When("user clicks the GitLab button")
+    WelcomePage.TopBar.`click on GitLab dropdown`
+    And("the GitLab option")
+    click on WelcomePage.TopBar.gitLabMenuItem
+    sleep(1 second)
+
+    Then("the user should be on the 'GitLab Welcome' page")
+    verify browserSwitchedTo GitLabWelcomePage
+
+    Then("the user goes to the 'Edit profile' page")
+    GitLabWelcomePage.`click on the User Settings dropdown`
+    click on GitLabWelcomePage.editProfileMenuOption sleep (2 seconds)
+
+    verify browserAt GitLabUserProfilePage
+
+    And("selects the 'Password' menu item")
+    click on GitLabUserProfilePage.passwordsMenuItem
+
+    And("enters password into the 'New password' field")
+    GitLabUserProfilePage.Password.newPasswordInput enterValue userCredentials.password
+    And("into the 'Password confirmation' field")
+    GitLabUserProfilePage.Password.passwordConfirmationInput enterValue userCredentials.password
+    And("saves")
+    click on GitLabUserProfilePage.Password.saveButton
+    sleep(2 seconds)
+
+    Then("the user should have GitLab password set")
+    if (!`check user has credentials`) fail("Setting password for the user in GitLab did not work")
+
+    webDriver closeTab GitLabWelcomePage
+  }
+}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Login.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Login.scala
@@ -26,7 +26,7 @@ import ch.renku.acceptancetests.workflows.LoginType._
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
-trait Login {
+trait Login extends GitLabCredentials {
   self: AcceptanceSpec =>
 
   private var maybeLoginType: Option[LoginType] = None
@@ -53,6 +53,10 @@ trait Login {
 
     Then("they should get into the Welcome page")
     verify browserAt WelcomePage
+
+    `verify user has GitLab credentials`
+
+    verify browserSwitchedTo WelcomePage
   }
 
   def `log out of Renku`: Unit = {


### PR DESCRIPTION
This PR adds a special flow to the acceptance tests which sets up GitLab password for the user the tests use for logging in. The main aim of the change is to simplify running tests with a test user that was registered with the standard registration process and so it's lacking GitLab password. The password is used by the tests to obtain an OAuth token that might be used for accessing GitLab API and by the tests' clean-up procedures. The new flow is triggered automatically and it's skipped when an OAuth token is injected into the tests or the tests can already fetch it (which means the GitLab password is already set).

/deploy