### PR TITLE
fix: Add authorization cookies to graph/status requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,5 @@ tags
 
 # Ignore scala metals .bsp folder
 .bsp/
+
+.direnv/

--- a/acceptance-tests/.envrc
+++ b/acceptance-tests/.envrc
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# reload when these files change
+watch_file flake.nix
+watch_file flake.lock
+
+use flake

--- a/acceptance-tests/flake.lock
+++ b/acceptance-tests/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1682303062,
+        "narHash": "sha256-x+KAADp27lbxeoPXLUMxKcRsUUHDlg+qVjt5PjgBw9A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5364316e314436f6b9c8fd50592b18920ab18f9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/acceptance-tests/flake.nix
+++ b/acceptance-tests/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "renku acceptance tests flake";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # renkuDeps = pkgs: with pkgs.python3Packages;
+      #   [ pip zconfig wcwidth
+      #     termcolor shellescape pytz prefixed
+      #   ];
+    in
+    rec
+    {
+      devShells = forAllSystems(system:
+        { default =
+            let
+              pkgs = import nixpkgs { inherit system; };
+            in
+              pkgs.mkShell {
+                buildInputs = [
+                  pkgs.sbt
+                  pkgs.openjdk
+                  pkgs.chromedriver
+                ];
+
+                CHROME_DRIVER = "${pkgs.chromedriver}/bin/chromedriver";
+
+                nativeBuildInputs =
+                  [
+                  ];
+              };
+        });
+    };
+}

--- a/acceptance-tests/local-run-test.sh
+++ b/acceptance-tests/local-run-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Use `direnv allow` or `nix develop` to drop into a shell with
+# required programs in place.
+
+set -e
+
+sbt "testOnly ch.renku.acceptancetests.$1"

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/HandsOnSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/HandsOnSpec.scala
@@ -49,7 +49,7 @@ class HandsOnSpec
     val flightsDatasetName = `follow the flights tutorial`(projectUrl)
 
     When("all the events are processed by the knowledge-graph")
-    `wait for KG to process events`(projectDetails.asProjectIdentifier)
+    `wait for KG to process events`(projectDetails.asProjectIdentifier, webDriver)
 
     `verify dataset was created`(flightsDatasetName)
 

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/LineageSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/LineageSpec.scala
@@ -46,7 +46,7 @@ class LineageSpec
     val (scriptPath, outputFilePath) = `setup a workflow`
 
     When("all the events are processed by the knowledge-graph")
-    `wait for KG to process events`(projectDetails.asProjectIdentifier)
+    `wait for KG to process events`(projectDetails.asProjectIdentifier, webDriver)
 
     `view the lineage of the outputFile`(outputFilePath)
 

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
@@ -36,7 +36,7 @@ trait KnowledgeGraphApi extends RestClient {
   def `wait for KG to process events`(projectId: ProjectIdentifier): Unit = {
     sleep(1 second)
     val gitLabProjectId = `get GitLab project id`(projectId)
-    checkStatusAndWait(projectId, gitLabProjectId)
+    checkStatusAndWait(projectId, gitLabProjectId, 1)
   }
 
   def findLineage(projectPath: String, filePath: String): JsonObject = {
@@ -51,15 +51,15 @@ trait KnowledgeGraphApi extends RestClient {
   }
 
   @tailrec
-  private def checkStatusAndWait(projectId: ProjectIdentifier, gitLabProjectId: Int, attempt: Int = 1): Unit =
+  private def checkStatusAndWait(projectId: ProjectIdentifier, gitLabProjectId: Int, attempt: Int): Unit =
     if (attempt == 60 * 5) // 5 minutes
       fail(s"Events for '$projectId' project not processed after 5 minutes")
     else if (findTotalDone(projectId, gitLabProjectId) == 0) {
       sleep(1 second)
-      checkStatusAndWait(projectId, gitLabProjectId)
-    } else if (findProgress(projectId, gitLabProjectId) != 100d) {
+      checkStatusAndWait(projectId, gitLabProjectId, attempt + 1)
+    } else if (findProgress(projectId, gitLabProjectId, token) != 100d) {
       sleep(1 second)
-      checkStatusAndWait(projectId, gitLabProjectId)
+      checkStatusAndWait(projectId, gitLabProjectId, attempt + 1)
     }
 
   private def findProgress(projectId: ProjectIdentifier, gitLabProjectId: Int): Double =

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/KnowledgeGraphApi.scala
@@ -25,6 +25,7 @@ import ch.renku.acceptancetests.model.projects.ProjectIdentifier
 import io.circe.JsonObject
 import org.http4s.Status.{NotFound, Ok}
 import org.http4s.circe.CirceEntityCodec._
+import org.openqa.selenium.WebDriver
 import org.scalatest.Assertions.fail
 
 import scala.annotation.tailrec
@@ -33,10 +34,10 @@ import scala.concurrent.duration._
 trait KnowledgeGraphApi extends RestClient {
   self: AcceptanceSpecData with GitLabApi with Grammar with IOSpec =>
 
-  def `wait for KG to process events`(projectId: ProjectIdentifier): Unit = {
+  def `wait for KG to process events`(projectId: ProjectIdentifier, browser: WebDriver): Unit = {
     sleep(1 second)
     val gitLabProjectId = `get GitLab project id`(projectId)
-    checkStatusAndWait(projectId, gitLabProjectId, 1)
+    checkStatusAndWait(projectId, gitLabProjectId, browser, 1)
   }
 
   def findLineage(projectPath: String, filePath: String): JsonObject = {
@@ -51,36 +52,37 @@ trait KnowledgeGraphApi extends RestClient {
   }
 
   @tailrec
-  private def checkStatusAndWait(projectId: ProjectIdentifier, gitLabProjectId: Int, attempt: Int): Unit =
-    if (attempt == 60 * 5) // 5 minutes
+  private def checkStatusAndWait(
+      projectId:       ProjectIdentifier,
+      gitLabProjectId: Int,
+      browser:         WebDriver,
+      attempt:         Int
+  ): Unit =
+    if (attempt >= 60 * 5)
       fail(s"Events for '$projectId' project not processed after 5 minutes")
-    else if (findTotalDone(projectId, gitLabProjectId) == 0) {
+    else if (findTotalDone(projectId, gitLabProjectId, browser) == 0) {
       sleep(1 second)
-      checkStatusAndWait(projectId, gitLabProjectId, attempt + 1)
-    } else if (findProgress(projectId, gitLabProjectId, token) != 100d) {
+      checkStatusAndWait(projectId, gitLabProjectId, browser, attempt + 1)
+    } else if (findProgress(projectId, gitLabProjectId, browser) < 100d) {
       sleep(1 second)
-      checkStatusAndWait(projectId, gitLabProjectId, attempt + 1)
+      checkStatusAndWait(projectId, gitLabProjectId, browser, attempt + 1)
     }
 
-  private def findProgress(projectId: ProjectIdentifier, gitLabProjectId: Int): Double =
-    GET(renkuBaseUrl / "api" / "projects" / gitLabProjectId.toString / "graph" / "status")
-      .send { response =>
-        response.status match {
-          case Ok       => response.as[GraphStatus].map(_.progressPercentage)
-          case NotFound => 0d.pure[IO]
-          case other =>
-            IO(logger.warn(s"Finding processing status for '$projectId' returned $other")).as(0d)
-        }
-      }
+  private def findProgress(projectId: ProjectIdentifier, gitLabProjectId: Int, browser: WebDriver): Double =
+    findStatus(projectId, gitLabProjectId, browser).map(_.progressPercentage).getOrElse(0d)
 
-  private def findTotalDone(projectId: ProjectIdentifier, gitLabProjectId: Int): Int =
+  private def findTotalDone(projectId: ProjectIdentifier, gitLabProjectId: Int, browser: WebDriver): Int =
+    findStatus(projectId, gitLabProjectId, browser).map(_.total).getOrElse(0)
+
+  private def findStatus(projectId: ProjectIdentifier, gitLabProjectId: Int, browser: WebDriver): Option[GraphStatus] =
     GET(renkuBaseUrl / "api" / "projects" / gitLabProjectId.toString / "graph" / "status")
+      .addCookiesFrom(browser)
       .send { response =>
         response.status match {
-          case Ok       => response.as[GraphStatus].map(_.total)
-          case NotFound => 0.pure[IO]
+          case Ok       => response.as[GraphStatus].map(_.some)
+          case NotFound => None.pure[IO]
           case other =>
-            IO(logger.warn(s"Finding processing status for '$projectId' returned $other")).as(0)
+            IO(logger.warn(s"Finding processing status for '$projectId' returned $other")).as(None)
         }
       }
 }

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/RestClient.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/tooling/RestClient.scala
@@ -32,12 +32,15 @@ import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.blaze.pipeline.Command
 import org.http4s.circe._
 import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.client.middleware.Logger
 import org.http4s.client.{Client, ConnectionFailure}
+import org.openqa.selenium.WebDriver
 import org.scalatest.Assertions.fail
 
 import java.net.ConnectException
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+import scala.jdk.CollectionConverters._
 
 trait RestClient extends Http4sClientDsl[IO] {
   self: IOSpec =>
@@ -63,8 +66,15 @@ trait RestClient extends Http4sClientDsl[IO] {
 
   implicit class RequestOps(request: Request[IO]) {
 
+    def addCookiesFrom(webDriver: WebDriver) =
+      webDriver
+        .manage()
+        .getCookies
+        .asScala
+        .foldLeft(request)((r, c) => r.addCookie(c.getName, c.getValue))
+
     def withAuthorizationToken(authorizationToken: AuthorizationToken): Request[IO] =
-      request.withHeaders(Headers(authorizationToken.asHeader))
+      request.putHeaders(Headers(authorizationToken.asHeader))
 
     def send[A](processResponse: Response[IO] => IO[A]): A =
       clientBuilder.resource.use(sendRequest(processResponse)).unsafeRunSync()

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Datasets.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/Datasets.scala
@@ -63,7 +63,7 @@ trait Datasets {
     pause asLongAsBrowserAt newDatasetPage
 
     And("all the events are processed by the knowledge-graph ")
-    `wait for KG to process events`(projectPage.asProjectIdentifier)
+    `wait for KG to process events`(projectPage.asProjectIdentifier, webDriver)
 
     Then("the user should see its newly created dataset without the KG warning message")
     val datasetPage = DatasetPage(datasetName)
@@ -108,7 +108,7 @@ trait Datasets {
     pause asLongAsBrowserAt newDatasetPage
 
     And("all the events are processed by the knowledge-graph")
-    `wait for KG to process events`(projectPage.asProjectIdentifier)
+    `wait for KG to process events`(projectPage.asProjectIdentifier, webDriver)
 
     val datasetPage = DatasetPage(datasetName)
     Then("the user should see its newly created dataset without the KG warning message")
@@ -165,7 +165,7 @@ trait Datasets {
     verify browserAt datasetPage
 
     And("all the events are processed by the knowledge-graph")
-    `wait for KG to process events`(projectPage.asProjectIdentifier)
+    `wait for KG to process events`(projectPage.asProjectIdentifier, webDriver)
 
     And("the user should see its newly created dataset without the KG warning message")
     reloadPage() sleep (2 seconds)

--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/JupyterNotebook.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/workflows/JupyterNotebook.scala
@@ -68,7 +68,7 @@ trait JupyterNotebook extends Datasets with Project with KnowledgeGraphApi {
     `stop session`
 
     When("all the events are processed by the knowledge-graph")
-    `wait for KG to process events`(projectDetails.asProjectIdentifier)
+    `wait for KG to process events`(projectDetails.asProjectIdentifier, webDriver)
 
     Then("the user can see the created dataset")
     `verify dataset was created`(datasetName)


### PR DESCRIPTION
The status endpoint has been changed to require an access token. Thus to have acceptance tests work for new dev deployments, the access token must be given to the request.

Additionally fixes the stop condition when checking the status, the attempts were not incremented.

/deploy #persist