### PR TITLE
chore(swagger): add enableServiceLinks swagger pod

### DIFF
--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -51,6 +51,7 @@ spec:
             httpGet:
               path: /swagger
               port: http
+      enableServiceLinks: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The swagger pods has been crashing on renkulab due to a relatively large amount of env variables being defined - initialization scripts which parsed the env vars did not work.

These are not required in the swagger pod and this change means that the large set of env vars are not defined in this pod.
