### PR TITLE
test(cypress): check KG status properly before starting the tests

### DIFF
--- a/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
+++ b/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
@@ -31,7 +31,7 @@ describe("Verify the infrastructure is ready", () => {
     retryRequest("api/templates/licenses", "GitLab");
     retryRequest("api/renku/versions", "Core");
     retryRequest("api/notebooks/version", "Notebooks");
-    retryRequest("api/kg/spec.json", "Graph");
+    retryRequest("api/kg/entities", "Graph");
     retryRequest("api/auth/login", "Gateway");
     retryRequest("ui-server/api/allows-iframe/https%3A%2F%2Fgoogle.com", "UI server");
     retryRequest("config.json", "UI client");


### PR DESCRIPTION
Prevent running Cypress tests until KG returns a valid response.

/deploy #persist extra-values=global.renku.cli_version=2.6.0rc1
