### PR TITLE
chore: update renku notebooks to 1.15.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,24 @@
 .. _changelog:
 
+0.24.1
+------
+
+Renku ``0.24.1`` introduces bug fixes.
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+* **Sessions**: Sessions crashing when automated token refresh runs in background 
+  (`#1416 <https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1416>`_).
+
+Individual components
+~~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-notebooks 1.15.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.15.1>`_
+
+
 0.24.0
 ------
 

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 - name: renku-notebooks
   alias: notebooks
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 1.15.0
+  version: 1.15.1
 - name: renku-gateway
   alias: gateway
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"


### PR DESCRIPTION
/deploy #persist

Ignore the automated PR for the update. This has the version update and chagelog updates.

Rerun when the notebooks pipeline finally publishes the chart.

You can check the status of the renku notebooks publishing pipeline here: https://github.com/SwissDataScienceCenter/renku-notebooks/actions/runs/4323167717/jobs/7546472835
