### PR TITLE
chore: graph services to use global.gitlab.url

### DIFF
--- a/docs/how-to-guides/admin/gitlab.rst
+++ b/docs/how-to-guides/admin/gitlab.rst
@@ -227,7 +227,7 @@ Upgrading Renku with the newly modified Helm values
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Backup your current unedited values file
-#. Replace every GitLab URL from \https://$RENKU_URL/gitlab to \https://gitlab.$RENKU_URL. There should be 4 instances, at ``gateway.gitlabUrl``, ``graph.gitlab.url``, ``notebooks.gitlab.url`` and ``ui.gitlabUrl``.
+#. Replace every GitLab URL from \https://$RENKU_URL/gitlab to \https://gitlab.$RENKU_URL. There should be 4 instances, at ``gateway.gitlabUrl``, ``notebooks.gitlab.url`` and ``ui.gitlabUrl``.
 #. If you have a value set at ``global.gitlab.urlPrefix`` change it from ``/gitlab`` to ``/``
 #. Set ``gitlab.enabled`` to ``false``.
 #. Re-install the Renku Helm chart with the newly modified values.

--- a/helm-chart/renku/templates/_helpers.tpl
+++ b/helm-chart/renku/templates/_helpers.tpl
@@ -133,7 +133,7 @@ KC_DB_PASSWORD: {{ default (randAlphaNum 64) .Values.global.keycloak.postgresPas
 {{- end -}}
 
 {{- define "renku.gitlabUrl" -}}
-{{ .Values.graph.gitlab.url | default (printf "%s://%s/gitlab" (include "renku.http" .) .Values.global.renku.domain) }}
+{{ .Values.global.gitlab.url | default (printf "%s://%s/gitlab" (include "renku.http" .) .Values.global.renku.domain) }}
 {{- end -}}
 
 {{- define "renku.baseUrl" -}}

--- a/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
+++ b/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
@@ -49,7 +49,7 @@ spec:
               {{- if .Values.gitlab.enabled }}
               value: ""
               {{- else }}
-              value: {{ .Values.graph.gitlab.url | default "" | quote }}
+              value: {{ .Values.global.gitlab.url | default "" | quote }}
               {{- end }}
             - name: REVPROXY_ALLOW_ORIGIN
               value: {{ join "," .Values.gateway.allowOrigin | quote }}

--- a/helm-chart/renku/templates/graph/commit-event-service-deployment.yaml
+++ b/helm-chart/renku/templates/graph/commit-event-service-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: TOKEN_REPOSITORY_BASE_URL
               value: "http://{{ template "renku.graph.tokenRepository.fullname" . }}:{{ .Values.graph.tokenRepository.service.port }}"
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.commitEventService.gitlab.rateLimit }}
             - name: SENTRY_ENABLED

--- a/helm-chart/renku/templates/graph/event-log-deployment.yaml
+++ b/helm-chart/renku/templates/graph/event-log-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: EVENT_LOG_BASE_URL
               value: "http://{{ template "renku.graph.eventLog.fullname" . }}:{{ .Values.graph.eventLog.service.port }}"
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.eventLog.gitlab.rateLimit }}
             - name: SENTRY_ENABLED

--- a/helm-chart/renku/templates/graph/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku/templates/graph/knowledge-graph-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: RENKU_CORE_SERVICE_URLS			
               value: {{ include "renku.graph.core.urls" . | quote }}
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.knowledgeGraph.gitlab.rateLimit }}
             - name: SENTRY_ENABLED

--- a/helm-chart/renku/templates/graph/token-repository-deployment.yaml
+++ b/helm-chart/renku/templates/graph/token-repository-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: TOKEN_REPOSITORY_POSTGRES_CONNECTION_POOL
               value: "{{ .Values.graph.tokenRepository.connectionPool }}"
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.tokenRepository.gitlab.rateLimit }}
             - name: SENTRY_ENABLED

--- a/helm-chart/renku/templates/graph/triples-generator-deployment.yaml
+++ b/helm-chart/renku/templates/graph/triples-generator-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: TOKEN_REPOSITORY_BASE_URL
               value: "http://{{ template "renku.graph.tokenRepository.fullname" . }}:{{ .Values.graph.tokenRepository.service.port }}"
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.triplesGenerator.gitlab.rateLimit }}
             - name: JENA_BASE_URL

--- a/helm-chart/renku/templates/graph/webhook-service-deployment.yaml
+++ b/helm-chart/renku/templates/graph/webhook-service-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: TOKEN_REPOSITORY_BASE_URL
               value: "http://{{ template "renku.graph.tokenRepository.fullname" . }}:{{ .Values.graph.tokenRepository.service.port }}"
             - name: GITLAB_BASE_URL
-              value: {{ .Values.graph.gitlab.url }}
+              value: {{ .Values.global.gitlab.url }}
             - name: GITLAB_RATE_LIMIT
               value: {{ .Values.graph.webhookService.gitlab.rateLimit }}
             - name: SELF_IP

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,7 +5,7 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
-## Upgrading to Renku 0.43.0
+## Upgrading to Renku 0.42.0
 
 * DELETE `graph.gitlab.url` has been removed as graph services uses the `global.gitlab.url`.
 

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,7 +5,7 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
-## Upgrading to Renku 0.42.0
+## Upgrading to Renku 0.43.0
 
 * DELETE `graph.gitlab.url` has been removed as graph services uses the `global.gitlab.url`.
 

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,6 +5,10 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
+## Upgrading to Renku 0.43.0
+
+* DELETE `graph.gitlab.url` has been removed as graph services uses the `global.gitlab.url`.
+
 ## Upgrading to Renku 0.41.0
 
 The UI includes a feature that allows projects to be displayed in the _Showcase_ section of the RenkuLab home page.


### PR DESCRIPTION
This PR changes relevant renku Helm chart config files so `global.gitlab.url` in used instead of `graph.gitlab.url`.

/deploy