### PR TITLE
fix(charts): gitlab chart template names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,18 @@
 .. _changelog:
 
+0.39.3
+------
+
+Renku ``0.39.3`` fixes various bugs.
+
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Bug Fixes**
+
+- **Helm chart**: Publish and use a new Gitlab Omnibus Helm chart (0.8.1) that works with the combined Renku charts
+
 0.39.2
 ------
 

--- a/helm-chart/gitlab/Chart.yaml
+++ b/helm-chart/gitlab/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Renku Gitlab server
 name: gitlab
-version: 0.8.0
+version: 0.8.1

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: gitlab
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.8.0
+  version: 0.8.1
   condition: gitlab.enabled
 - name: postgresql
   version: 9.1.1


### PR DESCRIPTION
The gitlab helm chart is using renkus templates i.e. `renku.http` but before these were not prefixed by `renku.` so we had to fix this there and publish a new version.

The new version of the helm chart has been published. We just have to use it in the renku helm chart now.