### PR TITLE
test(cypress): disable checking latest renku version

### DIFF
--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -76,7 +76,8 @@ describe("Basic public project functionality", () => {
     if (projectTestConfig.shouldCreateProject)
       cy.contains("Welcome to your new Renku project", { timeout: TIMEOUTS.vlong }).should("be.visible");
     cy.contains("Status").should("be.visible").click();
-    cy.contains("This project is using the latest version of renku").should("be.visible");
+    // ! TODO: temporarily disabled until the new project status section is ready
+    // cy.contains("This project is using the latest version of renku").should("be.visible");
     cy.contains("This project is using the latest version of the template").should("be.visible");
     cy.contains("Knowledge Graph integration is active", { timeout: TIMEOUTS.long }).should("be.visible");
   });


### PR DESCRIPTION
Temporarily disable checking the sentence `"This project is using the latest version of renku"` to prevent wrong results with candidate releases from renku-core.
This will be properly fixed one the new project's status section is ready on the UI (here is the reference PR: https://github.com/SwissDataScienceCenter/renku-ui/pull/2503 )

/deploy extra-values=global.renku.cli_version=2.4.1rc3 #persist #notest #cypress


