### PR TITLE
test: GH action to verify tests compile

### DIFF
--- a/.github/workflows/check-acceptance-test-code.yml
+++ b/.github/workflows/check-acceptance-test-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: run scalafmt
+      - name: run test compile
         run: |
           cd acceptance-tests
           sbt 'Test / compile'

--- a/.github/workflows/check-acceptance-test-code.yml
+++ b/.github/workflows/check-acceptance-test-code.yml
@@ -1,4 +1,4 @@
-name: Check format for acceptance tests
+name: Check acceptance tests dependencies and code
 
 on:
   [pull_request]
@@ -11,4 +11,4 @@ jobs:
       - name: run scalafmt
         run: |
           cd acceptance-tests
-          sbt scalafmtCheckAll
+          sbt 'Test / compile'

--- a/.github/workflows/check-acceptance-test-code.yml
+++ b/.github/workflows/check-acceptance-test-code.yml
@@ -4,7 +4,7 @@ on:
   [pull_request]
 jobs:
   formatting-check:
-    name: Scala formatting check
+    name: Scala dependencies and code check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR introduces a new GH action that checks if the Acceptance Tests code still compiles. The reason for the change is to have a smoke test that verifies if the tests are still OK after a dependencies update.