### PR TITLE
test(cypress): improve stability

### DIFF
--- a/cypress-tests/config.ts
+++ b/cypress-tests/config.ts
@@ -1,6 +1,8 @@
 // Timeouts for cypesss in miliseconds
 export const TIMEOUTS = {
-  standard: 20000,
-  long: 60000,
-  vlong: 300000,
+  minimal: 1_000,
+  short: 5_000,
+  standard: 20_000,
+  long: 60_000,
+  vlong: 180_000,
 };

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   defaultCommandTimeout: TIMEOUTS.standard,
   chromeWebSecurity: false,
-  viewportWidth: 1024,
-  viewportHeight: 768,
+  viewportWidth: 1280,
+  viewportHeight: 960,
   videoUploadOnPasses: false
 });

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -57,14 +57,7 @@ describe("Basic public project functionality", () => {
 
   it("Can search for project only when logged in", () => {
     // Assess the project has been indexed properly
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Project indexing", { timeout: TIMEOUTS.vlong })
-      .should("exist");
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
     cy.getDataCy("visibility-private")
       .should("be.visible")
       .should("be.checked");
@@ -79,10 +72,7 @@ describe("Basic public project functionality", () => {
 
   it("Can always search for project after changing the visibility", () => {
     // Change visibility to public
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Project indexing", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
     cy.getDataCy("visibility-private")
       .should("be.visible")
       .should("be.checked");
@@ -97,14 +87,11 @@ describe("Basic public project functionality", () => {
     // ? We need to wait before other checks take place.
     // ? This is a workaround until we use the new Project update endpoint.
     // ? Reference: https://github.com/SwissDataScienceCenter/renku-ui/issues/2778
-    cy.wait(TIMEOUTS.standard * 0.5); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(TIMEOUTS.short); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // Check all is up-to-date and ready.
     cy.get(".modal button.btn-close").should("be.visible").click();
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
     cy.getDataCy("visibility-private")
       .should("be.visible")
       .should("not.be.checked");

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -54,14 +54,7 @@ describe("Basic public project functionality", () => {
 
   it("Can search for project", () => {
     // Assess the project has been indexed properly.This might take time for new projects.
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Project indexing", { timeout: TIMEOUTS.vlong })
-      .should("exist");
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
     cy.searchForProject(projectIdentifier);
 
     // logout and search for the project and log back in

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -137,15 +137,11 @@ describe("Basic datasets functionality", () => {
 
     // Search for the dataset after the project has been indexed
     cy.getDataCy("go-back-button").should("be.visible").click();
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
     cy.searchForDataset(generatedDatasetName.slug);
   });
 
-  it("Delete the dataset and verify it is not searchable anaymore", () => {
+  it("Delete the dataset", () => {
     cy.getProjectSection("Datasets").click();
     if (listDatasetsInvoked)
       cy.wait("@listDatasets", { timeout: TIMEOUTS.long });
@@ -160,17 +156,9 @@ describe("Basic datasets functionality", () => {
     cy.get(".modal").contains("Deleting dataset...").should("be.visible");
 
     // Check the dataset is gone after the project has been indexed
-    if (projectTestConfig.shouldCreateProject) {
-      cy.contains("No datasets found for this project.", {
-        timeout: TIMEOUTS.vlong,
-      }).should("be.visible");
-    }
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
-    // ? Currently, it doesn't disappear instantly
+    cy.waitMetadataIndexing();
+    // ! Currently, datasets don't disappear instantly because the UI uses a renku-core API
+    // ! We can leave this disabled until that's addressed
     // cy.searchForDataset(generatedDatasetName.slug, false);
   });
 });

--- a/cypress-tests/cypress/e2e/updateProjects.cy.ts
+++ b/cypress-tests/cypress/e2e/updateProjects.cy.ts
@@ -139,12 +139,12 @@ describe("Fork and update old projects", () => {
       .should("exist")
       .click();
     if (!commitFetched) {
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(TIMEOUTS.minimal); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.getDataCy("refresh-commits")
         .as("refresh-commits-button-1")
         .should("be.visible");
       cy.get("@refresh-commits-button-1").should("be.visible").click();
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(TIMEOUTS.minimal); // eslint-disable-line cypress/no-unnecessary-waiting
     }
     cy.wait("@getCommits", { timeout: TIMEOUTS.long });
     cy.getDataCy("project-overview-content")
@@ -187,12 +187,12 @@ describe("Fork and update old projects", () => {
       .should("exist")
       .click();
     if (!commitFetched) {
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(TIMEOUTS.minimal); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.getDataCy("refresh-commits")
         .as("refresh-commits-button-2")
         .should("be.visible");
       cy.get("@refresh-commits-button-2").should("be.visible").click();
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(TIMEOUTS.minimal); // eslint-disable-line cypress/no-unnecessary-waiting
     }
     cy.wait("@getCommits", { timeout: TIMEOUTS.long });
     cy.getDataCy("project-overview-content")

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -154,16 +154,10 @@ describe("Basic public project functionality", () => {
       .should("be.visible");
     cy.get(".modal .btn-close").should("be.visible").click();
 
-    // Stop the session
+    // Stop the session and check the project has been indexed
     cy.stopSession();
-
-    // Be sure the project have been indexed
     cy.getDataCy("go-back-button").click();
-    cy.getProjectSection("Settings").click();
-    cy.getDataCy("kg-status-section-open").should("exist").click();
-    cy.getDataCy("project-settings-knowledge-graph")
-      .contains("Everything indexed", { timeout: TIMEOUTS.vlong })
-      .should("exist");
+    cy.waitMetadataIndexing();
 
     // Go the workflows page and check the new workflow appears
     cy.getProjectSection("Workflows").click();

--- a/cypress-tests/cypress/support/commands/datasets.ts
+++ b/cypress-tests/cypress/support/commands/datasets.ts
@@ -24,7 +24,11 @@ export function generatorDatasetName(name: string): DatasetNames {
 function searchForDataset(name: string, shouldExist = true) {
   cy.visit("/search");
   cy.getDataCy("list-card").should("be.visible");
-  cy.getDataCy("type-entity-dataset").should("be.visible").check();
+  cy.getDataCy("type-entity-dataset").should("exist").and("not.be.checked");
+  cy.getDataCy("type-entity-dataset")
+    .scrollIntoView()
+    .should("be.visible")
+    .check();
   cy.get("input[placeholder='Search...']")
     .should("be.visible")
     .type(name)


### PR DESCRIPTION
This should fix a couple of recurring problems with Cypress tests:
- Metadata indexing doesn't necessarily start immediately.
- Using the search page frequently fails.

/deploy
