### PR TITLE
fix: update to latest project templates

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -544,7 +544,7 @@ ui:
       custom: true
       repositories:
         - url: https://github.com/SwissDataScienceCenter/renku-project-template
-          ref: 0.3.4
+          ref: 0.3.5
           name: Renku
         - url: https://github.com/SwissDataScienceCenter/contributed-project-templates
           ref: 0.4.1


### PR DESCRIPTION
This fixes a problem with nbconvert which is needed by jupyter server when it runs.

nbconver (a python package) was failing because of an unpinned dependency that it does not like. But nbconver does not explicitly mention this in their requirements. Otherwise this would not have happened.

/deploy #persist