### PR TITLE
docs: configures pipx path according to documentation

### DIFF
--- a/docs/how-to-guides/own_machine/cli-installation.rst
+++ b/docs/how-to-guides/own_machine/cli-installation.rst
@@ -28,7 +28,7 @@ and make sure that the ``$PATH`` is correctly configured.
 ::
 
     $ python3 -m pip install --user pipx
-    $ pipx ensurepath
+    $ python3 -m pipx ensurepath
 
 Once ``pipx`` is installed use following command to install ``renku``.
 


### PR DESCRIPTION
Following the recommended way to configure the PATH variable for pipx : https://github.com/pypa/pipx#install-pipx