### PR TITLE
fix: AT to assume project not created on 400 from GET /status

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Environments.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Environments.scala
@@ -85,7 +85,7 @@ trait Environments {
 
   private def stopSessionOnProjectPage(projectPage: ProjectPage): Unit = {
     When("the user switches back to the Renku frame")
-    webDriver.switchTo().defaultContent();
+    webDriver.switchTo().defaultContent()
     // And("opens the sessions menu")
     // click on projectPage.Sessions.Running.sessionDropdownMenu sleep (1 second)
     And("clicks on stop button to open modal")


### PR DESCRIPTION
This PR addresses acceptance tests flakiness in cases when GET kg/status returns 400 straight after project creation.

/deploy #persist