### PR TITLE
chore: run certificates injection as non-root

### DIFF
--- a/certificates/Dockerfile
+++ b/certificates/Dockerfile
@@ -4,7 +4,8 @@ ARG ALPINE_VERSION=3.14
 FROM $FROM_IMAGE:$ALPINE_VERSION
 
 ARG CA_PKG_VERSION=20211220-r0
-RUN apk --update --no-cache add ca-certificates=${CA_PKG_VERSION} java-cacerts=1.0-r1
+RUN apk --update --no-cache add ca-certificates=${CA_PKG_VERSION} java-cacerts=1.0-r1 && \
+    adduser -u 1000 -D -H renku
 
 COPY scripts/bundle-certificates.sh /scripts/
 

--- a/helm-chart/certificates/templates/_init-container.tpl
+++ b/helm-chart/certificates/templates/_init-container.tpl
@@ -4,9 +4,9 @@
   image: "{{ .Values.global.certificates.image.repository }}:{{ .Values.global.certificates.image.tag }}"
   securityContext:
     allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - all
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
   volumeMounts:
     - name: etc-ssl-certs
       mountPath: /etc/ssl/certs/

--- a/helm-chart/certificates/templates/_volumes.tpl
+++ b/helm-chart/certificates/templates/_volumes.tpl
@@ -6,7 +6,7 @@
 {{- if $customCAsEnabled }}
 - name: custom-ca-certs
   projected:
-    defaultMode: 0440
+    defaultMode: 0444
     sources:
     {{- range $customCA := .Values.global.certificates.customCAs }}
       - secret:


### PR DESCRIPTION
It turns out that with some tweaks to the Dockerfile and permissions of mounted certificates secrets we can run certificate injection as non-root.