### PR TITLE
chore: release 0.17.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 .. _changelog:
 
+0.17.1
+------
+
+Fixes a bug in the UI with anonymous sessions that was caught after tagging 0.17.0,
+but before deploying that version.
+
 0.17.0
 ------
 

--- a/helm-chart/renku/Chart.yaml
+++ b/helm-chart/renku/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku platform
 name: renku
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.17.0
+version: 0.17.1


### PR DESCRIPTION
This creates a version of 0.17 that can be deployed (0.17.0 contains a bug that was found after tagging but before deploying).

/deploy #persist