### PR TITLE
Improve ingress handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,21 @@
 .. _changelog:
 
+0.34.0
+------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**🌟 New Features**
+
+- **Infrastructure**: add support for ingress class name
+
+**✨ Improvements**
+
+- **Documentation**: refactor certificate management part to show how to make use of
+  cert-manager and manually created certificates in both development and production
+  contexts.
+
 0.33.0
 ------
 

--- a/helm-chart/renku/templates/ingress.yaml
+++ b/helm-chart/renku/templates/ingress.yaml
@@ -35,6 +35,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -178,6 +178,8 @@ ingress:
   ## Enables the creation of an ingress
   enabled: false
 
+  className: "" # nginx
+
   ## Annotations for the created ingress
   annotations:
     ## The ingress class

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -181,7 +181,7 @@ ingress:
   ## Annotations for the created ingress
   annotations:
     ## The ingress class
-    cert-manager.io/cluster-issuer: letsencrypt-production # TO DO: should be changed because not everyone is using cert-manager
+    cert-manager.io/cluster-issuer: letsencrypt-production # Use null as value if not using cert-manager to remove this entry
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: "0" # Adjust to a reasonable value for production to avoid DOS attacks.
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # Needed if GitLab is behind this ingress

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -6,11 +6,12 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
-## Upgrading to Renku 0.30.0
+## Upgrading to Renku 0.34.0
 * NEW - *ingress.className* is now available to select a specific IngressClass to
   be used for the ingress. While often supporting both, current ingress
   controllers uses this value over the deprecated kubernetes.io/ingress.class
-  annotation.
+  annotation. Existing instances of Renku do not need to be changed unless their
+  administrators wish to take advantage of the IngressClass.
 
 For more information about the move to IngressClass see this [Kubernetes blog
 entry](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/).

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -6,6 +6,26 @@ Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
 ----
+## Upgrading to Renku 0.30.0
+* NEW - *ingress.className* is now available to select a specific IngressClass to
+  be used for the ingress. While often supporting both, current ingress
+  controllers uses this value over the deprecated kubernetes.io/ingress.class
+  annotation.
+
+For more information about the move to IngressClass see this [Kubernetes blog
+entry](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/).
+
+To make use of it:
+  ```
+  ingress:
+    className: nginx
+
+    # optional
+    annotations:
+      kubernetes.io/ingress.class: null
+  ```
+
+----
 ## Upgrading to Renku 0.29.0
 * NEW - *global.graph.triplesGenerator.postgresPassword.value* should be specified. If it is not specified, a password will be generated automatically when the database is initialized. It is strongly recommended, however, to specify it here such that the password is explicitly managed and can be restored in disaster scenarios. Generate through `openssl rand -hex 32`.
 


### PR DESCRIPTION
This merge request has the following aims:

- Make the ingress class selection follow current best practice
- Allow the deployment with and without cert-manager
- Improve the documentation related to certificate handling

The updated documentation provides now an example that developers can use to test-drive Renku using https.