### PR TITLE
chore: bump ca-certificates chart to 0.0.4

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: "https://codecentric.github.io/helm-charts"
   condition: keycloak.enabled
 - name: certificates
-  version: 0.0.3
+  version: 0.0.4
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
 - name: redis
   # bitnami claims that this will always contain a full set of charts - let us pray...


### PR DESCRIPTION
Updates the ca certificates injection to handle new java versions used by the KG.

Already tested at the BIT.