### PR TITLE
chore: add load tests helm chart

### DIFF
--- a/helm-chart/load-tests/.helmignore
+++ b/helm-chart/load-tests/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/load-tests/Chart.yaml
+++ b/helm-chart/load-tests/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: load-tests
+description: Load tests for Renku
+type: application
+version: 0.0.1
+appVersion: "0.0.1"

--- a/helm-chart/load-tests/templates/_helpers.tpl
+++ b/helm-chart/load-tests/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "load-tests.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "load-tests.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "load-tests.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "load-tests.labels" -}}
+helm.sh/chart: {{ include "load-tests.chart" . }}
+{{ include "load-tests.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "load-tests.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "load-tests.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "load-tests.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "load-tests.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart/load-tests/templates/cronjob.yaml
+++ b/helm-chart/load-tests/templates/cronjob.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "load-tests.fullname" . }}
+  labels:
+    {{- include "load-tests.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule }}
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "load-tests.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "load-tests.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              env:
+                {{- if gt (len .Values.extraEnvVars) 0 }}
+                {{- toYaml .Values.extraEnvVars | nindent 16 }}
+                {{- end }}
+                {{- if .Values.credentials.secret.mount }}
+                - name: CREDENTIALS_FILE
+                  value: "/credentials/{{ .Values.credentials.secret.secretKey }}"
+                {{- end }}
+              {{- if .Values.credentials.secret.mount }}
+              volumeMounts:
+                - name: credentials         
+                  mountPath: "/credentials"
+                  readOnly: true
+              {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.credentials.secret.mount }}
+          volumes:
+            - name: credentials         
+              secret:
+                secretName: {{ .Values.credentials.secret.secretName | quote }}
+          {{- end }}

--- a/helm-chart/load-tests/templates/serviceaccount.yaml
+++ b/helm-chart/load-tests/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "load-tests.serviceAccountName" . }}
+  labels:
+    {{- include "load-tests.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/load-tests/values.yaml
+++ b/helm-chart/load-tests/values.yaml
@@ -1,0 +1,62 @@
+# Default values for load-tests.
+
+image:
+  repository: renku/load-tests
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.0.1"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+schedule: "0 3 * * *"
+
+extraEnvVars: []
+  # - name: "K6_PROMETHEUS_RW_SERVER_URL"
+  #   value: "http://prometheus-server"
+
+credentials:
+  secret:
+    # Mount the credentials from a k8s secret
+    mount: false
+    secretName: "credentials-secret-name"
+    secretKey: "credentials.json"

--- a/helm-chart/load-tests/values.yaml
+++ b/helm-chart/load-tests/values.yaml
@@ -51,8 +51,23 @@ affinity: {}
 schedule: "0 3 * * *"
 
 extraEnvVars: []
+  ## Any K6 config environment variable can be specified here, for example:
   # - name: "K6_PROMETHEUS_RW_SERVER_URL"
   #   value: "http://prometheus-server"
+  ## In addition to K6 config environment variables, additional environment variables can be set.
+  ## These variables can override defaults in the configuration of the load tests. Here are variables can be used for this purpose:
+  # - name: "BASE_URL"  # the url of the Renku deployment
+  #   value: "https://dev.renku.ch"
+  # - name: "GIT_URL"  # the url of the Gitlab deployment Renku is using
+  #   value: "https://gitlab.dev.renku.ch"
+  # - name: "REGISTRY_DOMAIN"  # the domain for Gitlab's docker image registry
+  #   value: "repository.dev.renku.ch"
+  # - name: "CREDENTIALS_FILE"  # used to log into Renku and run the tests
+  #   value: "/credentials.json"
+  # - name: "OLD_RENKU_TEMPLATE_REF"  # the version of the old Renku template used to test migrations
+  #   value: "0.4.0"
+  # - name: "CONCURRENT_USERS"  # number of concurrent virtual users for the load tests - higher values mean higher load
+  #   value: "3"
 
 credentials:
   secret:

--- a/load-tests/.dockerignore
+++ b/load-tests/.dockerignore
@@ -1,0 +1,3 @@
+credentials.json
+.gitignore
+chartpress.yaml

--- a/load-tests/.gitignore
+++ b/load-tests/.gitignore
@@ -1,0 +1,1 @@
+credentials.json

--- a/load-tests/Dockerfile
+++ b/load-tests/Dockerfile
@@ -1,0 +1,6 @@
+FROM grafana/k6:0.43.1
+USER 1000:1000
+WORKDIR /app
+COPY . .
+ENTRYPOINT [ "/bin/sh" ]
+CMD [ "entrypoint.sh" ]

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,15 @@
+# Load testing with k6
+
+## To run
+
+1. Download k6: https://k6.io/docs/get-started/installation/ - you can also get a binary from the github page
+2. Enter the credentials for logging in in a file named `credentials.json`, you can
+   use the `credentials.examples.json` to start - just make a copy and rename it.
+3. Run the tests with `k6 run -e BASE_URL=https://dev.renku.ch -e GIT_URL="https://gitlab.dev.renku.ch" -e CREDENTIALS_FILE=./credentials.json -e REGISTRY_DOMAIN=registry.dev.renku.ch scenarioLecture.js`
+
+## Limitations
+
+- This can log into Renku only and specifically in the cases where Renku has its own built-in gitlab that does
+  not require a separate log in OR when the gitlab deployment is part of another renku deployment
+- The login flow cannot handle giving authorization when prompted in the oauth flow - do this
+  for the first time manually then run the tests with the same account

--- a/load-tests/chartpress.yaml
+++ b/load-tests/chartpress.yaml
@@ -1,0 +1,18 @@
+charts:
+  - name: ../helm-chart/load-tests
+    resetTag: latest
+    imagePrefix: load-tests/
+    repo:
+      git: SwissDataScienceCenter/helm-charts
+      published: https://swissdatasciencecenter.github.io/helm-charts
+    paths:
+      - ../helm-chart/load-tests
+    images:
+      load-tests:
+        buildArgs:
+          BUILDKIT_INLINE_CACHE: "1"
+        contextPath: ./
+        dockerfilePath: ./Dockerfile
+        valuesPath: image
+        paths:
+          - ./

--- a/load-tests/config.js
+++ b/load-tests/config.js
@@ -1,16 +1,8 @@
-function getEnv(name) {
-  let val = __ENV[name];
-  if ((val === undefined) || (val === null)) {
-      throw new Error("missing env var for " + name);
-  }
-  return val;
-}
-
-export const baseUrl = getEnv("BASE_URL");
-export const gitUrl = getEnv("GIT_URL");
-export const registryDomain = getEnv("REGISTRY_DOMAIN");
+export const baseUrl = __ENV["BASE_URL"] || "https://dev.renku.ch";
+export const gitUrl = __ENV["GIT_URL"] || "https://gitlab.dev.renku.ch";
+export const registryDomain = __ENV["REGISTRY_DOMAIN"] || "repository.dev.renku.ch";
 export const oldRenkuTemplateRef = __ENV["OLD_RENKU_TEMPLATE_REF"] || "0.4.0";
 export const concurentUsers = __ENV["CONCURRENT_USERS"] || "3";
 
-const credentialsFile = getEnv("CREDENTIALS_FILE");
+const credentialsFile = __ENV["CREDENTIALS_FILE"] || "/credentials.json";
 export const credentials = JSON.parse(open(credentialsFile));

--- a/load-tests/config.js
+++ b/load-tests/config.js
@@ -1,0 +1,16 @@
+function getEnv(name) {
+  let val = __ENV[name];
+  if ((val === undefined) || (val === null)) {
+      throw new Error("missing env var for " + name);
+  }
+  return val;
+}
+
+export const baseUrl = getEnv("BASE_URL");
+export const gitUrl = getEnv("GIT_URL");
+export const registryDomain = getEnv("REGISTRY_DOMAIN");
+export const oldRenkuTemplateRef = __ENV["OLD_RENKU_TEMPLATE_REF"] || "0.4.0";
+export const concurentUsers = __ENV["CONCURRENT_USERS"] || "3";
+
+const credentialsFile = getEnv("CREDENTIALS_FILE");
+export const credentials = JSON.parse(open(credentialsFile));

--- a/load-tests/credentials.example.json
+++ b/load-tests/credentials.example.json
@@ -1,0 +1,22 @@
+[
+  [
+    {
+      "username": "first-userA@email.com",
+      "password": "first-secret-password-for-userA"
+    },
+    {
+      "username": "second-userA@email.com",
+      "password": "second-secret-password-for-userA"
+    }
+  ],
+  [
+    {
+      "username": "first-userB@email.com",
+      "password": "first-secret-password-for-userB"
+    },
+    {
+      "username": "second-userB@email.com",
+      "password": "second-secret-password-for-userB"
+    }
+  ]
+]

--- a/load-tests/entrypoint.sh
+++ b/load-tests/entrypoint.sh
@@ -1,0 +1,4 @@
+k6 run --include-system-env-vars -o experimental-prometheus-rw scenarioCoreRequests.js
+k6 run --include-system-env-vars -o experimental-prometheus-rw scenarioFileUpload.js
+k6 run --include-system-env-vars -o experimental-prometheus-rw scenarioLecture.js
+k6 run --include-system-env-vars -o experimental-prometheus-rw scenarioProjectMigration.js

--- a/load-tests/scenarioCoreRequests.js
+++ b/load-tests/scenarioCoreRequests.js
@@ -1,0 +1,57 @@
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+import { renkuLogin } from "./utils/oauth.js";
+import { getRandomInt } from "./utils/general.js";
+import { createProject, getTemplates, projectInfo } from "./utils/core.js";
+import { credentials, baseUrl, gitUrl, concurentUsers } from "./config.js";
+import { deleteProjectByName } from "./utils/git.js";
+
+export const options = {
+  scenarios: {
+    coreRequests: {
+      executor: "per-vu-iterations",
+      vus: concurentUsers,
+      iterations: 1,
+    },
+  },
+};
+
+export default function test() {
+  const uuid = uuidv4();
+  const ramdomCredentials = credentials[getRandomInt(0, credentials.length)];
+  const namespace = ramdomCredentials[ramdomCredentials.length - 1].username.split("@")[0]
+  let repoUrl;
+
+  describe("Create a project and show info with the core service", () => {
+    describe("user should login", () => {
+      renkuLogin(baseUrl, ramdomCredentials);
+    });
+    describe("user should be able to get templates", () => {
+      const res = getTemplates(baseUrl);
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+      expect(res.json(), 'response').to.have.nested.property("result.templates");
+      expect(res.json().result.templates, 'templates list to contain at least one element').to.satisfy((templates) => templates.length > 0);
+    });
+    describe("should create a project", () => {
+      const res = createProject(baseUrl, gitUrl, "python-minimal", uuid, namespace);
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+      expect(res.json(), 'response').to.have.nested.property("result.url");
+      repoUrl = res.json().result.url;
+    });
+    describe("should show information about created project", () => {
+      const res = projectInfo(baseUrl, repoUrl);
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+    });
+    describe("should delete the project", () => {
+      const res = deleteProjectByName(baseUrl, namespace + "/" + uuid)
+      expect(res.status, 'response status').to.equal(202);
+    });
+  });
+}

--- a/load-tests/scenarioFileUpload.js
+++ b/load-tests/scenarioFileUpload.js
@@ -1,0 +1,45 @@
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+import { renkuLogin } from "./utils/oauth.js";
+import { getRandomInt } from "./utils/general.js";
+import { uploadRandomFile } from "./utils/core.js";
+import { credentials, baseUrl, concurentUsers } from "./config.js";
+
+export const options = {
+  scenarios: {
+    testUploads: {
+      executor: "per-vu-iterations",
+      vus: concurentUsers,
+      iterations: 1,
+    },
+  },
+};
+
+export default function test() {
+  const uuid = uuidv4();
+  const ramdomCredentials = credentials[getRandomInt(0, credentials.length)];
+  const fileName = `${uuid}.bin`;
+  const numChunks = 100
+  const chunkSizeBytes = 1e6
+
+  describe("file upload load test scenario", () => {
+    describe("user should login", () => {
+      renkuLogin(baseUrl, ramdomCredentials);
+    });
+    describe("file should upload", () => {
+      const fileUploadResponses = uploadRandomFile(
+        baseUrl,
+        uuid,
+        fileName,
+        numChunks,
+        chunkSizeBytes,
+      );
+      expect(fileUploadResponses, "responses").to.have.lengthOf(numChunks);
+      expect(fileUploadResponses, "responses to all have status codes 200").to.satisfy((responses) => responses.every((res) => res.status === 200));
+      expect(fileUploadResponses, "responses to all not have errors").to.satisfy((responses) => responses.every((res) => res.json().error === undefined));
+      const lastResponse = fileUploadResponses[fileUploadResponses.length - 1]
+      expect(lastResponse.json(), "last response").to.have.nested.property("result.files[0].file_name", fileName);
+    });
+  });
+}

--- a/load-tests/scenarioLecture.js
+++ b/load-tests/scenarioLecture.js
@@ -1,0 +1,86 @@
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+import { Trend } from "k6/metrics";
+import { sleep } from "k6";
+
+import { renkuLogin } from "./utils/oauth.js";
+import { getRandomInt } from "./utils/general.js";
+import { getCommitShasFromProjectName, deleteProjectByName } from "./utils/git.js";
+import { createProject } from "./utils/core.js";
+import { startServer, waitForServerState, getServer, stopServer, waitForImageToBuild } from "./utils/servers.js";
+import { credentials, baseUrl, gitUrl, registryDomain, concurentUsers } from "./config.js";
+
+export const options = {
+  scenarios: {
+    lecture: {
+      executor: "per-vu-iterations",
+      vus: concurentUsers, // tested up to 30
+      iterations: 1,
+      maxDuration: '30m',
+      gracefulStop: '2m',
+    },
+  },
+};
+
+// k6 custom metrics
+const sessionStartupDuration = new Trend("session_startup_duration", true);
+
+// Test code
+export default function test() {
+  let commitSha, server;
+  const uuid = uuidv4();
+  const ramdomCredentials = credentials[getRandomInt(0, credentials.length)];
+  const namespace = ramdomCredentials[ramdomCredentials.length - 1].username.split("@")[0]
+
+  describe("class load test scenario", () => {
+    describe("user should login", ()=> {
+      renkuLogin(baseUrl, ramdomCredentials);
+    });
+    describe("should create a project", () => {
+      const res = createProject(baseUrl, gitUrl, "python-minimal", uuid, namespace);
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+    });
+    describe("should get the project commit sha", () => {
+      const res = getCommitShasFromProjectName(baseUrl, namespace + "/" + uuid)
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'json response').to.have.nested.property("[0].id");
+      commitSha = res.json()[0].id
+    });
+    describe("should wait for the image to build", () => {
+      const res = waitForImageToBuild(baseUrl, registryDomain, namespace, uuid, commitSha);
+      expect(res.imageBuilt, ".imageBuild in response").to.be.true;
+    });
+    describe("should launch session", () => {
+      const res = startServer(baseUrl, commitSha, namespace, uuid);
+      expect(res.status, "response status").to.equal(201);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), "response").to.have.property("name")
+      server = res.json()
+    });
+    describe("should wait for server to become ready", () => {
+      const res = waitForServerState(baseUrl, server.name, "running")
+      expect(res.stateAchieved, ".stateAchieved in response").to.be.true;
+      expect(res.lastResponse.status, "last state check response status code").to.equal(200);
+      sessionStartupDuration.add(res.durationSeconds * 1000)
+    });
+    describe("should query the server 10 times", () => {
+      for (let i = 0; i < 10; i++) {
+        const res = getServer(baseUrl, server.name);
+        expect(res.status, 'response status').to.equal(200);
+        expect(res).to.have.validJsonBody();
+        sleep(1)
+      }
+    });
+    describe("should stop the server", () => {
+      const res = stopServer(baseUrl, server.name);
+      expect(res.status, 'response status').to.equal(204);
+    });
+    describe("should delete the project", () => {
+      const res = deleteProjectByName(baseUrl, namespace + "/" + uuid)
+      expect(res.status, 'response status').to.equal(202);
+    });
+  });
+}

--- a/load-tests/scenarioProjectMigration.js
+++ b/load-tests/scenarioProjectMigration.js
@@ -1,0 +1,50 @@
+import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+
+import { renkuLogin } from "./utils/oauth.js";
+import { getRandomInt } from "./utils/general.js";
+import { createProject, migrateProject } from "./utils/core.js";
+import { credentials, baseUrl, gitUrl, oldRenkuTemplateRef, concurentUsers } from "./config.js";
+import { deleteProjectByName } from "./utils/git.js";
+
+export const options = {
+  scenarios: {
+    testUploads: {
+      executor: "per-vu-iterations",
+      vus: concurentUsers,
+      iterations: 1,
+    },
+  },
+};
+
+export default function test() {
+  const uuid = uuidv4();
+  const ramdomCredentials = credentials[getRandomInt(0, credentials.length)];
+  const namespace = ramdomCredentials[ramdomCredentials.length - 1].username.split("@")[0]
+  let repoUrl;
+
+  describe("Create a project and show info with the core service", () => {
+    describe("user should login", () => {
+      renkuLogin(baseUrl, ramdomCredentials);
+    });
+    describe("should create a project from an old template", () => {
+      const res = createProject(baseUrl, gitUrl, "python", uuid, namespace, oldRenkuTemplateRef);
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+      expect(res.json(), 'response').to.have.nested.property("result.url");
+      repoUrl = res.json().result.url;
+    });
+    describe("should be able to migrate the project", () => {
+      const res = migrateProject(baseUrl, repoUrl)
+      expect(res.status, 'response status').to.equal(200);
+      expect(res).to.have.validJsonBody();
+      expect(res.json(), 'response').to.not.have.property("error");
+      expect(res.json(), 'response').to.have.nested.property("result.docker_migrated", true);
+    });
+    describe("should delete the project", () => {
+      const res = deleteProjectByName(baseUrl, namespace + "/" + uuid)
+      expect(res.status, 'response status').to.equal(202);
+    });
+  });
+}

--- a/load-tests/utils/core.js
+++ b/load-tests/utils/core.js
@@ -1,0 +1,91 @@
+import http from "k6/http";
+import { Trend } from "k6/metrics";
+import { URL } from "https://jslib.k6.io/url/1.0.0/index.js";
+import crypto from "k6/crypto";
+
+const coreHttpReqDuration = new Trend("http_req_duration_core", true);
+
+export function createProject(baseUrl, repoUrl, templateId, projectName, projectNamespace, ref = null) {
+  const payload = {
+    project_repository: repoUrl,
+    project_namespace: projectNamespace,
+    project_name: projectName,
+    identifier: templateId,
+    url: "https://github.com/SwissDataScienceCenter/renku-project-template",
+    ref: ref,
+  };
+  let res = http.post(
+    `${baseUrl}/ui-server/api/renku/templates.create_project`,
+    JSON.stringify(payload),
+    { headers: { "Content-Type": "application/json" } },
+  );
+  coreHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function migrateProject(baseUrl, repoUrl) {
+  const migratePayload = {
+    force_template_update: true,
+    git_url: repoUrl,
+    is_delayed: false,
+    skip_docker_update: false,
+    skip_migrations: false,
+    skip_template_update: false,
+  };
+  const res = http.post(
+    `${baseUrl}/ui-server/api/renku/cache.migrate`,
+    JSON.stringify(migratePayload),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  coreHttpReqDuration.add(res.timings.duration)
+  return res
+}
+
+export function projectInfo(baseUrl, repoUrl) {
+  const payload = {
+    git_url: repoUrl,
+    is_delayed: false,
+    migrate_project: false,
+  };
+  const res = http.post(
+    `${baseUrl}/ui-server/api/renku/project.show`,
+    JSON.stringify(payload),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  coreHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function getTemplates(baseUrl, ref=null) {
+  let res = http.get(
+    `${baseUrl}/ui-server/api/renku/templates.read_manifest?url=https%3A%2F%2Fgithub.com%2FSwissDataScienceCenter%2Frenku-project-template`
+  );
+  if (ref) res = res + `&ref=${ref}`;
+  coreHttpReqDuration.add(res.timings.duration)
+  return res
+}
+
+export function uploadRandomFile(baseUrl, uuid, fileName, numChunks, chunkSizeBytes) {
+  const responses = [];
+  for (let i = 0; i < numChunks; i++) {
+    const url = new URL(`ui-server/api/renku/cache.files_upload`, baseUrl);
+    url.searchParams.append("dzuuid", uuid);
+    url.searchParams.append("dzchunkindex", i);
+    url.searchParams.append("dztotalfilesize", numChunks * chunkSizeBytes);
+    url.searchParams.append("dzchunksize", chunkSizeBytes);
+    url.searchParams.append("dztotalchunkcount", numChunks);
+    url.searchParams.append("dzchunkbyteoffset", i * chunkSizeBytes);
+    url.searchParams.append("chunked_content_type", "application/octet-stream");
+    const res = http.post(url.toString(), {
+      file: http.file(
+        crypto.randomBytes(chunkSizeBytes),
+        fileName,
+        "application/octet-stream"
+      ),
+    });
+    coreHttpReqDuration.add(res.timings.duration)
+    responses.push(res);
+  }
+  console.log(responses.length)
+  return responses;
+}

--- a/load-tests/utils/general.js
+++ b/load-tests/utils/general.js
@@ -1,0 +1,3 @@
+export function getRandomInt(min, maxExclusive) {
+  return min + Math.floor(Math.random() * maxExclusive);
+}

--- a/load-tests/utils/git.js
+++ b/load-tests/utils/git.js
@@ -1,0 +1,65 @@
+import http from "k6/http";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { Trend } from "k6/metrics";
+
+const gitHttpReqDuration = new Trend("http_req_duration_git", true);
+
+export function deleteProjectById(baseUrl, projectId) {
+  const res = http.del(`${baseUrl}/ui-server/api/projects/${projectId}`)
+  gitHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function deleteProjectByName(baseUrl, namespace_name) {
+  const res = http.del(`${baseUrl}/ui-server/api/projects/${encodeURIComponent(namespace_name)}`)
+  gitHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function getCommitShasFromProjectId(baseUrl, projectId) {
+  const res = http.get(
+    `${baseUrl}/ui-server/api/projects/${projectId}/repository/commits`
+  );
+  gitHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function getCommitShasFromProjectName(baseUrl, namespace_name) {
+  const res = http.get(
+    `${baseUrl}/ui-server/api/projects/${encodeURIComponent(namespace_name)}/repository/commits`
+  );
+  gitHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function getGitProjectInfo(baseUrl, projectId) {
+  let projectData = http.get(
+    `${baseUrl}/ui-server/api/projects/${projectId}`
+  );
+  gitHttpReqDuration.add(projectData.timings.duration)
+  return projectData
+}
+
+export function forkProject(baseUrl, projectId) {
+  const uuid = uuidv4();
+  let projectData = getGitProjectInfo(baseUrl, projectId)
+  check(projectData, {
+    "response code for getting project info was 2XX": (res) =>
+      res.status >= 200 && res.status < 300,
+  });
+  projectData = projectData.json();
+  let forkName = `test-forked-project-${uuid}`;
+  const payload = {
+    id: gitlabProjectId,
+    name: forkName,
+    namespace_id: projectData.namespace.id,
+    path: forkName,
+    visibility: projectData.visibility,
+  };
+  let forkRes = http.post(
+    `${baseUrl}/ui-server/api/projects/${gitlabProjectId}/fork`,
+    payload
+  );
+  gitHttpReqDuration.add(forkRes.timings.duration)
+  return forkRes;
+}

--- a/load-tests/utils/oauth.js
+++ b/load-tests/utils/oauth.js
@@ -1,0 +1,64 @@
+import http from 'k6/http';
+import { parseHTML } from 'k6/html';
+import { Trend } from "k6/metrics";
+
+const loginHttpReqDuration = new Trend("http_req_duration_login", true);
+
+function handleRenkuLoginForm(httpResponse, username, password) {
+  const doc = parseHTML(httpResponse.body);
+  const actionUrl = doc.find('#kc-form-login').attr('action');
+  if (!actionUrl) {
+    throw new Error(`Could not locate login form in http response ${httpResponse.body}`)
+  }
+  const loginData = {
+    username,
+    password,
+    credentialId: '',
+  };
+  const res = http.post(actionUrl, loginData)
+  loginHttpReqDuration.add(res.timings.duration)
+  return res
+}
+
+function followRedirectLinkFromHtml(httpResponse) {
+  const doc = parseHTML(httpResponse.body);
+  let url = doc.find('a').attr("href")
+  if (!url) {
+    throw new Error(`Could not find <a> element with href attribute in ${httpResponse.body}`)
+  }
+  if (url.endsWith("/")) {
+    // leaving trailing slashes here results in 404
+    url = url.slice(0,-1)
+  }
+  return http.get(url)
+}
+
+export function renkuLogin(baseUrl, credentials) {
+  // double slashes when composing url causes trouble and 404s
+  if (baseUrl.endsWith("/")) {
+    baseUrl = baseUrl.slice(0,-1)
+  }
+  // the trailing slash is needed here keycloak accepts only such and longer callbacks
+  const redirectUrl = `${baseUrl}/`
+  let finalResponse = null
+  const res1 = http.get(`${baseUrl}/ui-server/auth/login?redirect_url=${redirectUrl}"`)
+  loginHttpReqDuration.add(res1.timings.duration)
+  const res2 = handleRenkuLoginForm(res1, credentials[0].username, credentials[0].password)
+  loginHttpReqDuration.add(res2.timings.duration)
+  const res3 = followRedirectLinkFromHtml(res2)
+  loginHttpReqDuration.add(res3.timings.duration)
+  if (res3.body.match(".*redirect.*|.*Redirect.*") && parseHTML(res3.body).find("a").toArray().length > 0) {
+    // no more login forms just follow a single last redirect
+    finalResponse = followRedirectLinkFromHtml(res3)
+  }
+  else if (parseHTML(res3.body).find('#kc-form-login').toArray().length > 0) {
+    // one more login required, usually happens for ci and similar deployments that do not have their own gitlab
+    const res4 = handleRenkuLoginForm(res3, credentials[1].username, credentials[1].password)
+    loginHttpReqDuration.add(res4.timings.duration)
+    finalResponse = followRedirectLinkFromHtml(res4)
+    loginHttpReqDuration.add(finalResponse.timings.duration)
+  }
+  if (finalResponse.status != 200) {
+    throw new Error(`Could not successfully login, expected status code 200 but got ${finalResponse.status}`)
+  }
+}

--- a/load-tests/utils/servers.js
+++ b/load-tests/utils/servers.js
@@ -1,0 +1,77 @@
+import http from "k6/http";
+import { Trend } from "k6/metrics";
+import { sleep } from "k6";
+
+const notebooksGetHttpReqDuration = new Trend("http_req_duration_get_notebooks", true);
+const notebooksGetImagesHttpReqDuration = new Trend("http_req_duration_get_notebooks_images", true);
+const notebooksPostHttpReqDuration = new Trend("http_req_duration_post_notebooks", true);
+const notebooksDeleteHttpReqDuration = new Trend("http_req_duration_delete_notebooks", true);
+
+export function stopServer(baseUrl, serverName) {
+  const res = http.del(
+    `${baseUrl}/ui-server/api/notebooks/servers/${serverName}`
+  )
+  notebooksDeleteHttpReqDuration.add(res.timings.duration)
+  return res;
+}
+
+export function getServer(baseUrl, serverName) {
+  const res = http.get(`${baseUrl}/ui-server/api/notebooks/servers/${serverName}`);
+  notebooksGetHttpReqDuration.add(res.timings.duration)
+  return res
+}
+
+export function startServer(baseUrl, commitSha, namespace, projectName, serverOptions = {}) {
+  const payload = {
+    commit_sha: commitSha,
+    namespace: namespace,
+    project: projectName,
+    serverOptions: serverOptions,
+  };
+
+  const res = http.post(
+    `${baseUrl}/ui-server/api/notebooks/servers`,
+    JSON.stringify(payload),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  notebooksPostHttpReqDuration.add(res.timings.duration)
+  return res
+}
+
+export function waitForServerState(baseUrl, serverName, state, secondsTimeout = 600, callback = null) {
+  let resJson, res;
+  const start = Date.now();
+  do {
+    sleep(1);
+    res = getServer(baseUrl, serverName)
+    notebooksGetHttpReqDuration.add(res.timings.duration)
+    resJson = res.json()
+    if (callback) {
+      callback(res)
+    }
+    if ((Date.now() - start) / 1000 > secondsTimeout) {
+      break;
+    }
+  } while (
+    resJson.status === undefined ||
+    resJson.status.state != state
+  );
+  return { lastResponse: res, stateAchieved: resJson.status.state == state, durationSeconds: (Date.now() - start) / 1000 };
+}
+
+export function waitForImageToBuild(baseUrl, registryDomain, namespace, name, commitSha, secondsTimeout = 600) {
+  const imageName = `${registryDomain}/${namespace}/${name}:${commitSha.substring(0, 7)}`
+  let res;
+  const start = Date.now();
+  do {
+    sleep(1);
+    res = http.get(`${baseUrl}/ui-server/api/notebooks/images?image_url=${encodeURIComponent(imageName)}`)
+    notebooksGetImagesHttpReqDuration.add(res.timings.duration)
+    if ((Date.now() - start) / 1000 > secondsTimeout) {
+      break;
+    }
+  } while (
+    res.status != 200
+  );
+  return { imageBuilt: res.status == 200, durationSeconds: (Date.now() - start) / 1000 };
+}


### PR DESCRIPTION
This combines pre-existing load tests that existed mostly in the renku-python repo, puts them all in one place (here in this repo), updates the tests to use the chai-like describe/expect syntax and adds a helm chart for the load tests.

In addition to tests can be setup to publish their metrics to prometheus.

See existing metrics at https://grafana.dev.renku.ch. All metrics from k6 start with the name `k6`.

The idea is that the cronjob would run nightly on the dev cluster.

Once this is merged and the helm chart is published I will make a PR in the dev ops repo to deploy this. The existing results are only from running the tests a few times.