### PR TITLE
chore: set bitnami-common version in the parent chart

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -36,6 +36,7 @@ dependencies:
     repository: "oci://registry-1.docker.io/bitnamicharts"
     version: "8.9.2"
     condition: solr.enabled
+    # setting the version of bitnami-common here to avoid conflicts in sub-charts bundling different versions
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -36,3 +36,8 @@ dependencies:
     repository: "oci://registry-1.docker.io/bitnamicharts"
     version: "8.9.2"
     condition: solr.enabled
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+    - bitnami-common
+    version: 2.x.x


### PR DESCRIPTION
`bitnami/common` is used in several places and can cause version conflicts. 
