### PR TITLE
test(cypress): add session-specific test

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -134,9 +134,6 @@ jobs:
     needs: [check-deploy, deploy-pr]
     steps:
       - uses: actions/checkout@v3
-      - name: Wait for PR deployment to be ready
-        run: sleep 60s
-        shell: bash
       - uses: cypress-io/github-action@v5
         name: Run Cypress acceptance tests
         id: cypress

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -3,7 +3,11 @@ import { TIMEOUTS } from "./config";
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.BASE_URL || "https://dev.renku.ch"
+    baseUrl: process.env.BASE_URL || "https://dev.renku.ch",
+    specPattern: [
+      "cypress/e2e/verifyInfrastructure.cy.ts",
+      "cypress/e2e/*.{js,jsx,ts,tsx}"
+    ],
   },
   env: {
     TEST_EMAIL: process.env.TEST_EMAIL,

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -1,0 +1,87 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { TIMEOUTS } from "../../config";
+
+
+const username = Cypress.env("TEST_USERNAME");
+
+const projectTestConfig = {
+  shouldCreateProject: true,
+  projectName: `test-session-${uuidv4().substring(24)}`
+};
+
+// ? Modify the config -- useful for debugging
+// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectName = "test-session-4f79daad6d4e";
+
+const projectIdentifier = { name: projectTestConfig.projectName, namespace: username };
+
+describe("Basic public project functionality", () => {
+  before(() => {
+    // Save all cookies across tests
+    Cypress.Cookies.defaults({
+      preserve: (_) => true,
+    });
+    // Register with the CI deployment
+    cy.robustLogin();
+
+    // Create a project
+    if (projectTestConfig.shouldCreateProject) {
+      cy.visit("/");
+      cy.createProject({ templateName: "Basic Python", ...projectIdentifier });
+    }
+  });
+
+  after(() => {
+    if (projectTestConfig.shouldCreateProject)
+      cy.deleteProject(projectIdentifier);
+  });
+
+  beforeEach(() => {
+    cy.visitAndLoadProject(projectIdentifier);
+  });
+
+  it("Start a new session on the project and interact with the terminal.", () => {
+    // Start a session with options
+    let serversInvoked = false;
+    cy.intercept("/ui-server/api/notebooks/servers*",  req => { serversInvoked = true; }).as("getServers");
+    cy.dataCy("project-overview-content")
+      .contains("your new Renku project", { timeout: TIMEOUTS.long }).should("exist");
+    cy.getProjectPageLink(projectIdentifier, "sessions").should("exist").click();
+    if (serversInvoked)
+      cy.wait("@getServers");
+    cy.getProjectPageLink(projectIdentifier, "sessions/new").should("exist").first().click();
+
+    // Wait for the image to be ready and start a session
+    cy.get(".renku-container").contains("A session gives you an environment").should("exist");
+    cy.get(".renku-container .badge.bg-success", { timeout: TIMEOUTS.vlong })
+      .contains("available").should("exist");
+    cy.get(".renku-container button.btn-rk-green", { timeout: TIMEOUTS.long })
+      .contains("Start session").should("exist").click();
+    cy.get(".progress-box .progress-title").should("exist"); //.contains("Step 2 of 2");
+    cy.get(".fullscreen-header").should("exist").contains(projectTestConfig.projectName).should("exist");
+    cy.get(".progress-box .progress-title").contains("Starting Session").should("exist");
+    cy.get(".progress-box .progress-title", { timeout: TIMEOUTS.vlong }).should("not.exist");
+
+    // Verify the "Connect" button works as well
+    cy.get(".fullscreen-header").should("exist").get(".fullscreen-back-button").contains("Back")
+      .should("exist").click();
+    cy.dataCy("open-session").should("exist").click();
+    cy.get(".progress-box .progress-title").contains("Starting Session").should("exist");
+
+    // run a simple workflow in the iframe
+    cy.getIframe("iframe#session-iframe").within(() => {
+      cy.get(".jp-Launcher-content", { timeout: TIMEOUTS.long }).should("exist");
+      cy.get(".jp-Launcher-section").should("exist");
+      cy.get('.jp-LauncherCard[title="Start a new terminal session"]').should("exist").click();
+      // TODO: use the terminal to execute a simple workflow
+      // ? /SwissDataScienceCenter/notebooks-cypress-tests/blob/main/cypress/support/commands/jupyterlab.ts
+    });
+
+    cy.dataCy("stop-session-button").should("exist").click();
+    cy.dataCy("stop-session-modal-button").should("exist").click();
+    cy.dataCy("stopping-btn").should("exist");
+    cy.get(".renku-container", { timeout: TIMEOUTS.long }).should("exist")
+      .contains("No currently running sessions").should("exist");
+  });
+});

--- a/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
+++ b/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
@@ -1,0 +1,39 @@
+
+/**
+ * Retry invoking a Cypress request until it succeeds or fail a few times in a row.
+ * @param url - target URL
+ * @param service - name of the tested service
+ * @param limit - maximum attempts before failing
+ * @param delaySeconds - delay between attempts
+ * @returns response body from the request or `null`
+ */
+function retryRequest(url: string, service: string, limit = 10, delaySeconds = 30, retries = 1): Cypress.Response<any> {
+  if (retries > limit) {
+    const minutes = Math.floor(limit * delaySeconds / 60);
+    throw new Error(`Backend service "${service}" not available within ${minutes} minutes at URL ${url}.`)
+  }
+
+  cy.request({
+    url,
+    failOnStatusCode: false
+  }).then(resp => {
+    if (resp.status < 400 && !resp.body.error)
+      return resp.body;
+    
+    cy.wait(delaySeconds * 1000).then(() => retryRequest(url, service, limit, delaySeconds, retries + 1));
+  });
+  return null;
+}
+
+describe("Verify the infrastructure is ready", () => {
+  it("Can interact with the backend components", () => {
+    retryRequest("api/templates/licenses", "GitLab");
+    retryRequest("api/renku/version", "Core");
+    retryRequest("api/notebooks/version", "Notebooks");
+    retryRequest("api/kg/spec.json", "Graph");
+    retryRequest("api/auth/login", "Gateway");
+    retryRequest("ui-server/api/allows-iframe/https%3A%2F%2Fgoogle.com", "UI server");
+    retryRequest("config.json", "UI client");
+    cy.visit("/");
+  });
+});


### PR DESCRIPTION
This PR extends the Cypress acceptance tests with a new test to verify that starting and terminating a session goes through the expected steps. There is also minimal interaction inside a JupyterLab environment.
This addresses the first part of #2852 but it doesn't tests workflows yet -- to be expanded.

/deploy #persist #notest #cypress
re #2852