### PR TITLE
fix(tests): increase sleep for finding the terminal

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/JupyterNotebook.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/JupyterNotebook.scala
@@ -60,7 +60,7 @@ trait JupyterNotebook extends Datasets with Project with KnowledgeGraphApi {
 
     `try few times before giving up` { _ =>
       When("the user clicks on the Terminal icon")
-      click on jupyterLabPage.terminalIcon sleep (2 seconds)
+      click on jupyterLabPage.terminalIcon sleep (10 seconds)
     }
 
     val datasetName = DatasetName.generate


### PR DESCRIPTION
The tests are timing out because they are trying to click the terminal icon and eventually succeed. But this takes ~ 45 mins.

I think the problem is that when the terminal is not found then whole page is reloaded and we look for the terminal again. But the sleeps in this process are not long enough to fully download assets and render stuff. But if we do not reload the page and keep retrying the page should just load eventually and the step should succeed.