### PR TITLE
chore: prep 0.14.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,17 @@
 .. _changelog:
 
+0.14.1
+------
+
+This release updates a minor GitLab version to ``14.10.5``.
+
+Upgrading from 0.14.1
+~~~~~~~~~~~~~~~~~~~~~~
+
+BREAKING CHANGES!
+We advise admins to make a backup of their GitLab and PostgreSQL volumes before going through this upgrade.
+
+
 0.14.0
 ------
 

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.13.0
+version: 0.14.1

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -401,7 +401,7 @@ gitlab:
     # Check out the gitlab docs on upgrading versions before changing the image tag.
     # https://docs.gitlab.com/ee/update/#upgrade-paths
     # in particular major versions https://docs.gitlab.com/ce/update/#upgrading-to-a-new-major-version
-    tag: 14.9.5-ce.0
+    tag: 14.10.5-ce.0
 
   ## automatically log in to gitlab
   oauth:


### PR DESCRIPTION
Prepare new release with new minor version of GitLab to 14.10.5.
Merging this will upgrade dev's renku GitLab.