### PR TITLE
Skip stopping button check

### DIFF
--- a/cypress-tests/cypress/support/commands/sessions.ts
+++ b/cypress-tests/cypress/support/commands/sessions.ts
@@ -84,7 +84,6 @@ function deleteSession(args?: { fromSessionPage?: boolean }) {
   }
 
   cy.getDataCy("delete-session-modal-button").should("be.visible").click();
-  cy.getDataCy("stopping-btn").should("be.visible");
   cy.get(".renku-container", { timeout: TIMEOUTS.vlong })
     .contains("No currently running sessions")
     .should("be.visible");


### PR DESCRIPTION
The check for the stopping button to be visible after stopping a session causes flakiness since the session can be removed very quickly, in which case the button is never shown.