### PR TITLE
chore: set keycloak max db connections to 10

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -250,6 +250,8 @@ keycloakx:
     - name: JAVA_OPTS_APPEND
       value: >-
         -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+    - name: KC_DB_POOL_MAX_SIZE
+      value: "10"
 
   command:
     - "/opt/keycloak/bin/kc.sh"


### PR DESCRIPTION
@leafty found that the default value for this in the Keycloak helm chart is 100.\

/deploy