### PR TITLE
fix(chart): generate db secrets on upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@
 
 Renku ``0.29.0`` introduces a PostgreSQL DB for triples-generator.
 
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Bug Fixes**
+
+- **Infrastructure**: properly generate postgres secrets on upgrade (`#3137 <https://github.com/SwissDataScienceCenter/renku/issues/3137>`_).
+
+
 
 0.28.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Internal Changes
 
 **Bug Fixes**
 
-- **Infrastructure**: properly generate postgres secrets on upgrade (`#3137 <https://github.com/SwissDataScienceCenter/renku/issues/3137>`_).
+- **Infrastructure**: properly generate PostgreSQL secrets on upgrade (`#3137 <https://github.com/SwissDataScienceCenter/renku/issues/3137>`_).
 
 
 

--- a/helm-chart/renku/templates/gitlab-postgres-secret.yaml
+++ b/helm-chart/renku/templates/gitlab-postgres-secret.yaml
@@ -22,12 +22,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{ if or .Values.global.gitlab.postgresPassword.value -}}
     "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
-    {{- else -}}
-    "helm.sh/hook": "pre-install"
-    {{- end }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   gitlab-postgres-password: {{ $db_password }}

--- a/helm-chart/renku/templates/graph-db-postgres-secret.yaml
+++ b/helm-chart/renku/templates/graph-db-postgres-secret.yaml
@@ -21,12 +21,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{ if or .Values.global.graph.dbEventLog.postgresPassword.value -}}
     "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
-    {{- else -}}
-    "helm.sh/hook": "pre-install"
-    {{- end }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   graph-dbEventLog-postgresPassword: {{ $db_password }}

--- a/helm-chart/renku/templates/graph-tg-postgres-secret.yaml
+++ b/helm-chart/renku/templates/graph-tg-postgres-secret.yaml
@@ -21,12 +21,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{ if or .Values.global.graph.triplesGenerator.postgresPassword.value -}}
     "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
-    {{- else -}}
-    "helm.sh/hook": "pre-install"
-    {{- end }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   graph-triplesGenerator-postgresPassword: {{ $db_password }}

--- a/helm-chart/renku/templates/graph-token-postgres-secret.yaml
+++ b/helm-chart/renku/templates/graph-token-postgres-secret.yaml
@@ -21,12 +21,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{ if or .Values.global.graph.tokenRepository.postgresPassword.value -}}
     "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
-    {{- else -}}
-    "helm.sh/hook": "pre-install"
-    {{- end }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   graph-tokenRepository-postgresPassword: {{ $db_password }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -11,6 +11,8 @@ global:
     ## Postgres user for the gitlab database
     postgresUser: gitlab
     ## Postgres password for the gitlab database
+    ## NOTE: The helm chart cannot update this password in Postgres once it has been created for the first time either by
+    ## setting this value or by randomly generating it because it was omitted below.
     postgresPassword:
       value:
     ## URL prefix for gitlab
@@ -55,6 +57,8 @@ global:
       ## Name of the postgres user to be used to access the Event Log db
       postgresUser: eventlog
       ## Postgres password to be used to access the Event Log db
+      ## NOTE: The helm chart cannot update this password in Postgres once it has been created for the first  time either by
+      ## setting this value or by randomly generating it because it was omitted below.
       postgresPassword:
         value:
       existingSecret: '{{ template "renku.fullname" . }}-db-postgres'
@@ -62,6 +66,8 @@ global:
       ## Name of the postgres user to be used to access the db storing access tokens
       postgresUser: tokenstorage
       ## Postgres password to be used to access the db storing access tokens
+      ## NOTE: The helm chart cannot update this password in Postgres once it has been created for the first time either by
+      ## setting this value or by randomly generating it because it was omitted below.
       postgresPassword:
         value:
       existingSecret: '{{ template "renku.fullname" . }}-token-postgres'
@@ -69,6 +75,8 @@ global:
       ## Name of the postgres user to be used to access the tg db
       postgresUser: triplesgenerator
       ## Postgres password to be used to access the db storing access tokens
+      ## NOTE: The helm chart cannot update this password in Postgres once it has been created for the first time either by
+      ## setting this value or by randomly generating it because it was omitted below.
       postgresPassword:
         value:
       existingSecret: '{{ template "renku.fullname" . }}-tg-postgres'


### PR DESCRIPTION
I am not sure what is the logic behind the helm hooks for the secret creation.

But IMO it was needlessly complicated and it did not work when you upgrade from the helm chart version where the secret wasn't there.

So the changes I made are the following:
- removed the deletion hook because it was setting a value that is already the default
- made the hooks run before installing, upgrading or rolling back

This way the secret can be created when you are upgrading. Which was not the case before. 

I tested by deploying an older version and then upgrading. With this fix the secret is properly randomly created when you upgrade renku.

Because we have the logic to check if the secret exists (and not update it if it does) we can run the hook every time.

We have had similar discussions about this before. This does not prevent the admin from setting the value for a password in the helm chart values and breaking the deployment. Because the postgres secret is not updated when the helm chart values change. But this is acceptable IMO. I also added warnings about this in the values for the helm chart.

/deploy #persist