### PR TITLE
fix(chart): session network policies, tolerations and affinities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,19 @@
 .. _changelog:
 
+0.39.3
+------
+
+Renku ``0.39.3`` fixes various bugs.
+
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Bug Fixes**
+
+- **Helm chart**: fix problem with missing network policies preventing access to sessions
+- **Helm chart**: use the session specific affinity, node selector and tolerations and not the general configuration reserved for Renku services
+
 0.39.2
 ------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -274,6 +274,7 @@ terraform
 th
 timestamp
 tinkerpop
+tolerations
 toolchain
 Traefik
 truthy

--- a/helm-chart/renku/templates/notebooks/network-policy.yaml
+++ b/helm-chart/renku/templates/notebooks/network-policy.yaml
@@ -22,28 +22,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "renku.notebooks.fullname" . }}-ssh-sessions
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: jupyterserver
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/name: amalthea
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app: {{ template "renku.notebooks.name" . }}-ssh
-      ports:
-        - port: ssh
-          protocol: TCP
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ template "renku.notebooks.fullname" . }}-ssh-sessions-egress
+  name: {{ template "renku.notebooks.fullname" . }}-ssh-jumphost
 spec:
   podSelector:
     matchLabels:
@@ -65,3 +44,52 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "renku.notebooks.fullname" . }}-sessions
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: jupyterserver
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: amalthea
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      # Allow ssh ingress to sessions only for the ssh jump host
+        - podSelector:
+            matchLabels:
+              app: {{ template "renku.notebooks.name" . }}-ssh
+      ports:
+        - port: ssh
+          protocol: TCP
+    - from:
+      # Allow ingress to the oauth2proxy for anyone
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 4180
+  egress:
+    - to:
+      # Allow DNS resolution (internal and external)
+      ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    - to:
+      # Allow access to any port/protocol as long as it is directed
+      # outside of the cluster. This is done by excluding
+      # IP ranges which are reserved for private networking from
+      # the allowed range.
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16

--- a/helm-chart/renku/templates/notebooks/statefulset.yaml
+++ b/helm-chart/renku/templates/notebooks/statefulset.yaml
@@ -135,17 +135,17 @@ spec:
             - name: NB_SESSIONS__CA_CERTS__SECRETS
               value: |
                 {{- .Values.global.certificates.customCAs | toYaml | nindent 16 }}
-            {{- with .Values.sessionNodeSelector }}
+            {{- with .Values.notebooks.sessionNodeSelector }}
             - name: NB_SESSIONS__NODE_SELECTOR
               value: |
                 {{- toYaml . | nindent 16 }}
             {{- end }}
-            {{- with .Values.sessionAffinity }}
+            {{- with .Values.notebooks.sessionAffinity }}
             - name: NB_SESSIONS__AFFINITY
               value: |
                 {{- toYaml . | nindent 16 }}
             {{- end }}
-            {{- with .Values.sessionTolerations }}
+            {{- with .Values.notebooks.sessionTolerations }}
             - name: NB_SESSIONS__TOLERATIONS
               value: |
                 {{- toYaml . | nindent 16 }}

--- a/helm-chart/renku/templates/notebooks/test.yaml
+++ b/helm-chart/renku/templates/notebooks/test.yaml
@@ -68,17 +68,17 @@ spec:
         {{ end }}
         - name: NB_K8S__RENKU_NAMESPACE
           value: {{ $.Release.Namespace | quote }}
-        {{- with $.Values.sessionNodeSelector }}
+        {{- with $.Values.notebooks.sessionNodeSelector }}
         - name: NB_SESSIONS__NODE_SELECTOR
           value: |
             {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with $.Values.sessionAffinity }}
+        {{- with $.Values.notebooks.sessionAffinity }}
         - name: NB_SESSIONS__AFFINITY
           value: |
             {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with $.Values.sessionTolerations }}
+        {{- with $.Values.notebooks.sessionTolerations }}
         - name: NB_SESSIONS__TOLERATIONS
           value: |
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This is the result of the helm chart consolidation.

We did not see this because the problems that this solves do not appear in CI deployments or are not obvious in CI deployments.

/deploy
