### PR TITLE
feat(actions) Add action to test Renku-dev

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.5.2
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.0.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.5.2
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.0.0
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -97,8 +97,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "RenkuBot"
       - name: Create comment pre deploy
-        if:
-          "steps.findcomment.outputs.comment-id == 0 &&
+        if: "steps.findcomment.outputs.comment-id == 0 &&
           needs.check-deploy.outputs.pr-contains-string == 'true'"
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -109,26 +108,26 @@ jobs:
 
   test-pr:
     runs-on: ubuntu-20.04
-    if:
-      ${{ github.event.action != 'closed' &&
+    if: ${{ github.event.action != 'closed' &&
       needs.check-deploy.outputs.pr-contains-string == 'true' &&
       needs.check-deploy.outputs.test-enabled == 'true' }}
     needs: [check-deploy, deploy-pr]
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.5.2
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.0.0
         with:
-          renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+          kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: ci-renku-${{ github.event.number }}
           gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
           persist: "${{ needs.check-deploy.outputs.persist }}"
-          ci-renku-values: ${{ secrets.CI_RENKU_VALUES }}
+          s3-results-access-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_ACCESS_KEY }}
+          s3-results-secret-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_SECRET_KEY }}
           test-timeout-mins: "80"
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-20.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.5.2
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.0.0
         env:
           HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -1,12 +1,14 @@
 name: Deploy and Test PR
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - closed
-      - edited
+  push: ### Temp: remove before merging
+    branches: ["refactor_pr_test_action"]
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
+  #     - closed
+  #     - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -56,28 +58,28 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.0.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@refactor_tests_action
         with:
           string: /deploy
-          pr_ref: ${{ github.event.number }}
+          pr_ref: ${{ github.event.pull_request.number }}
   deploy-pr:
     if: github.event.action != 'closed'
     needs: [check-deploy]
     runs-on: ubuntu-latest
     environment:
-      name: ci-renku-${{ github.event.number }}
+      name: ci-renku-${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.0.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@refactor_tests_action
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
           KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
           RENKU_ANONYMOUS_SESSIONS: true
-          RENKU_RELEASE: ci-renku-${{ github.event.number }}
+          RENKU_RELEASE: ci-renku-${{ github.event.pull_request.number }}
           RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
           RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -104,7 +106,7 @@ jobs:
           token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
+            You can access the deployment of this PR at https://ci-renku-${{ github.event.pull_request.number }}.dev.renku.ch
 
   test-pr:
     runs-on: ubuntu-20.04
@@ -113,10 +115,10 @@ jobs:
       needs.check-deploy.outputs.test-enabled == 'true' }}
     needs: [check-deploy, deploy-pr]
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.0.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@refactor_tests_action
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-          renku-release: ci-renku-${{ github.event.number }}
+          renku-release: ci-renku-${{ github.event.pull_request.number }}
           gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
           persist: "${{ needs.check-deploy.outputs.persist }}"
           s3-results-access-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_ACCESS_KEY }}
@@ -127,9 +129,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.0.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@refactor_tests_action
         env:
-          HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
+          HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.pull_request.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           MAX_AGE_SECONDS: 0

--- a/.github/workflows/renku-dev-test.yaml
+++ b/.github/workflows/renku-dev-test.yaml
@@ -1,0 +1,19 @@
+name: Test Renku-dev release
+on:
+  repository_dispatch:
+    types: [HelmRelease/renku.renku]
+jobs:
+  run-tests-staging:
+    if: ${{ github.event.client_payload.metadata.summary == 'renku-dev' &&
+      github.event.client_payload.message == 'Helm test succeeded' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.0.0
+        with:
+          kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+          renku-release: renku
+          gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
+          persist: true
+          s3-results-access-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_ACCESS_KEY }}
+          s3-results-secret-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_SECRET_KEY }}
+          test-timeout-mins: "80"


### PR DESCRIPTION
This PR is part of a work to redefine the way acceptance-tests
are piloted in production clusters: instead of having Flux running
the full test-suite, we run it from Github actions with the goal
of making the logs and the test artifacts more easily accessible and
visible.

The `pull-request-test` action is refactored to properly use the latest
version of the renku-actions.

Depends on SwissDataScienceCenter/renku-actions#32.
