### PR TITLE
fix: lineage spec to use REST API instead of GraphQL

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
@@ -42,7 +42,8 @@ trait KnowledgeGraphApi extends RestClient {
   def findLineage(projectPath: String, filePath: String): JsonObject = {
     val toSegments: String => List[String] = _.split('/').toList
     val uri =
-      toSegments(projectPath).foldLeft(renkuBaseUrl / "knowledge-graph" / "projects")(_ / _) / "files" / filePath / "lineage"
+      toSegments(projectPath)
+        .foldLeft(renkuBaseUrl / "knowledge-graph" / "projects")(_ / _) / "files" / filePath / "lineage"
     GET(uri)
       .send(whenReceived(status = Ok) >=> bodyToJson)
       .extract(jsonRoot.data.lineage.obj.getOption)

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
@@ -46,7 +46,7 @@ trait KnowledgeGraphApi extends RestClient {
         .foldLeft(renkuBaseUrl / "knowledge-graph" / "projects")(_ / _) / "files" / filePath / "lineage"
     GET(uri)
       .send(whenReceived(status = Ok) >=> bodyToJson)
-      .extract(jsonRoot.data.lineage.obj.getOption)
+      .extract(jsonRoot.obj.getOption)
       .getOrElse(fail(s"Cannot find lineage data for project $projectPath file $filePath"))
   }
 


### PR DESCRIPTION
This PR switches the LineageSpec to use the REST API instead of GraphQL that was recently removed

/deploy