### PR TITLE
chore: change auto-pr action to create proper PR body for renku pre-releases

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: close existing PRs
+        id: close_prs
         run: |
           renku_repo="https://api.github.com/repos/SwissDataScienceCenter/renku"
           # find the repo that made the PR
@@ -17,6 +18,17 @@ jobs:
           # find other PRs from that repo
           other_prs=$(curl -s ${renku_repo}/pulls | jq ".[] | select((.head.ref | test(\"auto-update/${pr_repo}\")) and (.head.ref != \"${GITHUB_REF:11}\")) | .number")
           for pr in $other_prs ; do curl -s -H "Authorization: token $GITHUB_TOKEN" -X PATCH -d '{"state": "closed"}' ${renku_repo}/pulls/${pr} ; done
+
+          pr_body="This is an automated pull request.\n\n/deploy"
+          # get current cli version for core PRs and set PR body for tests to pass
+          if [ pr_repo == "renku-core" ]; then
+            regex='renku-core-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)'
+            [[ ${GITHUB_REF} =~ $regex ]]
+            core_version=${BASH_REMATCH[1]}
+            current_version_maybe_rc=$(curl -s https://pypi.org/pypi/renku/json | jq -r ".releases | keys_unsorted | map(select( . | startswith(\"$core_version\"))) | sort_by(. | split(\"[.]|rc\";\"\") | map(tonumber))[-1]")
+            pr_body="$pr_body extra-values=global.renku.cli_version=$current_version_maybe_rc"
+          fi
+          echo "pr_body=$pr_body" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
       - name: pull-request-action
@@ -25,4 +37,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
           PULL_REQUEST_BRANCH: "master"
-          PULL_REQUEST_BODY: "This is an automated pull request.\n\n/deploy"
+          PULL_REQUEST_BODY: ${{needs.close_prs.outputs.pr_body}}

--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -29,7 +29,7 @@ jobs:
           pr_body="This is an automated pull request.\n\n/deploy"
 
           # get current cli version for core PRs and set PR body for tests to pass
-          if [ pr_repo == "renku-core" ]; then
+          if [ "$pr_repo" == "renku-core" ]; then
             regex='renku-core-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)'
             [[ ${GITHUB_REF} =~ $regex ]]
             core_version=${BASH_REMATCH[1]}

--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: close existing PRs
-        id: close_prs
         run: |
           renku_repo="https://api.github.com/repos/SwissDataScienceCenter/renku"
           # find the repo that made the PR
@@ -18,8 +17,17 @@ jobs:
           # find other PRs from that repo
           other_prs=$(curl -s ${renku_repo}/pulls | jq ".[] | select((.head.ref | test(\"auto-update/${pr_repo}\")) and (.head.ref != \"${GITHUB_REF:11}\")) | .number")
           for pr in $other_prs ; do curl -s -H "Authorization: token $GITHUB_TOKEN" -X PATCH -d '{"state": "closed"}' ${renku_repo}/pulls/${pr} ; done
+        env:
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+      - name: set PR body
+        id: set_pr_body
+        run: |
+          regex='renku-[a-z]+'
+          [[ ${GITHUB_REF} =~ $regex ]]
+          pr_repo=$BASH_REMATCH
 
           pr_body="This is an automated pull request.\n\n/deploy"
+
           # get current cli version for core PRs and set PR body for tests to pass
           if [ pr_repo == "renku-core" ]; then
             regex='renku-core-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)'
@@ -29,12 +37,10 @@ jobs:
             pr_body="$pr_body extra-values=global.renku.cli_version=$current_version_maybe_rc"
           fi
           echo "pr_body=$pr_body" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
       - name: pull-request-action
         uses: vsoch/pull-request-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           BRANCH_PREFIX: "auto-update/"
           PULL_REQUEST_BRANCH: "master"
-          PULL_REQUEST_BODY: ${{needs.close_prs.outputs.pr_body}}
+          PULL_REQUEST_BODY: ${{needs.set_pr_body.outputs.pr_body}}

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
@@ -42,7 +42,7 @@ object CliVersion {
 
   final case class ReleasedVersion(value: String) extends CliVersion
   object ReleasedVersion {
-    private val validator = raw"\d+\.\d+\.\d+(\.post\d+)?(\.dev\d+)?"
+    private val validator = raw"\d+\.\d+\.\d+(rc\d+)?"
 
     def get(value: String): Option[CliVersion] =
       Option.when(value.trim matches validator)(new ReleasedVersion(value.trim))
@@ -57,7 +57,7 @@ object CliVersion {
   }
 
   object NonReleasedVersion {
-    private val validator = raw"\d+\.\d+\.\d+(?:(?:\-?rc\d+)?|(?:\.post\d+)?)\.dev\d+\+g([0-9a-f]{5,40})"
+    private val validator = raw"\d+\.\d+\.\d+((rc\d+)?|(?:\.post\d+)?)\.dev\d+\+g([0-9a-f]{5,40})"
 
     def get(value: String): Option[CliVersion] =
       Option.when(value.trim matches validator)(new NonReleasedVersion(value.trim))

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -27,6 +27,10 @@ spec:
         value: '{{ .Values.tests.parameters.fullname }}'
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
+      {{ if .Values.global.renku.cli_version }}
+      - name: RENKU_CLI_VERSION
+        value: '{{ .Values.global.renku.cli_version }}'
+      {{ end }}
       {{ if .Values.tests.parameters.provider }}
       - name: RENKU_TEST_PROVIDER
         value: '{{ .Values.tests.parameters.provider }}'

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -49,6 +49,9 @@ global:
     ## the UI) If not set explicitly the version will be picked up
     ## from the respective renku (sub)chart.
     version: 0.4.0
+    ## CLI Version to be used for project creation. if not set, the
+    ## same version as core-svc is used.
+    # cli_version: 2.4.0
   ## Note that the graph will not turned on by default until renku 0.4.0
   graph:
     dbEventLog:


### PR DESCRIPTION
Needs https://github.com/SwissDataScienceCenter/renku-python/pull/3415 to properly work 

closes https://github.com/SwissDataScienceCenter/renku-python/issues/3402

allows setting something like `extra-values=global.renku.cli_version=2.4.0rc2` in auto-prs to test with a specific version (this is automatically set by CI with the changes in this PR)

/deploy #persist