### PR TITLE
chore: upgrade GitLab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,16 @@
 .. _changelog:
 
+0.14.0
+------
+
+This release updates a minor GitLab version to ``14.9.5``.
+
+Upgrading from 0.13.0
+~~~~~~~~~~~~~~~~~~~~~~
+
+BREAKING CHANGES!
+We advise admins to make a backup of their GitLab and PostgreSQL volumes before going through this upgrade.
+
 0.13.0
 -------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -398,10 +398,10 @@ gitlab:
   image:
     #   pullPolicy: IfNotPresent
     repository: gitlab/gitlab-ce
-    # Check out the gitlab docs on upgrading versions - in particular major
-    # versions - before changing the image tag.
-    #  https://docs.gitlab.com/ce/update/#upgrading-to-a-new-major-version
-    tag: 14.4.4-ce.0
+    # Check out the gitlab docs on upgrading versions before changing the image tag.
+    # https://docs.gitlab.com/ee/update/#upgrade-paths
+    # in particular major versions https://docs.gitlab.com/ce/update/#upgrading-to-a-new-major-version
+    tag: 14.9.5-ce.0
 
   ## automatically log in to gitlab
   oauth:


### PR DESCRIPTION
Prepare new release with new minor version of GitLab, another minor release will follow with ``14.10.5``.
Merging this will upgrade dev's renku GitLab.