### PR TITLE
fix(chart): default value for client ID in Gitlab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,18 @@
 .. _changelog:
 
+0.39.3
+------
+
+Renku ``0.39.3`` fixes various bugs.
+
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Bug Fixes**
+
+- **Helm chart**: use the correct default value for the Renku OAuth client in Gitlab
+
 0.39.2
 ------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -47,7 +47,7 @@ global:
     cliClientSecret:
     ## Client id and client secret of the renku gateway client application which is registered in GitLab.
     ## Can be set here or as .gitlabClientId outside of .global, the values set ouside of global (if defined) take precedence.
-    gitlabClientId: #renku
+    gitlabClientId: renku-ui
     ## Should be set to a proper value (i.e. by using openssl rand -hex 32) for production.
     ## Can be set here or as .gitlabClientSecret outside of .global, the values set ouside of global (if defined) take precedence.
     gitlabClientSecret:


### PR DESCRIPTION
The gateway helm chart did not have a default value set for this. But the default value was set in the renku helm chart. When I was combining the helm charts I copied over the values from the component charts into Renku. And when I did this I removed the default we had set for this in the renku chart.

This puts it back. 

For example if you go to https://github.com/SwissDataScienceCenter/renku/blob/0.38.0/helm-chart/renku/values.yaml#L41 you will see it. 0.38.0 is the last version before we combined the helm charts.