### PR TITLE
fix(networkpolicy) Grant post-install-gitlab job access to Postgres.

### DIFF
--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -31,6 +31,12 @@ spec:
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - podSelector:
+            matchLabels:
+              app: post-install-gitlab
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
         {{- end }}
         - podSelector:
             matchLabels:

--- a/helm-chart/renku/templates/post-install-job-gitlab.yaml
+++ b/helm-chart/renku/templates/post-install-job-gitlab.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       name: "{{.Release.Name}}-post-install-gitlab"
       labels:
+        app: post-install-gitlab
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
         chart: {{ template "renku.chart" . }}


### PR DESCRIPTION
This fix an issue introduced by #2613 resulting in the Post-install-gitlab
job not being able to access Postgres directly, which is needed.
