### PR TITLE
fix(tests): update default gitlab url value

### DIFF
--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -18,7 +18,7 @@ spec:
       - name: RENKU_TEST_URL
         value: '{{ template "http" . }}://{{ .Values.global.renku.domain }}'
       - name: GITLAB_TEST_URL
-        value: {{ .Values.gateway.gitlabUrl | default (printf "%s://%s/gitlab" (include "http" .) .Values.global.renku.domain) | quote }}
+        value: {{ .Values.gateway.gitlabUrl | default (printf "%s://gitlab.%s" (include "http" .) .Values.global.renku.domain) | quote }}
       - name: RENKU_TEST_EMAIL
         value: '{{ .Values.tests.parameters.email }}'
       - name: RENKU_TEST_USERNAME


### PR DESCRIPTION
This removes the traces of the old gitlab deployment from the acceptance tests.