### PR TITLE
chore: add global debug flag

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -127,6 +127,10 @@ global:
     customCAs: []
       # - secret:
 
+  ## Set to true to enable debug mode
+  ## Individual components can handle debug mode as makes sense for them
+  debug: false
+
 ## Ingress configuration
 ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:


### PR DESCRIPTION
Mainly used to enable/disable automounting the serviceaccount token in components, can be used for other debug features in the future.