### PR TITLE
fix(cypress): fix the checkWorkflows test

### DIFF
--- a/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
+++ b/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
@@ -103,7 +103,8 @@ describe("Workflows pages", () => {
       .contains("span", "m")
       .should("be.visible");
     cy.getDataCy("workflow-details")
-      .get("a#icon-link-5")
+      .contains("tr", "Default value")
+      .find("a")
       .should("be.visible")
       .click();
     cy.get("#file-card-header")

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -19,7 +19,7 @@ export const getIframe = (selector: string) => {
     .then(cy.wrap);
 };
 
-function getDataCy(value: string, exist: true) {
+function getDataCy(value: string, exist?: boolean) {
   if (exist) return cy.get(`[data-cy=${value}]`).should("exist");
   return cy.get(`[data-cy=${value}]`);
 }
@@ -33,8 +33,8 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      getDataCy(value: string, exist?: boolean);
-      getIframe(selector: string): Chainable<unknown>;
+      getDataCy: typeof getDataCy;
+      getIframe: typeof getIframe;
     }
   }
 }


### PR DESCRIPTION
Rewrite the `checkWorkflows` test to use a more descriptive and more robust action to follow the "Default input" link.

See also: https://github.com/SwissDataScienceCenter/renku-ui/pull/3022.

/deploy