### PR TITLE
chore: jena upgraded to 4.10.0

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 17.4.2
   condition: redis.install
 - name: renku-jena
-  version: "0.0.21"
+  version: "0.0.22"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   alias: jena
 - name: amalthea


### PR DESCRIPTION
This PR upgrades Jena to `4.10.0` through renku-jena chart `0.22.0`.

/deploy