### PR TITLE
feat: redirect /gitlab to external GitLab url

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.15.0
+  version: 0.16.0
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: 0.6.0

--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -59,15 +59,19 @@ spec:
             port:
               name: {{ $keycloakServicePort }}
       {{- end }}
-      {{- if $gitlabEnabled }}
       - path: /gitlab
         pathType: Prefix
         backend:
           service:
+            {{- if $gitlabEnabled }}
             name: {{ $gitlabFullname }}
             port:
               number: {{ $gitlabServicePort }}
-      {{- end }}
+            {{ else }}
+            name: renku-traefik
+            port:
+              number: 80
+            {{- end }}
       - path: /repos
         pathType: Prefix
         backend:


### PR DESCRIPTION
Forward /gitlab traffic to renku-traefik if external GitLab is used.

This should be merged at the same time as https://github.com/SwissDataScienceCenter/renku-gateway/pull/596, which configures Traefik to redirect /gitlab to the external GitLab URL, including the trailing relative path content if it exists.

#deploy /persist