### PR TITLE
feat: Support the two different representation of graph status

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/GraphStatus.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/GraphStatus.scala
@@ -1,0 +1,47 @@
+package ch.renku.acceptancetests.tooling
+
+import io.circe.Decoder
+
+sealed trait GraphStatus {
+  def progressPercentage: Double
+  def total:              Int
+
+  final def widen: GraphStatus = this
+}
+
+object GraphStatus {
+
+  final case class Legacy(done: Int, total: Int, progress: Double) extends GraphStatus {
+    val progressPercentage: Double = progress
+  }
+
+  object Legacy {
+    implicit val jsonDecoder: Decoder[Legacy] =
+      Decoder.forProduct3("done", "total", "progress")(Legacy.apply)
+  }
+
+  final case class Progress(done: Int, total: Int, percentage: Float)
+  object Progress {
+    implicit val jsonDecoder: Decoder[Progress] =
+      Decoder.forProduct3("done", "total", "percentage")(Progress.apply)
+  }
+
+  final case class Details(status: String, message: String)
+  object Details {
+    implicit val jsonDecoder: Decoder[Details] =
+      Decoder.forProduct2("status", "message")(Details.apply)
+  }
+
+  final case class Status(activated: Boolean, progress: Progress, details: Details) extends GraphStatus {
+    val progressPercentage: Double = progress.percentage.toDouble
+    val total:              Int    = progress.total
+  }
+
+  object Status {
+    implicit val jsonDecoder: Decoder[Status] =
+      Decoder.forProduct3("activated", "progress", "details")(Status.apply)
+  }
+
+  implicit val jsonDecoder: Decoder[GraphStatus] =
+    Status.jsonDecoder.map(_.widen).or(Legacy.jsonDecoder.map(_.widen))
+}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/GraphStatusSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/GraphStatusSpec.scala
@@ -1,0 +1,43 @@
+package ch.renku.acceptancetests.tooling
+
+import io.circe.Decoder
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import io.circe.literal._
+
+class GraphStatusSpec extends AnyFlatSpec with should.Matchers {
+
+  it should "decode legacy structures" in {
+    val legacyStatus =
+      json"""
+        { "done": 1, "total": 4, "progress": 0.25 }
+          """
+
+    Decoder[GraphStatus].decodeJson(legacyStatus) shouldBe Right(GraphStatus.Legacy(1, 4, 0.25))
+  }
+
+  it should "decode detailed status response" in {
+    val detailedStatus =
+      json"""
+            { "activated": true,
+              "progress": {
+                "done": 1,
+                "total": 4,
+                "percentage": 0.25
+              },
+              "details": {
+                "status": "in-progress",
+                "message": "Thing is in progress."
+              }
+            }
+          """
+
+    Decoder[GraphStatus].decodeJson(detailedStatus) shouldBe Right(
+      GraphStatus.Status(
+        true,
+        GraphStatus.Progress(1, 4, 0.25f),
+        GraphStatus.Details("in-progress", "Thing is in progress.")
+      )
+    )
+  }
+}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
@@ -23,9 +23,10 @@ import cats.effect.IO
 import cats.syntax.all._
 import ch.renku.acceptancetests.model.projects.ProjectIdentifier
 import io.circe.literal.JsonStringContext
-import io.circe.{Json, JsonObject}
+import io.circe.JsonObject
 import org.http4s.Status.{NotFound, Ok}
 import org.http4s.circe._
+import org.http4s.circe.CirceEntityCodec._
 import org.scalatest.Assertions.fail
 
 import scala.annotation.tailrec
@@ -74,25 +75,21 @@ trait KnowledgeGraphApi extends RestClient {
     GET(renkuBaseUrl / "api" / "projects" / gitLabProjectId.toString / "graph" / "status")
       .send { response =>
         response.status match {
-          case Ok       => response.as[Json].map(jsonRoot.progress.double.getOption)
-          case NotFound => 0d.some.pure[IO]
+          case Ok       => response.as[GraphStatus].map(_.progressPercentage)
+          case NotFound => 0d.pure[IO]
           case other =>
-            logger.warn(s"Finding processing status for '$projectId' returned $other")
-            0d.some.pure[IO]
+            IO(logger.warn(s"Finding processing status for '$projectId' returned $other")).as(0d)
         }
       }
-      .getOrElse(0d)
 
   private def findTotalDone(projectId: ProjectIdentifier, gitLabProjectId: Int): Int =
     GET(renkuBaseUrl / "api" / "projects" / gitLabProjectId.toString / "graph" / "status")
       .send { response =>
         response.status match {
-          case Ok       => response.as[Json].map(jsonRoot.total.int.getOption)
-          case NotFound => 0.some.pure[IO]
+          case Ok       => response.as[GraphStatus].map(_.total)
+          case NotFound => 0.pure[IO]
           case other =>
-            logger.warn(s"Finding processing status for '$projectId' returned $other")
-            0.some.pure[IO]
+            IO(logger.warn(s"Finding processing status for '$projectId' returned $other")).as(0)
         }
       }
-      .getOrElse(0)
 }


### PR DESCRIPTION
Currently the structure returned from `/status` endpoint is being changed. The tests support old and new variants until the new version is everywhere.