### PR TITLE
ci: remove the job to clean up old artifacts

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -7,19 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  remove-old-artifacts:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Remove old artifacts
-        uses: c-hive/gha-remove-artifacts@v1
-        with:
-          age: '1 week'
-          # Optional inputs
-          skip-tags: true
-          skip-recent: 10
-        
   remove-CI-deployments:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
It's not needed anymore since we configure the retention days separately.