### PR TITLE
fix: Do not use OCI helm chart requirements.

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     condition: gitlab.enabled
   - name: postgresql
     version: "14.2.4"
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
     condition: postgresql.enabled
   - name: keycloakx
     version: 2.1.0


### PR DESCRIPTION
The toolchain to publish the Renku chart is not ready yet to deal with those.

/deploy