### PR TITLE
chore: add java to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,7 @@
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
             "packages": ["libenchant-2-2", "graphviz"]
-        }
+        }, 
+		"ghcr.io/devcontainers/features/java:1": {}
 	}
 }


### PR DESCRIPTION
Java is needed since we are running plantuml locally. To build docs, go to docs directory and do `make html`. 