### PR TITLE
feat: enable NetPol for Solr.

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -498,7 +498,17 @@ solr:
     - renku-search
   javaMem: "-Xmx512M"
   networkPolicy:
-    enabled: false # Awaiting instructions from: https://github.com/bitnami/charts/issues/23424
+    allowExternal: false
+    extraIngress:
+      - ports:
+          - port: 8983
+        from:
+          - podSelector:
+              matchLabels:
+                app: search-api
+          - podSelector:
+              matchLabels:
+                app: search-provision
   persistence:
     enabled: true
     size: 8Gi


### PR DESCRIPTION
This change to the values files of Solr enables a network policy to Solr such that only `search-api` and `search-provision` are allowed to connect to it.
/deploy
