### PR TITLE
chore(tests): use requirements.txt for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "acceptance-tests/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -37,16 +37,7 @@ USER attests
 ENV PATH=/home/attests/.local/bin:/home/attests/.local/lib/python3.8/site-packages:$PATH
 
 RUN python3 -m pip install --upgrade 'pip==22.3.1' && \
-    python3 -m pip install \
-      'papermill==2.1.3' \
-      'requests>=2.20.0' \
-      'jupyterhub==1.1.0' \
-      'nbresuse==0.3.3' \
-      'jupyterlab-git==0.20.0' \
-      'pipx>=0.15.0.0' \
-      'pandas==1.3.0' \
-      'seaborn==0.11.1' \
-      'toil==5.7.1'
+    python3 -m pip install -r /tests/requirements.txt
 
 ENV DOCKER="1"
 ENTRYPOINT ["/tests/docker-run-tests.sh"]

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -158,6 +158,18 @@ Docker avoids this problem.
 
 ## Running in console
 
+To simply run all tests run:
+
+```bash
+sbt test
+```
+
+To run a specific test (e.g. the `UnprivilegedSessionSpec` test) run:
+
+```bash
+sbt 'testOnly *UnprivilegedSessionSpec*'
+```
+
 For development, it can be nice to try things out on the console. For this, get started by running the
 following:
 

--- a/acceptance-tests/requirements.txt
+++ b/acceptance-tests/requirements.txt
@@ -1,0 +1,9 @@
+papermill==2.1.3
+requests>=2.20.0
+jupyterhub==1.1.0
+nbresuse==0.3.3
+jupyterlab-git==0.20.0
+pipx>=0.15.0.0
+pandas==1.3.0
+seaborn==0.11.1
+toil==5.7.1


### PR DESCRIPTION
A few changes to make the acceptance tests a bit easier to use/run.

1. Updated the readme to indicate how to run the tests locally (and especially how to run only a specific test)
2. Moved the python packages used in the acceptance tests in a requirements.txt file

/deploy #persist