### PR TITLE
chore: graph updated to 2.43.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,20 @@
 .. _changelog:
 
+0.39.3
+------
+
+Renku ``0.39.3`` fixes a bug in KG reducing the number of updates in the Triples Store.
+
+**🐞 Bug Fixes**
+
+- **KG**: reduces the number of update queries run against the Triples Store causing its performance degradation.
+
+Individual components
+~~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-graph 2.43.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.43.0>`_
+
+
 0.39.2
 ------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1412,7 +1412,7 @@ graph:
   webhookService:
     image:
       repository: renku/webhook-service
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1432,7 +1432,7 @@ graph:
   tokenRepository:
     image:
       repository: renku/token-repository
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1458,7 +1458,7 @@ graph:
     replicas: 1
     image:
       repository: renku/triples-generator
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1481,7 +1481,7 @@ graph:
     replicas: 1
     image:
       repository: renku/knowledge-graph
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1501,7 +1501,7 @@ graph:
   eventLog:
     image:
       repository: renku/event-log
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1517,7 +1517,7 @@ graph:
   commitEventService:
     image:
       repository: renku/commit-event-service
-      tag: '2.42.1'
+      tag: '2.43.0'
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP


### PR DESCRIPTION
This PR updates graph to `2.43.0`. The release deals with the problem of a high volume of `PROJECT_VIEWED` events causing Triples Store performance degradation. It also fixes validation for ORCID identifiers.

/deploy