### PR TITLE
chore: consistent usage of Dataset name/slug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -241,6 +241,8 @@ Individual components
 ------
 
 Renku ``0.40.0`` introduces UI performance improvements and fixes internal KG and Triples Store performance issues.
+Renku ``0.40.0`` brings coherent usage of Dataset `name` and `slug` across all renku APIs.
+This is a breaking change.
 
 User-Facing Changes
 ~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,9 @@
 0.43.0
 ------
 
-Renku ``0.43.0`` brings improvements to the KG API, addresses a few bugs in the UI
+Renku ``0.43.0`` brings coherent usage of Dataset `name` and `slug` across all renku APIs, addresses a few bugs in the UI
 and in the data services API.
+This is a breaking change. It also comes with improvements to the KG API.
 
 **A note to Renku administrators**: this release includes breaking changes in our Helm chart values file.
 For more details on the Helm chart values changes please refer to the explanation in ``helm-chart/values.yaml.changelog.md``.
@@ -88,10 +89,14 @@ Renku ``0.42.1`` is a bugfix release that addresses the following bugs in a few 
 Individual components
 ~~~~~~~~~~~~~~~~~~~~~~
 
+- `renku-ui x.x.x <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/x.x.x>`_
+- `renku-python x.x.x <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/x.x.x>`_
+- `renku-graph 2.44.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.44.0>`_
 - `renku-data-services 0.2.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.2.1>`_
 - `renku-data-services 0.2.2 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.2.2>`_
 - `renku-notebooks 1.20.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.20.1>`_
 - `renku-notebooks 1.20.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.20.2>`_
+
 
 0.42.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ User-Facing Changes
   (`#1760 <https://github.com/SwissDataScienceCenter/renku-graph/pull/1760>`_).
 - **KG**: Token service and Webhook service can now accept an AES token that is not base64 encoded.
   (`#1774 <https://github.com/SwissDataScienceCenter/renku-graph/pull/1774>`_).
+- **Core Service, CLI**: Add support for specifying project images.
+  (`#3623 <https://github.com/SwissDataScienceCenter/renku-python/issues/3623>`)
+- **CLI**: Add support for pausing/resuming sessions.
+  (`#3633 <https://github.com/SwissDataScienceCenter/renku-python/issues/3633>`)
+- **Core Service**: Add prometheus metrics.
+  (`#3640 <https://github.com/SwissDataScienceCenter/renku-python/issues/3640>`)
 
 **🐞 Bug Fixes**
 
@@ -53,6 +59,8 @@ Internal Changes
   (`#2871 <https://github.com/SwissDataScienceCenter/renku-ui/pull/2871>`_).
 - **CRC**: Do not create new quotas when updating existing ones
 - **CRC**: Use one database connection pool with limited number of connections
+- **Core Service,CLI**: Make slug and name consistent with rest of platform.
+  (`#3620 <https://github.com/SwissDataScienceCenter/renku-python/issues/3620>`)
 
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
@@ -64,6 +72,7 @@ Individual Components
 - `renku-graph 2.44.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.44.0>`_
 - `renku-ui 3.15.1 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.15.1>`_
 - `renku-data-services 0.2.3 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.2.3>`_
+- `renku-python 2.8.0 <https://github.com/SwissDataScienceCenter/renku-python/tree/v2.8.0>`
 
 
 0.42.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,11 +86,17 @@ Renku ``0.42.1`` is a bugfix release that addresses the following bugs in a few 
 - accidentally removing the git repository directory from hibernated sessions
 - properly templating node affinities and tolerations from the ``data-services`` into user sessions
 
+Internal Changes
+~~~~~~~~~~~~~~~~~~~
+
+- **KG**: Java upgraded to 21.0 and Jena to 4.10.0
+
 Individual components
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-ui x.x.x <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/x.x.x>`_
 - `renku-python x.x.x <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/x.x.x>`_
+- `renku-graph 2.45.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.45.0>`_
 - `renku-graph 2.44.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.44.0>`_
 - `renku-data-services 0.2.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.2.1>`_
 - `renku-data-services 0.2.2 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.2.2>`_

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -141,7 +141,7 @@ describe("Basic datasets functionality", () => {
     // Search for the dataset after the project has been indexed
     cy.getDataCy("go-back-button").should("be.visible").click();
     cy.waitMetadataIndexing();
-    cy.searchForDataset(generatedDatasetName.slug);
+    cy.searchForDataset(generatedDatasetName.name);
   });
 
   it("Delete the dataset", () => {

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -5,10 +5,12 @@ admin
 Amalthea
 analytics
 app
+aqs
 args
 Args
 argv
 Ascii
+astroquery
 attrs
 auditability
 auth
@@ -185,6 +187,7 @@ params
 pipenv
 pipx
 PNG
+png
 Postgresql
 powerline
 pre
@@ -193,6 +196,7 @@ prepended
 preprocessed
 preprocessing
 programmatically
+prometheus
 py
 pyshacl
 rclone
@@ -311,6 +315,7 @@ versioning
 Versioning
 vertices
 viewmodel
+vis
 vm
 webhook
 webhooks

--- a/helm-chart/renku/templates/core/deployment.yaml
+++ b/helm-chart/renku/templates/core/deployment.yaml
@@ -140,6 +140,8 @@ spec:
               value: {{ $.Values.global.renku.cli_version | default "" | quote }}
             - name: METADATA_VERSIONS_LIST
               value: /svc/config/metadata-versions/metadata-versions.json
+            - name: RENKU_SKIP_MIN_VERSION_CHECK
+              value: "1"
             {{- include "certificates.env.python" $ | nindent 12 }}
           volumeMounts:
             - name: shared-volume

--- a/helm-chart/renku/templates/graph/triples-generator-deployment.yaml
+++ b/helm-chart/renku/templates/graph/triples-generator-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: "http://{{ template "renku.graph.tokenRepository.fullname" . }}:{{ .Values.graph.tokenRepository.service.port }}"
             - name: GITLAB_BASE_URL
               value: {{ .Values.global.gitlab.url }}
+            - name: RENKU_SKIP_MIN_VERSION_CHECK
+              value: "1"
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.triplesGenerator.gitlab.rateLimit }}
             - name: JENA_BASE_URL

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -27,10 +27,6 @@ spec:
         value: '{{ .Values.tests.parameters.fullname }}'
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
-      {{ if .Values.global.renku.cli_version }}
-      - name: RENKU_CLI_VERSION
-        value: '2.7.0.dev13+gd3eedb5e'
-      {{ end }}
       {{ if .Values.tests.parameters.provider }}
       - name: RENKU_TEST_PROVIDER
         value: '{{ .Values.tests.parameters.provider }}'

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -51,6 +51,8 @@ spec:
       - name: RENKU_TEST_ANON_AVAILABLE
         value: '{{ .Values.tests.parameters.anonAvailable }}'
       {{ end }}
+      - name: RENKU_SKIP_MIN_VERSION_CHECK
+        value: "1"
       {{ if .Values.tests.parameters.batchRemove }}
       - name: RENKU_TEST_BATCH_REMOVE
         value: '{{ .Values.tests.parameters.batchRemove }}'

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -27,6 +27,10 @@ spec:
         value: '{{ .Values.tests.parameters.fullname }}'
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
+      {{ if .Values.global.renku.cli_version }}
+      - name: RENKU_CLI_VERSION
+        value: '2.7.0.dev13+gd3eedb5e'
+      {{ end }}
       {{ if .Values.tests.parameters.provider }}
       - name: RENKU_TEST_PROVIDER
         value: '{{ .Values.tests.parameters.provider }}'

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -62,7 +62,7 @@ global:
         fullnameOverride: ""
         image:
           repository: renku/renku-core
-          tag: "v2.7.0"
+          tag: "v2.8.0"
           pullPolicy: IfNotPresent
       v9:
         name: v9


### PR DESCRIPTION
This PR brings together changes in CLI, UI and KG introducing consistent usage of Dataset `name` and `slug` properties.

/deploy renku-graph=1511-ds-slug-name-only renku-core=develop renku-ui=master


**IMPORTANT:** Undo all the changes to the deployment files before merging!