### PR TITLE
chore(docs): cleanup requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,31 +1,4 @@
--i https://pypi.org/simple
-babel==2.9.1
-backcall==0.1.0
-certifi==2018.4.16
-chardet==3.0.4
-decorator==4.3.0
-docutils==0.14
-idna==2.7
-imagesize==1.0.0
-jedi==0.12.1
-jinja2==2.11.3
-markupsafe==1.1.1
-packaging==21.3
-parso==0.3.0
-pexpect==4.6.0; sys_platform != 'win32'
-pickleshare==0.7.4
 plantweb==1.1.0
-prompt-toolkit==1.0.15
-ptyprocess==0.6.0
-pyenchant==3.*
-pygments==2.7.4
-pyparsing==2.2.0
-pytz==2018.5
-PyYAML==5.4
-requests>=2.20.0
-simplegeneric==0.8.1
-six==1.11.0
-snowballstemmer==1.2.1
 sphinx>=4.1
 sphinxcontrib-mermaid==0.7.1
 sphinxcontrib-napoleon==0.7
@@ -36,7 +9,4 @@ sphinx-rtd-theme==1.0.0
 renku-sphinx-theme==0.2.1
 sphinxcontrib-spelling==7.*
 sphinxcontrib-websupport==1.1.0
-traitlets==4.3.2
-urllib3>=1.26.5
-wcwidth==0.1.7
 ./docs/renku-python


### PR DESCRIPTION
We were pinning many libraries that were not directly relevant for the docs. This PR cleans up requirements to only address the needs of the docs build. 