### PR TITLE
doc: improve the custom CA configuration part

### DIFF
--- a/docs/how-to-guides/admin/prerequisites/certificates.rst
+++ b/docs/how-to-guides/admin/prerequisites/certificates.rst
@@ -48,16 +48,17 @@ configuration values:
 
 .. code-block:: yaml
 
+  global:
+    certificates:
+      customCAs:
+        - secret: renku-tls # must match the secretName field of the CA Certificate object.
+
   ingress:
     enabled: true
     annotations:
       cert-manager.io/cluster-issuer: null
       cert-manager.io/issuer: my-ca-issuer
       cert-manager.io/common-name: my-selfsigned-ca
-
-  certificates:
-    customCAs:
-      - secret: renku-tls
 
 For more details about the annotations, please check the ``values.yaml`` files.
 


### PR DESCRIPTION
The current version shows the configuration at the top level of the yaml while it should be under the global scope.

More details about the global scope in the [helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/).