### PR TITLE
chore: update date and remove unused authors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = "index"
 # General information about the project.
 project = "Renku"
 copyright = "2017-2023, Swiss Data Science Center"
-
+author = { "The Renku team and other contributors (see individual repositories)" }
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = "index"
 # General information about the project.
 project = "Renku"
 copyright = "2017-2023, Swiss Data Science Center"
-author = { "The Renku team and other contributors (see individual repositories)" }
+author = ( "The Renku team and other contributors (see individual repositories)" )
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,16 +68,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Renku"
-copyright = "2017-2022, Swiss Data Science Center"
-author = (
-    "Mohammad Alisafaee, Andreas Bleuler, Eric Bouillet, \n"
-    "Lorenzo Cavazzi, Christine Choirat, Jakub Chrobasik, Andrea Cordoba, Alessandro Degano, \n"
-    "Pamela Delgado, Julien Eberle, Virginia Friedrich, Viktor Gal, \n"
-    "Fotis Georgatos, Ralf Grubenmann, Emma Jablonski, Wesley Johnson, Laura Kinkead, \n"
-    "Jiri Kuncar, David Kunzmann, Gavin Lee, Travis Lee, Cyril Matthey-Doret, Izabela Moise, Sean Murphy, Tasko Olevski, Samuel Picek, \n"
-    "Chandrasekhar Ramakrishnan, Rok Roškar, Sofiane Sarni, Tao Sun, \n"
-    "Sandra Savchenko De Jong, Johann-Michael Thiebaut, Olivier Verscheure"
-)
+copyright = "2017-2023, Swiss Data Science Center"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This updates the year in the docs and removes the authors which are hard to maintain and don't show up anywhere. 