### PR TITLE
chore: Add scala-steward config file

### DIFF
--- a/.scala-steward-config
+++ b/.scala-steward-config
@@ -1,0 +1,9 @@
+# https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+
+# It is possible to have multiple scala projects in a single
+# repository. In that case the folders containing the projects
+# (build.sbt folders) are specified using the buildRoots property.
+# Note that the paths used there are relative and if the repo
+# directory itself also contains a build.sbt the dot can be used to
+# specify it. Default: ["."]
+buildRoots = [ "acceptance-tests" ]


### PR DESCRIPTION
We can use scala-steward to update dependencies in the acceptance tests. This config file tells scala-steward where the sbt project is located.