### PR TITLE
chore(gitlab): update gitlab chart - bump container image version, change redis chart repo, bump chart version

### DIFF
--- a/chartpress-gitlab.yaml
+++ b/chartpress-gitlab.yaml
@@ -1,0 +1,25 @@
+# this file should be used as and when necessary to build the renku gitlab helm
+# chart. As renku moves to use of the standard gitlab cloud native chart, this
+# will become redundnat but for now it is still in use.
+#
+# To use this, you will need to remove the chartpress.yaml for building renku and
+# replace it with this file (it seems chartpress cannot work with a file other than
+# one called chartpress.yaml).
+#
+# To build and push a release candidate chart do this:
+# 
+# chartpress --publish --tag x.y.z-rc.Q
+#
+# To publish a chart which is not a release candidate do this, making sure that
+# your appropriate merges/commits are made before doing this:
+# 
+# chartpress --publish --tag x.y.z
+#
+
+charts:
+  - name: helm-chart/gitlab
+    imagePrefix: renku/
+    repo:
+      git: SwissDataScienceCenter/helm-charts
+      published: https://swissdatasciencecenter.github.io/helm-charts
+

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,14 +1,6 @@
-charts:
-  ## gitlab and renku chart versions are not evolving together. Uncomment
-  ## this only when explicitly building the gitlab chart and set the appropriate tag.
-  # - name: gitlab
-  #   imagePrefix: renku/
-  #   repo:
-  #     git: SwissDataScienceCenter/helm-charts
-  #     published: https://swissdatasciencecenter.github.io/helm-charts
-  #   paths:
-  #     - ./gitlab
+# this chartpress config file can be used to build and publish the renku helm chart
 
+charts:
   - name: helm-chart/renku
     resetTag: latest
     imagePrefix: renku/

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.6.1
+version: 0.7.0

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.6.0
+version: 0.6.1

--- a/helm-chart/gitlab/requirements.yaml
+++ b/helm-chart/gitlab/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis
   version: 10.7.11
-  repository: "https://charts.bitnami.com/bitnami"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami"

--- a/helm-chart/gitlab/values.yaml
+++ b/helm-chart/gitlab/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gitlab/gitlab-ce
-  tag: 12.9.5-ce.0
+  tag: 14.10.5-ce.0
   pullPolicy: IfNotPresent
 
 ssh:


### PR DESCRIPTION
There was an issue with v0.6.0 of this helm chart which impacted how prometheus was scraping data from gitlab; that is the primary driver for the new release of this chart (#2656). 

It was also noticed that the dependent redis chart must be changed due to the issues with bitnami changing how they publish artifacts and also the gitlab container image was a bit out of date.

This has been deployed within a dedicated namespace, with the renku gitlab dep pointing at this local version 0.6.1 of the gitlab helm chart.