### PR TITLE
chore(redis): upgrade redis helm chart

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,43 +1,43 @@
 charts:
   ## gitlab and renku chart versions are not evolving together. Uncomment
   ## this only when explicitly building the gitlab chart and set the appropriate tag.
-  # - name: gitlab
-  #   imagePrefix: renku/
-  #   repo:
-  #     git: SwissDataScienceCenter/helm-charts
-  #     published: https://swissdatasciencecenter.github.io/helm-charts
-  #   paths:
-  #     - ./gitlab
-
-  - name: helm-chart/renku
-    resetTag: latest
+  - name: helm-chart/gitlab
     imagePrefix: renku/
     repo:
       git: SwissDataScienceCenter/helm-charts
       published: https://swissdatasciencecenter.github.io/helm-charts
     paths:
       - helm-chart
-      - acceptance-tests
-      - scripts/init-realm
-    images:
-      tests:
-        buildArgs:
-          BUILDKIT_INLINE_CACHE: "1"
-        contextPath: acceptance-tests
-        dockerfilePath: acceptance-tests/Dockerfile
-        valuesPath: tests.image
-        paths:
-          - acceptance-tests
-      init-realm:
-        contextPath: scripts/init-realm
-        dockerfilePath: scripts/init-realm/Dockerfile
-        valuesPath: keycloak.initRealm.image
-        paths:
-          - scripts/init-realm
-          - scripts/init-realm/init-realm.py
-      init-db:
-        contextPath: scripts/init-db
-        dockerfilePath: scripts/init-db/Dockerfile
-        valuesPath: initDb.image
-        paths:
-          - scripts/init-db
+
+  # - name: helm-chart/renku
+  #   resetTag: latest
+  #   imagePrefix: renku/
+  #   repo:
+  #     git: SwissDataScienceCenter/helm-charts
+  #     published: https://swissdatasciencecenter.github.io/helm-charts
+  #   paths:
+  #     - helm-chart
+  #     - acceptance-tests
+  #     - scripts/init-realm
+  #   images:
+  #     tests:
+  #       buildArgs:
+  #         BUILDKIT_INLINE_CACHE: "1"
+  #       contextPath: acceptance-tests
+  #       dockerfilePath: acceptance-tests/Dockerfile
+  #       valuesPath: tests.image
+  #       paths:
+  #         - acceptance-tests
+  #     init-realm:
+  #       contextPath: scripts/init-realm
+  #       dockerfilePath: scripts/init-realm/Dockerfile
+  #       valuesPath: keycloak.initRealm.image
+  #       paths:
+  #         - scripts/init-realm
+  #         - scripts/init-realm/init-realm.py
+  #     init-db:
+  #       contextPath: scripts/init-db
+  #       dockerfilePath: scripts/init-db/Dockerfile
+  #       valuesPath: initDb.image
+  #       paths:
+  #         - scripts/init-db

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.6.1-rc.2
+version: 0.6.1-rc.3

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.6.1-rc.3
+version: 0.6.1-rc.4

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.6.0
+version: 0.6.1-rc.2

--- a/helm-chart/gitlab/requirements.yaml
+++ b/helm-chart/gitlab/requirements.yaml
@@ -1,4 +1,4 @@
-dependencies:
-- name: redis
-  version: 10.7.11
-  repository: "https://charts.bitnami.com/bitnami"
+# dependencies:
+# - name: redis
+#   version: 10.7.11
+#   repository: "https://charts.bitnami.com/bitnami"

--- a/helm-chart/gitlab/templates/_gitlab.rb.tpl
+++ b/helm-chart/gitlab/templates/_gitlab.rb.tpl
@@ -77,7 +77,7 @@ gitlab_rails['db_port'] = 5432
 ###! Docs: https://docs.gitlab.com/omnibus/settings/redis.html
 
 #### Redis TCP connection
-# gitlab_rails['redis_host'] = '{{ include "call-nested" (list . "redis" "redis.fullname") }}-master'
+# gitlab_rails['redis_host'] = 
 # gitlab_rails['redis_port'] = 6379
 # gitlab_rails['redis_password'] = nil
 # gitlab_rails['redis_database'] = 0

--- a/helm-chart/gitlab/templates/_gitlab.rb.tpl
+++ b/helm-chart/gitlab/templates/_gitlab.rb.tpl
@@ -77,7 +77,7 @@ gitlab_rails['db_port'] = 5432
 ###! Docs: https://docs.gitlab.com/omnibus/settings/redis.html
 
 #### Redis TCP connection
-gitlab_rails['redis_host'] = '{{ include "call-nested" (list . "redis" "redis.fullname") }}-master'
+# gitlab_rails['redis_host'] = '{{ include "call-nested" (list . "redis" "redis.fullname") }}-master'
 # gitlab_rails['redis_port'] = 6379
 # gitlab_rails['redis_password'] = nil
 # gitlab_rails['redis_database'] = 0

--- a/helm-chart/gitlab/templates/deployment.yaml
+++ b/helm-chart/gitlab/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
       labels:
         app: {{ template "gitlab.name" . }}
         release: {{ .Release.Name }}
-        # {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:

--- a/helm-chart/gitlab/templates/deployment.yaml
+++ b/helm-chart/gitlab/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         app: {{ template "gitlab.name" . }}
         release: {{ .Release.Name }}
-        {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
+        # {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:

--- a/helm-chart/gitlab/values.yaml
+++ b/helm-chart/gitlab/values.yaml
@@ -102,22 +102,22 @@ tolerations: []
 
 affinity: {}
 
-redis:
+# redis:
 
-  nameOverride: gl-redis
+#   nameOverride: gl-redis
 
-  cluster:
-    enabled: false
+#   cluster:
+#     enabled: false
 
-  usePassword: false
+#   usePassword: false
 
-  master:
-    persistence:
-      enabled: false
+#   master:
+#     persistence:
+#       enabled: false
 
-  networkPolicy:
-    enabled: true
-    allowExternal: false
+#   networkPolicy:
+#     enabled: true
+#     allowExternal: false
 
 # Enable json logs for all services
 logging:

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 0.16.0
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.6.1-rc.3
+  version: 0.6.1-rc.4
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 0.16.0
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.6.0
+  version: 0.6.1-rc.2
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph
@@ -39,7 +39,7 @@ dependencies:
 #   version: 10.7.11
 #   repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
 #   condition: redis.install
-- name: renku-redis
+- name: redis
   version: 17.3.10 # release data: 14/11/2022
   repository: "https://charts.bitnami.com/bitnami" 
   condition: redis.install

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -39,7 +39,7 @@ dependencies:
 #   version: 10.7.11
 #   repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
 #   condition: redis.install
-- name: redis
+- name: renku-redis
   version: 17.3.10 # release data: 14/11/2022
   repository: "https://charts.bitnami.com/bitnami" 
   condition: redis.install

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 0.16.0
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.6.1-rc.2
+  version: 0.6.1-rc.3
   condition: gitlab.enabled
 - name: renku-graph
   alias: graph

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -35,7 +35,11 @@ dependencies:
 - name: certificates
   version: 0.0.3
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
+# - name: redis
+#   version: 10.7.11
+#   repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
+#   condition: redis.install
 - name: redis
-  version: 10.7.11
-  repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
+  version: 17.3.10 # release data: 14/11/2022
+  repository: "https://charts.bitnami.com/bitnami" 
   condition: redis.install

--- a/helm-chart/renku/templates/secrets.yaml
+++ b/helm-chart/renku/templates/secrets.yaml
@@ -22,12 +22,12 @@ data:
   gateway-gitlab-client-secret: {{ required "Fill in .Values.global.gateway.gitlabClientSecret with `openssl rand -hex 32`" .Values.global.gateway.gitlabClientSecret | b64enc | quote }}
 
 
-{{- if and (eq .Values.redis.install true) (eq .Values.redis.createSecret true) }}
+{{- if and (eq .Values.renku-redis.install true) (eq .Values.renku-redis.createSecret true) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.redis.existingSecret }}
+  name: {{ .Values.renku-redis.existingSecret }}
   labels:
     app: {{ template "renku.name" . }}
     chart: {{ template "renku.chart" . }}
@@ -35,5 +35,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ .Values.redis.existingSecretPasswordKey }}: {{ .Values.redis.password | b64enc | quote }}
+  {{ .Values.renku-redis.existingSecretPasswordKey }}: {{ .Values.renku-redis.password | b64enc | quote }}
 {{- end }}

--- a/helm-chart/renku/templates/secrets.yaml
+++ b/helm-chart/renku/templates/secrets.yaml
@@ -22,12 +22,12 @@ data:
   gateway-gitlab-client-secret: {{ required "Fill in .Values.global.gateway.gitlabClientSecret with `openssl rand -hex 32`" .Values.global.gateway.gitlabClientSecret | b64enc | quote }}
 
 
-{{- if and (eq .Values.renku-redis.install true) (eq .Values.renku-redis.createSecret true) }}
+{{- if and (eq .Values.redis.install true) (eq .Values.redis.createSecret true) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.renku-redis.existingSecret }}
+  name: {{ .Values.redis.existingSecret }}
   labels:
     app: {{ template "renku.name" . }}
     chart: {{ template "renku.chart" . }}
@@ -35,5 +35,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ .Values.renku-redis.existingSecretPasswordKey }}: {{ .Values.renku-redis.password | b64enc | quote }}
+  {{ .Values.redis.existingSecretPasswordKey }}: {{ .Values.redis.password | b64enc | quote }}
 {{- end }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -379,7 +379,7 @@ redis:
         memory: 256Mi
   sentinel:
     port: 26379
-    enabled: true
+    enabled: false
     resources:
       requests:
         cpu: 200m

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -332,15 +332,15 @@ redis:
   ## config for newer redis versions, here for later reference
   # replicas:
   #   replicaCount: 2
-  # auth:
-  #   enabled: true
-  #   sentinel: true
-  #   existingSecret: redis-secret
-  #   existingSecretPasswordKey: redis-password
+  auth:
+    enabled: true
+    sentinel: false
+    existingSecret: redis-secret
+    existingSecretPasswordKey: redis-password
 
-  usePassword: true
-  existingSecret: redis-secret
-  existingSecretPasswordKey: redis-password
+  # usePassword: true
+  # existingSecret: redis-secret
+  # existingSecretPasswordKey: redis-password
 
   master:
     # Fixed redis bug prevents us from using this before

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -335,8 +335,9 @@ redis:
   auth:
     enabled: true
     sentinel: false
-    existingSecret: redis-secret
-    existingSecretPasswordKey: redis-password
+    password: "pass1234"
+    # existingSecret: redis-secret
+    # existingSecretPasswordKey: redis-password
 
   # usePassword: true
   # existingSecret: redis-secret

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -379,7 +379,7 @@ redis:
         memory: 256Mi
   sentinel:
     port: 26379
-    enabled: false
+    enabled: true
     resources:
       requests:
         cpu: 200m

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -352,6 +352,7 @@ redis:
     #     labelSelector:
     #       matchLabels:
     #         app: redis
+    count: 1
     persistence:
       enabled: false
     resources:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -320,6 +320,10 @@ redis:
   # The actual password, ignored if createSecret is false.
   password: # openssl rand -hex 32
 
+  usePassword: true
+  existingSecret: redis-secret
+  existingSecretPasswordKey: redis-password
+
   ###########################################################################
   ### Configuration that is passed on to the redis chart, for details and ###
   ### further config options check out                                    ###
@@ -338,28 +342,27 @@ redis:
     existingSecret: redis-secret
     existingSecretPasswordKey: redis-password
 
-  usePassword: true
-  existingSecret: redis-secret
-  existingSecretPasswordKey: redis-password
+  # master:
+  #   # Fixed redis bug prevents us from using this before
+  #   # we bump the redis chart version
+  #   # spreadConstraints:
+  #   #   - maxSkew: 1
+  #   #     topologyKey: node
+  #   #     whenUnsatisfiable: DoNotSchedule
+  #   #     labelSelector:
+  #   #       matchLabels:
+  #   #         app: redis
+  #   persistence:
+  #     enabled: false
+  #   resources:
+  #     requests:
+  #       cpu: 200m
+  #       memory: 256Mi
 
-  master:
-    # Fixed redis bug prevents us from using this before
-    # we bump the redis chart version
-    # spreadConstraints:
-    #   - maxSkew: 1
-    #     topologyKey: node
-    #     whenUnsatisfiable: DoNotSchedule
-    #     labelSelector:
-    #       matchLabels:
-    #         app: redis
-    count: 1
-    persistence:
-      enabled: false
-    resources:
-      requests:
-        cpu: 200m
-        memory: 256Mi
+  # these are call replicas now and there are no keys called
+  # slave
   # slave:
+
   replica:
     # Fixed redis bug prevents us from using this before
     # we bump the redis chart version
@@ -377,6 +380,7 @@ redis:
       requests:
         cpu: 200m
         memory: 256Mi
+
   sentinel:
     port: 26379
     enabled: true

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -334,7 +334,7 @@ redis:
   #   replicaCount: 2
   auth:
     enabled: true
-    sentinel: false
+    sentinel: true
     existingSecret: redis-secret
     existingSecretPasswordKey: redis-password
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -306,7 +306,7 @@ postgresql:
     password: repl_password # generate a random password `openssl rand -hex 32`
     slaveReplicas: 1
 
-renku-redis:
+redis:
   ###########################################################################
   ### Configuration that is unknown to the redis chart but picked up      ###
   ### by the renku chart.                                                 ###

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -358,7 +358,8 @@ redis:
       requests:
         cpu: 200m
         memory: 256Mi
-  slave:
+  # slave:
+  replica:
     # Fixed redis bug prevents us from using this before
     # we bump the redis chart version
     # spreadConstraints:
@@ -368,6 +369,7 @@ redis:
     #     labelSelector:
     #       matchLabels:
     #         app: redis
+    replicaCount: 2
     persistence:
       enabled: false
     resources:
@@ -383,6 +385,9 @@ redis:
         memory: 64Mi
     downAfterMilliseconds: 1000
     failoverTimeout: 2000
+  # add support for ptometheus scraping
+  metrics:
+    enabled: true
   networkPolicy:
     enabled: true
     allowExternal: false

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -306,7 +306,7 @@ postgresql:
     password: repl_password # generate a random password `openssl rand -hex 32`
     slaveReplicas: 1
 
-redis:
+renku-redis:
   ###########################################################################
   ### Configuration that is unknown to the redis chart but picked up      ###
   ### by the renku chart.                                                 ###

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -335,13 +335,12 @@ redis:
   auth:
     enabled: true
     sentinel: false
-    password: "pass1234"
-    # existingSecret: redis-secret
-    # existingSecretPasswordKey: redis-password
+    existingSecret: redis-secret
+    existingSecretPasswordKey: redis-password
 
-  # usePassword: true
-  # existingSecret: redis-secret
-  # existingSecretPasswordKey: redis-password
+  usePassword: true
+  existingSecret: redis-secret
+  existingSecretPasswordKey: redis-password
 
   master:
     # Fixed redis bug prevents us from using this before

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -370,7 +370,7 @@ redis:
     #     labelSelector:
     #       matchLabels:
     #         app: redis
-    replicaCount: 2
+    replicaCount: 3
     persistence:
       enabled: false
     resources:


### PR DESCRIPTION
The bitnami redis helm chart used in renku is quite old (v10.7.11, published 9/7/2020). It contains Redis version 6.0.5 (released 6/9/2020).

Latest versions of the bitnami helm chart are 17.3.x and they contain redis version 7.x. Redis releases have moved from the 6.x series to the 7.x series, with the last 6.x release being in April 2022 and hence it makes sense to make the transition.

The newer redis helm charts operate somewhat differently from the older ones - the notion of `slave` has been replaced with `replica` and there is now a clear distinction between operating in a mode which has an explicit `master` or operating in `sentinel` mode - these are mutually exclusive. This means that the values we use to control redis are not backwards compatible and it is necessary to simultaneously perform a redis chart upgrade and change the values. Clearly this means that care should be taken with this upgrade.

In our previous redis configuration, the standard configuration was to have a single pod named `master` and two `slave` pods. In the new configuration, all three pods have essentially the same names (`node-0|1|2`). All three nodes contain 3 containers: `redis`, `sentinel` and a `metrics` container for prometheus data collection.

A service is defined called `renku-redis` and all three pods sit behind this; the `redis` ports and the `sentinel` ports are accessible via this service.

Currently, our services query `sentinel` on `renku-redis` to obtain the current `master` - this works. It is (arguably) not the standard `sentinel` configuration (in which a list of `sentinels` would be defined); however, it provides an upgrade path which is no less robust than our current solution and requires no changes to our services - it could even be more robust.


