### PR TITLE
chore: renku-graph 2.50.0 (with Jena 5.0.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,12 +13,17 @@ Internal Changes
 - **Data services**: Initial support for project and user search for Renku 2.0 (alpha release)
 - **Search services**: Initial support for project and user search for Renku 2.0 (alpha release)
 
+**Improvements**
+
+- **KG**: Jena 5.0.0 upgrade
+
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-data-services 0.6.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.6.0>`_
 - `renku-gateway 0.24.0 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/0.24.0>`_
 - `renku-search 0.0.37 <https://github.com/SwissDataScienceCenter/renku-search/releases/tag/v0.0.37>`_
+- `renku-graph 2.50.0 <https://github.com/SwissDataScienceCenter/renku-graph/releases/tag/2.50.0>`_
 
 
 0.49.1

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 17.4.2
     condition: redis.install
   - name: renku-jena
-    version: "0.0.23"
+    version: "0.0.24"
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
     alias: jena
   - name: amalthea

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 17.4.2
     condition: redis.install
   - name: renku-jena
-    version: "0.0.24"
+    version: "0.0.25"
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
     alias: jena
   - name: amalthea

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1378,7 +1378,7 @@ graph:
     aesEncryptionKey: # A 8, 16 or 32 bytes string used for AES encryption of the project tokens
     image:
       repository: renku/webhook-service
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1394,7 +1394,7 @@ graph:
     aesEncryptionKey: # A 8, 16 or 32 bytes string used for AES encryption of the project tokens
     image:
       repository: renku/token-repository
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1415,7 +1415,7 @@ graph:
     replicas: 1
     image:
       repository: renku/triples-generator
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1437,7 +1437,7 @@ graph:
     replicas: 1
     image:
       repository: renku/knowledge-graph
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1456,7 +1456,7 @@ graph:
   eventLog:
     image:
       repository: renku/event-log
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1471,7 +1471,7 @@ graph:
   commitEventService:
     image:
       repository: renku/commit-event-service
-      tag: "2.49.1"
+      tag: "2.50.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP


### PR DESCRIPTION
This PR:
* upgrades renku-graph to `2.50.0`
* upgrades Jena to `5.0.0`

/deploy