### PR TITLE
chore: add sentry and prometheus for data services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Internal Changes
 **New Features**
 
 - **Data services**: Initial support for project and user search for Renku 2.0 (alpha release)
+- **Data services**: Add support for sentry and prometheus
 - **Search services**: Initial support for project and user search for Renku 2.0 (alpha release)
 
 **Improvements**
@@ -21,6 +22,7 @@ Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-data-services 0.6.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.6.0>`_
+- `renku-data-services 0.7.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.7.0>`_
 - `renku-gateway 0.24.0 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/0.24.0>`_
 - `renku-search 0.0.37 <https://github.com/SwissDataScienceCenter/renku-search/releases/tag/v0.0.37>`_
 - `renku-graph 2.50.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.50.0>`_

--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -91,6 +91,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.redis.existingSecret }}
                   key: {{ .Values.global.redis.existingSecretPasswordKey }}
+            - name: SENTRY_ENABLED
+              value: {{ .Values.dataService.sentry.enabled | quote }}
+            - name: SENTRY_DSN
+              value: {{ .Values.dataService.sentry.dsn | quote }}
+            - name: SENTRY_ENVIRONMENT
+              value: {{ .Values.dataService.sentry.environment | quote }}
+            - name: SENTRY_SAMPLE_RATE
+              value: {{ .Values.dataService.sentry.sampleRate | quote }}
             {{- include "certificates.env.python" $ | nindent 12 }}
           volumeMounts:
             - name: server-options

--- a/helm-chart/renku/templates/data-service/service.yaml
+++ b/helm-chart/renku/templates/data-service/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "renku.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '8000'
 spec:
   type: {{ .Values.dataService.service.type }}
   ports:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1567,6 +1567,11 @@ dataService:
   service:
     type: ClusterIP
     port: 80
+  sentry:
+    enabled: false
+    dsn:
+    environment:
+    sampleRate: 0.1
   replicaCount: 2
   podAnnotations: {}
   resources: {}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1557,12 +1557,12 @@ initDb:
 dataService:
   image:
     repository: renku/renku-data-service
-    tag: "0.6.0"
+    tag: "0.7.0"
     pullPolicy: IfNotPresent
   keycloakSync:
     image:
       repository: renku/keycloak-sync
-      tag: "0.6.0"
+      tag: "0.7.0"
       pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
/deploy extra-values=dataService.sentry.enabled=true,dataService.sentry.dsn=https://e47c95d665684bce89984bd4595268df@sentry.dev.renku.ch/13,dataService.sentry.environment=ci-renku-3548,dataService.sentry.sampleRate=0.5