### PR TITLE
chore: remove Github action that opens PRs in `terraform-renku` to update Renkulab.

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -40,16 +40,3 @@ jobs:
         if: always()
     outputs:
       chart-version: ${{ steps.vars.outputs.tag }}
-  rollout-renku-deployments:
-    runs-on: ubuntu-20.04
-    needs:
-      - "publish-chart"
-    steps:
-      - uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Rollout renku version
-        uses: SwissDataScienceCenter/renku-actions/rollout-renku-version@v1.10.0
-        env:
-          CHART_VERSION: ${{ needs.publish-chart.outputs.chart-version }}
-          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Going forward @yat will rely on Renovate to create a PR in `terraform-renku` that updates the version of Renkulab.
