### PR TITLE
fix: acceptance tests not to fail when getting event processing status

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,6 +42,8 @@ As soon as the release PR is merged, the product team tag a release and inform Y
 for the rollout.
 
 
+
+
 ### Deploy [YAT]
 
 * Roll out the release: create one PR per deployment in the `terraform-renku` repository to update the version and make any needed configuration changes. Important: if needed, add the `scheduled maintenance` label to help avoiding it being merged too early. Limited should be rolled out before Renkulab, as a canary release (see below).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,8 +42,6 @@ As soon as the release PR is merged, the product team tag a release and inform Y
 for the rollout.
 
 
-
-
 ### Deploy [YAT]
 
 * Roll out the release: create one PR per deployment in the `terraform-renku` repository to update the version and make any needed configuration changes. Important: if needed, add the `scheduled maintenance` label to help avoiding it being merged too early. Limited should be rolled out before Renkulab, as a canary release (see below).

--- a/acceptance-tests/build.sbt
+++ b/acceptance-tests/build.sbt
@@ -42,9 +42,9 @@ libraryDependencies += "org.http4s"             %% "http4s-circe"        % "0.23
 libraryDependencies += "org.scalacheck"         %% "scalacheck"          % "1.17.0"     % Test
 libraryDependencies += "org.scalatest"          %% "scalatest"           % "3.2.14"     % Test
 libraryDependencies += "org.scalatestplus"      %% "selenium-3-141"      % "3.2.10.0"   % Test
-libraryDependencies += "org.seleniumhq.selenium" % "selenium-java"       % "4.6.0"      % Test
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-java"       % "4.7.0"      % Test
 libraryDependencies += "org.slf4j"               % "slf4j-log4j12"       % "2.0.5"      % Test
-libraryDependencies += "org.typelevel"          %% "cats-effect"         % "3.4.2"     % Test
+libraryDependencies += "org.typelevel"          %% "cats-effect"         % "3.4.2"      % Test
 
 scalacOptions += "-feature"
 scalacOptions += "-unchecked"


### PR DESCRIPTION
This PR brings some fixes to the acceptance tests around finding the status of events processing on the KG.

/deploy #persist