### PR TITLE
chore: skip individual cypress steps

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -129,7 +129,6 @@ jobs:
           test-timeout-mins: "120"
 
   test-pr-cypress:
-    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
 
@@ -149,6 +148,7 @@ jobs:
 
     steps:
       - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.9.1
+        if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ github.ref }}


### PR DESCRIPTION
Allows the PR to be merged even when tests are skipped. 
