### PR TITLE
fix(network-policies) Fix the correct key for the Gitlab pod name.

### DIFF
--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -27,7 +27,7 @@ spec:
         {{- if .Values.gitlab.enabled }}
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: gitlab
+              app: gitlab
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}


### PR DESCRIPTION
Empty descriptions cause the CI pipeline to fail.