### PR TITLE
chore: simplify devcontainer spec

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,8 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3
+// See devcontainer docs: https://code.visualstudio.com/docs/devcontainers/containers
 {
-	"name": "Python 3",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.9",
-			// Options
-			"NODE_VERSION": "lts/*"
-		}
-	},
-	// Configure tool-specific properties.
+	"name": "renku",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 	"customizations": {
-		// Configure properties specific to VS Code.
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
@@ -40,19 +26,16 @@
 			]
 		}
 	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "git submodule update --init && pip3 install --user -r docs/requirements.txt",
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"kubectl-helm-minikube": {
-			"version": "latest",
-			"helm": "3.5.2",
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.10"
 		},
-		"ghcr.io/devcontainers/features/docker-from-docker:1": {
-			"version": "latest"
-		}
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+            "packages": ["libenchant-2-2", "graphviz"]
+        }
 	}
 }


### PR DESCRIPTION
This simplifies the devcontainer spec by not relying on the Dockerfile anymore and just using standard devcontainer features. I left the `Dockerfile` in case it's needed again. 