### PR TITLE
test(cypress): add test for private projects and visibility

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -139,7 +139,14 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        tests: [publicProject, updateProjects, useSession, checkWorkflows, rstudioSession] 
+        tests: [
+          publicProject,
+          privateProject,
+          updateProjects,
+          useSession,
+          checkWorkflows,
+          rstudioSession
+        ]
 
     steps:
       - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.5.2

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -95,7 +95,7 @@ describe("Basic public project functionality", () => {
     // ? We need to wait before other checks take place.
     // ? This is a workaround until we use the new Project update endpoint.
     // ? Reference: https://github.com/SwissDataScienceCenter/renku-ui/issues/2778
-    cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(TIMEOUTS.standard); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // Check all is up-to-date and ready.
     cy.get(".modal button.btn-close").should("be.visible").click();

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -1,0 +1,157 @@
+import { TIMEOUTS } from "../../config";
+import {
+  ProjectIdentifier,
+  generatorProjectName
+} from "../support/commands/projects";
+import { validateLogin } from "../support/commands/general";
+
+const username = Cypress.env("TEST_USERNAME");
+
+const projectTestConfig = {
+  shouldCreateProject: true,
+  projectName: generatorProjectName("privateProject"),
+};
+
+// ? Uncomment to debug using an existing project
+// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectName = "cypress-privateproject-ad99f11c1482";
+
+const projectIdentifier: ProjectIdentifier = {
+  name: projectTestConfig.projectName,
+  namespace: username,
+};
+
+describe("Basic public project functionality", () => {
+  before(() => {
+    // Use a session to preserve login data
+    cy.session(
+      "login-publicProject",
+      () => {
+        cy.robustLogin();
+      },
+      validateLogin
+    );
+
+    // Create a project for the local spec
+    if (projectTestConfig.shouldCreateProject) {
+      cy.visit("/");
+      cy.createProject({ templateName: "Python", ...projectIdentifier, visibility: "private" });
+    }
+  });
+
+  beforeEach(() => {
+    // Restore the session
+    cy.session(
+      "login-publicProject",
+      () => {
+        cy.robustLogin();
+      },
+      validateLogin
+    );
+    cy.visitAndLoadProject(projectIdentifier);
+  });
+
+  it("Can search for project only when logged in", () => {
+    // Assess the project has been indexed properly
+    cy.dataCy("project-navbar", true)
+      .contains("a.nav-link", "Settings")
+      .should("be.visible")
+      .click();
+    cy.dataCy("project-settings-knowledge-graph")
+      .contains("Project indexing", { timeout: TIMEOUTS.vlong })
+      .should("exist");
+    cy.dataCy("kg-status-section-open").should("exist").click();
+    cy.dataCy("project-settings-knowledge-graph")
+      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
+      .should("exist");
+    cy.dataCy("visibility-private").should("be.visible").should("be.checked");
+    cy.searchForProject(projectIdentifier, true);
+
+    // logout and search for the project and log back in
+    cy.logout();
+    cy.get("#nav-hamburger").should("be.visible").click();
+    cy.searchForProject(projectIdentifier, false);
+    cy.robustLogin();
+  });
+
+  it("Can always search for project after changing the visibility", () => {
+    // Change visibility to public
+    cy.dataCy("project-navbar", true)
+      .contains("a.nav-link", "Settings")
+      .should("be.visible")
+      .click();
+    cy.dataCy("project-settings-knowledge-graph")
+      .contains("Project indexing", { timeout: TIMEOUTS.vlong })
+      .should("exist");
+    cy.dataCy("visibility-private").should("be.visible").should("be.checked");
+    cy.dataCy("visibility-public").should("be.visible").check();
+    cy.get(".modal")
+      .contains("Change visibility to Public")
+      .should("be.visible");
+    cy.dataCy("update-visibility-btn").should("be.visible").click();
+    cy.get(".modal .alert-success", { timeout: TIMEOUTS.long })
+      .contains("The visibility of the project has been modified")
+      .should("be.visible");
+    // ? We need to wait before other checks take place.
+    // ? This is a workaround until we use the new Project update endpoint.
+    // ? Reference: https://github.com/SwissDataScienceCenter/renku-ui/issues/2778
+    cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    // Check all is up-to-date and ready.
+    cy.get(".modal button.btn-close").should("be.visible").click();
+    cy.dataCy("kg-status-section-open").should("exist").click();
+    cy.dataCy("project-settings-knowledge-graph")
+      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
+      .should("exist");
+    cy.dataCy("visibility-private")
+      .should("be.visible")
+      .should("not.be.checked");
+    cy.dataCy("visibility-public").should("be.visible").should("be.checked");
+
+    // Search the project as both logged in and logged out.
+    cy.searchForProject(projectIdentifier, true);
+    cy.logout();
+    cy.get("#nav-hamburger").should("be.visible").click();
+    cy.searchForProject(projectIdentifier, false);
+    cy.robustLogin();
+
+  });
+
+  it("Deleting the project removes it from the search page", () => {
+    // Delete the project
+    cy.visitAndLoadProject(projectIdentifier);
+
+    const slug = projectIdentifier.namespace + "/" + projectIdentifier.name;
+    cy.intercept("DELETE", `/ui-server/api/kg/projects/${slug}`).as(
+      "deleteProject"
+    );
+    cy.dataCy("project-navbar", true)
+      .contains("a.nav-link", "Settings")
+      .should("exist")
+      .click();
+    cy.dataCy("project-settings-general-delete-project")
+      .should("be.visible")
+      .find("button")
+      .contains("Delete project")
+      .should("be.visible")
+      .click();
+    cy.contains("Are you absolutely sure?");
+    cy.get("input[name=project-settings-general-delete-confirm-box]").type(
+      slug
+    );
+    cy.get("button")
+      .contains("Yes, delete this project")
+      .should("be.visible")
+      .should("be.enabled")
+      .click();
+    cy.wait("@deleteProject");
+
+    cy.url().should("not.contain", `/projects/${slug}`);
+    cy.get(".Toastify")
+      .contains(`Project ${slug} deleted`)
+      .should("be.visible");
+
+    // Check that the project is not listed anymore on the search page
+    cy.searchForProject(projectIdentifier, false);
+  });
+});

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -95,7 +95,7 @@ describe("Basic public project functionality", () => {
     // ? We need to wait before other checks take place.
     // ? This is a workaround until we use the new Project update endpoint.
     // ? Reference: https://github.com/SwissDataScienceCenter/renku-ui/issues/2778
-    cy.wait(TIMEOUTS.standard); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(TIMEOUTS.standard * 0.5); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // Check all is up-to-date and ready.
     cy.get(".modal button.btn-close").should("be.visible").click();

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -77,6 +77,7 @@ describe("Basic public project functionality", () => {
       .contains("a.nav-link", "Settings")
       .should("be.visible")
       .click();
+    
     cy.dataCy("project-settings-knowledge-graph")
       .contains("Project indexing", { timeout: TIMEOUTS.vlong })
       .should("exist");

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -77,7 +77,6 @@ describe("Basic public project functionality", () => {
       .contains("a.nav-link", "Settings")
       .should("be.visible")
       .click();
-    
     cy.dataCy("project-settings-knowledge-graph")
       .contains("Project indexing", { timeout: TIMEOUTS.vlong })
       .should("exist");

--- a/cypress-tests/cypress/support/commands/projects.ts
+++ b/cypress-tests/cypress/support/commands/projects.ts
@@ -37,6 +37,7 @@ function projectSubpageUrl(identifier: ProjectIdentifier, subpage: string) {
 
 interface NewProjectProps extends ProjectIdentifier {
   templateName?: string;
+  visibility?: "public" | "private" | "internal";
 }
 
 function createProject(newProjectProps: NewProjectProps) {
@@ -47,6 +48,9 @@ function createProject(newProjectProps: NewProjectProps) {
 
   if (newProjectProps.templateName)
     cy.contains(newProjectProps.templateName).should("be.visible").click();
+
+  if (newProjectProps.visibility)
+    cy.dataCy(`visibility-${newProjectProps.visibility}`).should("be.visible").click();
 
   // The button may take some time before it is clickable
   cy.get("[data-cy=create-project-button]", { timeout: TIMEOUTS.vlong }).should("be.enabled").click();


### PR DESCRIPTION
Add Cypress tests to cover private projects and test visibility.

fix https://github.com/SwissDataScienceCenter/renku/pull/3216
/deploy #persist #cypress #notest
