### PR TITLE
Add CHANGELOG-template.rst

### DIFF
--- a/CHANGELOG-template.rst
+++ b/CHANGELOG-template.rst
@@ -1,0 +1,35 @@
+0.XX.0
+------
+
+Renku ``0.XX.0`` introduces ...
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🌟 New Features**
+
+- 🐸 **Team**: changelog item with emoji, ordered by importance to users
+
+**✨ Improvements**
+
+- 🐸 **Team**: changelog item with emoji, alphabetized by team name
+
+**🐞 Bug Fixes**
+
+- 🐸 **Team**: changelog item with emoji, alphabetized by team name
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Improvements**
+
+- **Team**: changelog item, alphabetized by team name
+
+**Bug Fixes**
+
+- **Team**: changelog item, alphabetized by team name
+
+Individual components
+~~~~~~~~~~~~~~~~~~~~~~
+
+- component links, alphabetized by team name

--- a/CHANGELOG-template.rst
+++ b/CHANGELOG-template.rst
@@ -16,7 +16,7 @@ User-Facing Changes
 
 **🐞 Bug Fixes**
 
-- 🐸 **Team**: changelog item with emoji, alphabetized by team name
+- **Team**: changelog item, alphabetized by team name
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,6 +104,11 @@ Internal Changes
 
 **Improvements**
 
+* **Core Service**: Metadata v10 support
+* **Knowledge Graph** Add support for the new Renku Metadata Schema v10.
+* **Knowledge Graph** Enable the Cross-Entity Search API to allow multiple sort parameters.
+* **Knowledge Graph** Remove deprecated GraphQL API
+* **Knowledge Graph**: Upgrade Jena to 4.7.0
 * **Sessions**: Show if ssh is enabled in /version of notebook service
   (`#1407 <https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1407>`_).
 * **Sessions**: Introduce experimental Azure Blob storage support
@@ -116,16 +121,6 @@ Internal Changes
 * **Sessions**: Cloning the correct SHA for anonymous user sessions
   (`#1406 <https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1406>`_).
 
-Internal Changes
-~~~~~~~~~~~~~~~~
-
-**Improvements**
-
-* **Knowledge Graph** Add support for the new Renku Metadata Schema v10.
-* **Knowledge Graph** Enable the Cross-Entity Search API to allow multiple sort parameters.
-* **Knowledge Graph** Remove deprecated GraphQL API
-* **Knowledge Graph**: Upgrade Jena to 4.7.0
-* **Core Service**: Metadata v10 support
 
 Individual components
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -208,19 +208,6 @@ Internal Changes
 * **Sessions**: Cloning the correct SHA for anonymous user sessions
   (`#1406 <https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1406>`_).
 
-<<<<<<< HEAD
-=======
-Internal Changes
-~~~~~~~~~~~~~~~~
-
-**Improvements**
-
-* **Core Service**: Metadata v10 support
-* **Knowledge Graph**: Add support for the new Renku Metadata Schema v10.
-* **Knowledge Graph**: Enable the Cross-Entity Search API to allow multiple sort parameters.
-* **Knowledge Graph**: Remove deprecated GraphQL API
-* **Knowledge Graph**: Upgrade Jena to 4.7.0
->>>>>>> master
 
 Individual components
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@ information.
 they want, the schedule is up to them. They are responsible for updating the
 `CHANGELOG.rst` file in the auto-PR in the Renku repository.
 Please create a new section above the last release if no one has already done it.
+Please follow the `CHANGELOG-template.rst` for formatting and ordering the changelog.
 The auto-PRs **must** be merged with an updated changelog/release notes. If upgrading
 a service will knowingly result in an extended outage (e.g. because of a DB migration)
 this *must* be clearly noted and highlighted in the release notes. Use emojis freely.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinxcontrib.mermaid",
-    "sphinxcontrib.spelling",
+    # "sphinxcontrib.spelling",
 ]
 
 # Plantweb configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinxcontrib.mermaid",
-    # "sphinxcontrib.spelling",
+    "sphinxcontrib.spelling",
 ]
 
 # Plantweb configuration


### PR DESCRIPTION
Added a template for the `CHANGELOG.rst`, so it's clear how the changelog should be formatted, and you don't have to put together a hodgepodge of copy-pasting to assemble each new changelog entry.

Also fixed a small CHANGELOG formatting mishap I noticed, in which `0.24.0` had 2 "Internal Changes" sections.