### PR TITLE
feat: Add network policy to restrict access to Postgres.

### DIFF
--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-ingress
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- if .Values.keycloak.enabled }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        {{- end }}
+        {{- if .Values.gitlab.enabled }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gitlab
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              app: event-log
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - podSelector:
+            matchLabels:
+              app: token-repository
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - podSelector:
+            matchLabels:
+              app: post-install-postgres
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/helm-chart/renku/templates/post-install-job-postgres.yaml
+++ b/helm-chart/renku/templates/post-install-job-postgres.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       name: "{{.Release.Name}}-post-install-postgres"
       labels:
+        app: post-install-postgres
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
         chart: {{ template "renku.chart" . }}


### PR DESCRIPTION
The Postgres database needs to be accessed only by Keycloak and Gitlab
in the same namespace. All other connections are forbidden.

/deploy

Close #1435 