### PR TITLE
chore: bump csi-rclone

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -30,6 +30,6 @@ dependencies:
   condition: notebooks.cloudstorage.s3.installDatashim
 - name: csi-rclone
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.1.5"
+  version: "0.1.6"
   condition: global.csi-rclone.install
   


### PR DESCRIPTION
/deploy extra-values=notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-test-liveness,global.csi-rclone.install=true,csi-rclone.storageClassName=csi-rclone-test-liveness,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule