### PR TITLE
chore: prep 0.12.16 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,21 @@
 .. _changelog:
 
+0.12.16
+-------
+
+This release fixes bugs in the user session service.
+
+Bug fixes
+~~~~~~~~~~
+
+* **User sessions**: include information about s3 bucket functionality in the server_options endpoint
+* **User sessions**: improve the parsing of messages from k8s that explain why a session is unschedulable
+
+Individual components
+~~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-notebooks 1.8.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.8.2>`_
+
 0.12.15
 -------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -209,6 +209,7 @@ unlink
 Unlink
 unmapped
 unpushed
+unschedulable
 untracked
 untracked
 url

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.12.15
+version: 0.12.16


### PR DESCRIPTION
This is a bugfix release for the notebook service.

The most important part of this is that a bug in the notebook service was making it appear as though s3 bucket mounting is not available on any deployment.

This fixes the problem.