### PR TITLE
Extend and improve Cypress tests

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -134,9 +134,6 @@ jobs:
     needs: [check-deploy, deploy-pr]
     steps:
       - uses: actions/checkout@v3
-      - name: Wait for PR deployment to be ready
-        run: sleep 60s
-        shell: bash
       - uses: cypress-io/github-action@v5
         name: Run Cypress acceptance tests
         id: cypress

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -3,7 +3,11 @@ import { TIMEOUTS } from "./config";
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.BASE_URL || "https://dev.renku.ch"
+    baseUrl: process.env.BASE_URL || "https://dev.renku.ch",
+    specPattern: [
+      "cypress/e2e/verifyInfrastructure.cy.ts",
+      "cypress/e2e/*.{js,jsx,ts,tsx}"
+    ],
   },
   env: {
     TEST_EMAIL: process.env.TEST_EMAIL,

--- a/cypress-tests/cypress/e2e/updateProjects.cy.ts
+++ b/cypress-tests/cypress/e2e/updateProjects.cy.ts
@@ -9,13 +9,14 @@ const projects = {
   namespace: "renku-ui-tests",
   v7: "renku-project-v7",
   v8: "renku-project-v8",
+  v9: "renku-project-v9"
 }
 
 // ? to simplify debugging, you can change `shouldFork` to false to use the projects directly instead of forking.
 // projects.shouldFork = false;
 // projects.namespace = "yourNamespace";
-// projects.v7 = "anotherProjectV7";
 // projects.v8 = "anotherProjectV8";
+// projects.v9 = "anotherProjectV9";
 
 describe("Fork and update old projects", () => {
   before(() => {
@@ -29,9 +30,9 @@ describe("Fork and update old projects", () => {
 
   it("Cannot update a very old and unsupported project", () => {
     // fork the project
-    const tempName = `test-project-update-v7-${uuidv4().substring(24)}`;
+    const tempName = `test-project-update-v8-${uuidv4().substring(24)}`;
     if (projects.shouldFork) {
-      const forkedProject = { namespace: projects.namespace, name: projects.v7 };
+      const forkedProject = { namespace: projects.namespace, name: projects.v8 };
       cy.visitAndLoadProject(forkedProject, true);
       cy.dataCy("header-project").contains("Error obtaining datasets").should("be.visible");
       cy.forkProject(forkedProject, tempName);
@@ -40,16 +41,73 @@ describe("Fork and update old projects", () => {
     // get to the status page
     const targetProject = projects.shouldFork ?
       { namespace: username, name: tempName } :
-      { namespace: projects.namespace, name: projects.v7 };
+      { namespace: projects.namespace, name: projects.v8 };
     if (!projects.shouldFork)
       cy.visitAndLoadProject(targetProject, true);
     cy.getProjectPageLink(targetProject, "overview/status").should("exist").click();
 
     // verify project cannot be updated
     cy.dataCy("project-overview-content").contains("Project Renku Version").should("exist");
-    cy.dataCy("project-overview-content").contains("(v7)").should("exist");
+    cy.dataCy("project-overview-content").contains("(v8)").should("exist");
     cy.dataCy("project-overview-content")
       .contains("This project is not compatible with the RenkuLab UI").should("exist");
+
+    // delete the project
+    if (projects.shouldFork)
+      cy.deleteProject(targetProject);
+  });
+
+  it("Can update an old but still supported project", () => {
+    // fork the project
+    const tempName = `test-project-update-v9-${uuidv4().substring(24)}`;
+    if (projects.shouldFork) {
+      const forkedProject = { namespace: projects.namespace, name: projects.v9 };
+      cy.visitAndLoadProject(forkedProject);
+      cy.forkProject(forkedProject, tempName);
+    }
+
+    // get to the commits page and check there is only 1 commit
+    const targetProject = projects.shouldFork ?
+      { namespace: username, name: tempName } :
+      { namespace: projects.namespace, name: projects.v9 };
+    if (!projects.shouldFork)
+      cy.visitAndLoadProject(targetProject);
+    let commitFetched = false;
+    cy.intercept(
+      "/ui-server/api/projects/*/repository/commits?ref_name=master&per_page=100&page=1",
+      req => { commitFetched = true; }
+    ).as("getCommits");
+    cy.getProjectPageLink(targetProject, "overview/commits").should("exist").click();
+    if (!commitFetched)
+      cy.dataCy("refresh-commits").should("exist").click();
+    cy.wait("@getCommits", { timeout: TIMEOUTS.long });
+    cy.dataCy("project-overview-content").get(".card-body ul li.commit-object").should("have.length", 1)
+
+    // verify project can be updated
+    cy.getProjectPageLink(targetProject, "overview/status").should("exist").click();
+    cy.dataCy("project-overview-content").contains("Project Renku Version").should("exist");
+    cy.dataCy("project-overview-content").contains("(v9)").should("exist");
+    cy.dataCy("project-overview-content")
+      .contains("it is using an older version of renku").should("exist");
+
+    // update the project
+    cy.dataCy("project-overview-content").get(".alert.alert-warning button.btn-warning")
+      .contains("Update").should("exist").click();
+    // ? Temporarily disabled until we fix this: https://github.com/SwissDataScienceCenter/renku-ui/issues/2315
+    // cy.dataCy("project-overview-content").contains("Updating...", { timeout: TIMEOUTS.long }).should("exist");
+    cy.dataCy("project-overview-content")
+      .contains("project is using the latest version of renku", { timeout: TIMEOUTS.vlong }).should("exist");
+
+    // verify the commits were added
+    commitFetched = false;
+    cy.getProjectPageLink(targetProject, "overview/commits").should("exist").click();
+    if (!commitFetched)
+      cy.dataCy("refresh-commits").should("exist").click();
+    cy.wait("@getCommits", { timeout: TIMEOUTS.long });
+    cy.dataCy("project-overview-content").get(".card-body ul li.commit-object")
+      .should("have.length.greaterThan", 1)
+    cy.dataCy("project-overview-content").get(".card-body ul li.commit-object")
+      .contains("migrate to latest version").should("exist");
 
     // delete the project
     if (projects.shouldFork)

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -1,0 +1,87 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { TIMEOUTS } from "../../config";
+
+
+const username = Cypress.env("TEST_USERNAME");
+
+const projectTestConfig = {
+  shouldCreateProject: true,
+  projectName: `test-session-${uuidv4().substring(24)}`
+};
+
+// ? Modify the config -- useful for debugging
+// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectName = "test-session-4f79daad6d4e";
+
+const projectIdentifier = { name: projectTestConfig.projectName, namespace: username };
+
+describe("Basic public project functionality", () => {
+  before(() => {
+    // Save all cookies across tests
+    Cypress.Cookies.defaults({
+      preserve: (_) => true,
+    });
+    // Register with the CI deployment
+    cy.robustLogin();
+
+    // Create a project
+    if (projectTestConfig.shouldCreateProject) {
+      cy.visit("/");
+      cy.createProject({ templateName: "Basic Python", ...projectIdentifier });
+    }
+  });
+
+  after(() => {
+    if (projectTestConfig.shouldCreateProject)
+      cy.deleteProject(projectIdentifier);
+  });
+
+  beforeEach(() => {
+    cy.visitAndLoadProject(projectIdentifier);
+  });
+
+  it("Start a new session on the project and interact with the terminal.", () => {
+    // Start a session with options
+    let serversInvoked = false;
+    cy.intercept("/ui-server/api/notebooks/servers*",  req => { serversInvoked = true; }).as("getServers");
+    cy.dataCy("project-overview-content")
+      .contains("your new Renku project", { timeout: TIMEOUTS.long }).should("exist");
+    cy.getProjectPageLink(projectIdentifier, "sessions").should("exist").click();
+    if (serversInvoked)
+      cy.wait("@getServers");
+    cy.getProjectPageLink(projectIdentifier, "sessions/new").should("exist").first().click();
+
+    // Wait for the image to be ready and start a session
+    cy.get(".renku-container").contains("A session gives you an environment").should("exist");
+    cy.get(".renku-container .badge.bg-success", { timeout: TIMEOUTS.vlong })
+      .contains("available").should("exist");
+    cy.get(".renku-container button.btn-rk-green", { timeout: TIMEOUTS.long })
+      .contains("Start session").should("exist").click();
+    cy.get(".progress-box .progress-title").should("exist"); //.contains("Step 2 of 2");
+    cy.get(".fullscreen-header").should("exist").contains(projectTestConfig.projectName).should("exist");
+    cy.get(".progress-box .progress-title").contains("Starting Session").should("exist");
+    cy.get(".progress-box .progress-title", { timeout: TIMEOUTS.vlong }).should("not.exist");
+
+    // Verify the "Connect" button works as well
+    cy.get(".fullscreen-header").should("exist").get(".fullscreen-back-button").contains("Back")
+      .should("exist").click();
+    cy.dataCy("open-session").should("exist").click();
+    cy.get(".progress-box .progress-title").contains("Starting Session").should("exist");
+
+    // run a simple workflow in the iframe
+    cy.getIframe("iframe#session-iframe").within(() => {
+      cy.get(".jp-Launcher-content", { timeout: TIMEOUTS.long }).should("exist");
+      cy.get(".jp-Launcher-section").should("exist");
+      cy.get('.jp-LauncherCard[title="Start a new terminal session"]').should("exist").click();
+      // TODO: use the terminal to execute a simple workflow
+      // ? /SwissDataScienceCenter/notebooks-cypress-tests/blob/main/cypress/support/commands/jupyterlab.ts
+    });
+
+    cy.dataCy("stop-session-button").should("exist").click();
+    cy.dataCy("stop-session-modal-button").should("exist").click();
+    cy.dataCy("stopping-btn").should("exist");
+    cy.get(".renku-container", { timeout: TIMEOUTS.long }).should("exist")
+      .contains("No currently running sessions").should("exist");
+  });
+});

--- a/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
+++ b/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
@@ -1,0 +1,39 @@
+
+/**
+ * Retry invoking a Cypress request until it succeeds or fail a few times in a row.
+ * @param url - target URL
+ * @param service - name of the tested service
+ * @param limit - maximum attempts before failing
+ * @param delaySeconds - delay between attempts
+ * @returns response body from the request or `null`
+ */
+function retryRequest(url: string, service: string, limit = 10, delaySeconds = 30, retries = 1): Cypress.Response<any> {
+  if (retries > limit) {
+    const minutes = Math.floor(limit * delaySeconds / 60);
+    throw new Error(`Backend service "${service}" not available within ${minutes} minutes at URL ${url}.`)
+  }
+
+  cy.request({
+    url,
+    failOnStatusCode: false
+  }).then(resp => {
+    if (resp.status < 400 && !resp.body.error)
+      return resp.body;
+    
+    cy.wait(delaySeconds * 1000).then(() => retryRequest(url, service, limit, delaySeconds, retries + 1));
+  });
+  return null;
+}
+
+describe("Verify the infrastructure is ready", () => {
+  it("Can interact with the backend components", () => {
+    retryRequest("api/templates/licenses", "GitLab");
+    retryRequest("api/renku/version", "Core");
+    retryRequest("api/notebooks/version", "Notebooks");
+    retryRequest("api/kg/spec.json", "Graph");
+    retryRequest("api/auth/login", "Gateway");
+    retryRequest("ui-server/api/allows-iframe/https%3A%2F%2Fgoogle.com", "UI server");
+    retryRequest("config.json", "UI client");
+    cy.visit("/");
+  });
+});


### PR DESCRIPTION
This PR extends and improves the Cypress acceptance tests in the following ways:
- Verifies the backend services availability _before_ starting the browser-based tests.
- Refreshes the "Update Projects" tests by using v9 projects and trying an actual update.
- Checks that all the steps to start and terminate sessions run properly.
- Improves the stability of the generic "Project" tests.

/deploy #persist #notest #cypress
re #2852