### PR TITLE
chore: restore contributed project templates ref

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -742,6 +742,9 @@ ui:
         - url: https://github.com/SwissDataScienceCenter/renku-project-template
           ref: 0.7.1
           name: Renku
+        - url: https://github.com/SwissDataScienceCenter/contributed-project-templates
+          ref: 0.6.0
+          name: Community
 
     # This defines the threshold for automatically showing a preview when browsing projects' files.
     # Above the soft limit, the user receives a warning. Above the hard limit, no preview is available.


### PR DESCRIPTION
This was accidentally removed in the chart refactoring.