### PR TITLE
chore: bump template version

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -596,7 +596,7 @@ ui:
       custom: true
       repositories:
         - url: https://github.com/SwissDataScienceCenter/renku-project-template
-          ref: 0.6.0
+          ref: 0.6.1
           name: Renku
         - url: https://github.com/SwissDataScienceCenter/contributed-project-templates
           ref: 0.5.0


### PR DESCRIPTION
bumps the templates to new version to push out images with fixed toil path. 

/deploy #persist