### PR TITLE
chore: disable automatic PRs

### DIFF
--- a/.github/workflows/auto-reqs-update-pr.yml
+++ b/.github/workflows/auto-reqs-update-pr.yml
@@ -1,8 +1,6 @@
 name: Automatic requirements.yml update PR
 on:
-  push:
-    branches:
-      - 'auto-update/**'
+  workflow_dispatch
 jobs:
   auto-pull-request:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disables automatic creation of PRs but keeps as a dispatch trigger in case we still want to use some of the functionality. 