### PR TITLE
chore(chart): Add triples-generator to postgres-ingress network policy

### DIFF
--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -47,6 +47,12 @@ spec:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
         - podSelector:
             matchLabels:
+              app: triples-generator
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - podSelector:
+            matchLabels:
               app: token-repository
           namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Extends #3125 and is part of https://github.com/SwissDataScienceCenter/renku-graph/issues/1282.
This change is necessary so that the triple generator service can access Postgres.
