### PR TITLE
chore: test formatting check not to raise an error in logs

### DIFF
--- a/acceptance-tests/docker-run-tests.sh
+++ b/acceptance-tests/docker-run-tests.sh
@@ -26,8 +26,12 @@ if [ ! -z $RENKU_TEST_S3_HOST ]; then
   MIRROR_JOB_ID=$(echo $!)
 fi
 
+# formatting check needs to be run in a git repository
+git init  2> /dev/null 1> /dev/null
+git add .
+
 echo "Target: " $TARGET
-sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtAll "$TARGET"
+sbt -Dsbt.color=always -Dsbt.supershell=false -Dsbt.global.base=/tests/.sbt/global -Dsbt.boot.directory=/tests/.sbt/boot/ -Dsbt.coursier.home=/tests/.sbt/coursier/ scalafmtCheckAll "$TARGET"
 TESTS_RC=$?
 echo "Tests completed with exit code $TESTS_RC"
 


### PR DESCRIPTION
Apparently, acceptance tests logs an error on tests sources formatting check. The statements look like follows:

```
[error] scalafmt: format all files; [git ls-files] (/tests): Failed to run command git rev-parse --show-toplevel. Error:
[error] > fatal: not a git repository (or any of the parent directories): .git
```

As this is a red herring it simply adds noise to the logs.

The reason scalafmt logs the error is its assumption that it's run inside a git repo. As tests sources are copied without the `.git` folder (tests sources live in a folder inside the renku repo) this requirement is not met. The fact is that the requirement does not prevent scalafmt to check formating correctly.

This PR simply workarounds the problem by initialising a git repo on the copied folder.

/deploy #persist