### PR TITLE
feat(scripts): Add script to generate SSH host keys secret.

### DIFF
--- a/scripts/generate-ssh-host-keys/README.md
+++ b/scripts/generate-ssh-host-keys/README.md
@@ -1,0 +1,33 @@
+# Generate SSH host keys
+
+This simple script helps generating the Kubernetes secret that renku-notebooks expect
+when the SSH-into-sessions feature is enabled and the Renku administrator wants to
+set the SSH host keys.
+
+## Running the script
+
+Install the python dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the scripts, optionally passing the name of the filename where to save the output, the name of the secret
+and the namespace where it will be deployed:
+```bash
+./generate-ssh-host-keys.py --filename ssh-host-keys-secret.yaml --name renku-ssh-host-keys --namespace renku
+```
+
+## Deploying the secret
+
+Use kubectl to deploy the generated secret:
+```bash
+kubectl apply -f ssh-host-keys-secret.yaml
+```
+
+Change the values file to point to the deployed secret:
+```yaml
+notebooks:
+  ssh:
+    enabled: true
+    hostKeySecret: renku-ssh-host-keys
+```

--- a/scripts/generate-ssh-host-keys/generate-ssh-host-keys.py
+++ b/scripts/generate-ssh-host-keys/generate-ssh-host-keys.py
@@ -1,0 +1,40 @@
+#!/bin/env python3
+
+import argparse
+import Crypto
+from Crypto.PublicKey import RSA
+from Crypto.PublicKey import DSA
+from Crypto.PublicKey import ECC
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PreservedScalarString as pss
+
+argparser = argparse.ArgumentParser(description=__doc__)
+argparser.add_argument("--filename", help="Name of the file to output the secret.", default="ssh-host-keys-secret.yaml")
+argparser.add_argument("--name", help="Name of the secret.", default="renku-ssh-host-keys")
+argparser.add_argument("--namespace", help="Target namespace for the secret.", default="renku")
+args = argparser.parse_args()
+
+rsa_key = RSA.generate(3072)
+dsa_key = DSA.generate(1024)
+ecdsa_key = ECC.generate(curve="P-256")
+ed25519_key = ECC.generate(curve="Ed25519")
+
+secret_manifest = {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {"name": args.name, "namespace": args.namespace},
+    "stringData": {
+        "ssh_host_dsa_key": pss(dsa_key.export_key(format="PEM").decode("UTF-8")),
+        "ssh_host_dsa_key.pub": pss(dsa_key.public_key().export_key(format="OpenSSH").decode("UTF-8")),
+        "ssh_host_rsa_key": pss(rsa_key.export_key().decode("UTF-8")),
+        "ssh_host_rsa_key.pub": pss(rsa_key.public_key().export_key().decode("UTF-8")),
+        "ssh_host_ecdsa_key": pss(ecdsa_key.export_key(format="PEM")),
+        "ssh_host_ecdsa_key.pub": pss(ecdsa_key.public_key().export_key(format="OpenSSH")),
+        "ssh_host_ed25519_key": pss(ed25519_key.export_key(format="PEM")),
+        "ssh_host_ed25519_key.pub": pss(ed25519_key.public_key().export_key(format="OpenSSH")),
+    },
+}
+
+with open("ssh-host-keys-secret.yaml", "w") as f:
+    YAML().dump(secret_manifest, f)

--- a/scripts/generate-ssh-host-keys/requirements.txt
+++ b/scripts/generate-ssh-host-keys/requirements.txt
@@ -1,0 +1,2 @@
+pycryptodome
+ruamel.yaml


### PR DESCRIPTION
This script can be used to generate the SSH host keys that can be optionally added to a Renkulab deployment when the SSH-into-session feature is enabled, so that they are persisted and the host key verification does not have to 
be performed again if Renku is re-deployed.

I have deployed in renku-dev the secret generated by this script and tested that I can still connect to my session.