### PR TITLE
fix: selenium tests to use CLI in version from Core

### DIFF
--- a/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
+++ b/acceptance-tests/src/test/scala/ch/renku/acceptancetests/model/commons.scala
@@ -54,7 +54,9 @@ object CliVersion {
 
     private lazy val extractionRegex: Regex = NonReleasedVersion.validator.r
 
-    lazy val extractionRegex(commitSha) = value
+    lazy val commitSha: String = value match {
+      case extractionRegex(groups @ _*) => groups.last
+    }
   }
 
   object NonReleasedVersion {

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -27,10 +27,6 @@ spec:
         value: '{{ .Values.tests.parameters.fullname }}'
       - name: RENKU_TEST_PASSWORD
         value: '{{ .Values.tests.parameters.password }}'
-      {{ if .Values.global.renku.cli_version }}
-      - name: RENKU_CLI_VERSION
-        value: '{{ .Values.global.renku.cli_version }}'
-      {{ end }}
       {{ if .Values.tests.parameters.provider }}
       - name: RENKU_TEST_PROVIDER
         value: '{{ .Values.tests.parameters.provider }}'


### PR DESCRIPTION
This PR:
* fixes a bug in the selenium tests around commit sha extraction from the non-release CLI version
* removes setting up the `RENKU_CLI_VERSION` env variable for the selenium tests so the version fetched from the Core is used.


/deploy