### PR TITLE
Improve realm init

### DIFF
--- a/scripts/init-realm/init-realm.py
+++ b/scripts/init-realm/init-realm.py
@@ -224,7 +224,7 @@ success = False
 
 while not success and n_attempts < 31:
     try:
-        sys.stdout.write("Getting an admin access token for Keycloak...")
+        sys.stdout.write("Getting an admin access token for Keycloak...\n")
         keycloak_admin = KeycloakAdmin(
             server_url=args.keycloak_url,
             username=args.admin_user,
@@ -232,8 +232,12 @@ while not success and n_attempts < 31:
             verify=True,
         )
         success = True
-    except (KeycloakConnectionError, KeycloakGetError, KeycloakPostError):
-        sys.stdout.write("Keycloak not responding, retrying in 10 seconds...\n")
+    except (KeycloakConnectionError, KeycloakGetError, KeycloakPostError) as error:
+        msg = "Keycloak not responding"
+        if error.response_code is not None:
+            msg += f" (status code: {error.response_code})"
+        msg += ", retrying in 10 seconds...\n"
+        sys.stdout.write(msg)
         n_attempts += 1
         time.sleep(10)
 if success:

--- a/scripts/init-realm/init-realm.py
+++ b/scripts/init-realm/init-realm.py
@@ -267,7 +267,7 @@ keycloak_admin.create_realm(
 sys.stdout.write("done\n")
 
 # Switching to the newly created realm
-keycloak_admin.realm_name = args.realm
+keycloak_admin.connection.realm_name = args.realm
 
 
 for new_client in new_clients:

--- a/scripts/init-realm/requirements.txt
+++ b/scripts/init-realm/requirements.txt
@@ -1,1 +1,1 @@
-python-keycloak==2.14.0
+python-keycloak==3.3.0


### PR DESCRIPTION
This merge request does several small improvements:

- Fixes a warning that will turn into an error when python-keycloak 4 will be out
- Improves the warning message when something goes wrong adding the status code so one can know what might be happening
- Bump the python-keycloak version to the latest release at the time of writing (3.3.0)

The last point goes beyond what is proposed in #3066 and this pull request can be used in place of it.

In any case, the python-keycloak bump is required as the current release of `init-realm` (0.29.0) fails to generate the realms and clients due to an internal error in the python-keycloak version used.