### PR TITLE
chore(deps): bump python-keycloak version in init-realm container from 0.24.0 to 2.14.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "scripts/init-realm" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "python-keycloak"
+        # I would like to replace this wich "version-update:semver-patch",  "version-update:semver-minor"  
+        # but just want to test this first...
+        update-types: ["version-update:semver-patch"] 
   - package-ecosystem: "pip"
     directory: "acceptance-tests/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 2
     ignore:
       - dependency-name: "python-keycloak"
-        # I would like to replace this wich "version-update:semver-patch",  "version-update:semver-minor"  
+        # I would like to replace this with "version-update:semver-patch",  "version-update:semver-minor"  
         # but just want to test this first...
         update-types: ["version-update:semver-patch"] 
   - package-ecosystem: "pip"

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -33,7 +33,8 @@ charts:
         dockerfilePath: scripts/init-realm/Dockerfile
         valuesPath: keycloak.initRealm.image
         paths:
-          - scripts/init-realm
+          - scripts/init-realm/Dockerfile
+          - scripts/init-realm/requirements.txt
           - scripts/init-realm/init-realm.py
       init-db:
         contextPath: scripts/init-db

--- a/scripts/init-realm/requirements.txt
+++ b/scripts/init-realm/requirements.txt
@@ -1,1 +1,1 @@
-python-keycloak==0.24.0
+python-keycloak==2.14.0


### PR DESCRIPTION
/deploy #persist

Keycloak post install jobs have been failing; looks like it's an issue with old python-keycloak deps.

This PR bumps the python-keycloak version - testing to be performed by CI job.