### PR TITLE
chore: update graph to 2.42.1

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
 - name: renku-graph
   alias: graph
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 2.42.0
+  version: 2.42.1
   condition: graph.enabled
 - name: postgresql
   version: 9.1.1


### PR DESCRIPTION
This PR brings a graph update to `2.42.1` instead of `2.42.0`. It was simply missed in the relevant upgrade PR (#3255).
The changelog has been updated to `2.42.1` already in the mentioned PR.

Sorry for the confusion.

/deploy