### PR TITLE
fix: parallel cypress tests

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.1
         env:
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set version
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.1
         env:
           CHART_DIR: helm-chart/
           CHART_NAME: renku

--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -35,7 +35,7 @@ jobs:
       - id: set-version
         run: |
           echo "publish_version=${{ steps.bump-semver.outputs.new_version }}.$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.1
         env:
           CHART_DIR: helm-chart/
           CHART_TAG: "--tag ${{env.publish_version}}"

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.1
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4.1.2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.1
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -120,7 +120,7 @@ jobs:
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.1
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: ci-renku-${{ github.event.number }}
@@ -148,7 +148,7 @@ jobs:
           ]
 
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@chore-update-node-cypress-action
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.11.1
         if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
         with:
           e2e-target: ${{ matrix.tests }}
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.1
         env:
           HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -148,7 +148,7 @@ jobs:
           ]
 
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@chore-update-node-cypress-action
         if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
         with:
           e2e-target: ${{ matrix.tests }}

--- a/.github/workflows/renku-dev-test.yaml
+++ b/.github/workflows/renku-dev-test.yaml
@@ -8,7 +8,7 @@ jobs:
       github.event.client_payload.message == 'Helm test succeeded' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.1
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku

--- a/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
+++ b/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
@@ -10,17 +10,6 @@ const project: ProjectIdentifier = {
 const sessionId = ["checkWorkflows", getRandomString()];
 
 describe("Workflows pages", () => {
-  before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-  });
-
   beforeEach(() => {
     // Restore the session
     cy.session(

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -38,7 +38,7 @@ describe("Basic public project functionality", () => {
       },
       validateLogin
     );
-    cy.createProject({templateName: "Python", ...projectIdentifier, visibility: "private"});
+    cy.createProjectIfMissing({templateName: "Python", ...projectIdentifier, visibility: "private"});
     cy.visitAndLoadProject(projectIdentifier);
   });
 

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -37,6 +37,13 @@ describe("Basic public project functionality", () => {
     // Create a project for the local spec
     if (projectTestConfig.shouldCreateProject) {
       cy.visit("/");
+      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+      cy.request("ui-server/api/user").then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).property("username").to.not.be.empty;
+        expect(response.body).property("username").to.not.be.null;
+        expect(response.body).property("state").to.equal("active");
+      });
       cy.createProject({
         templateName: "Python",
         ...projectIdentifier,

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -39,7 +39,7 @@ describe("Basic public project functionality", () => {
       },
       validateLogin
     );
-    cy.createProject({ templateName: "Python", ...projectIdentifier });
+    cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
   });
 

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -9,12 +9,12 @@ import { validateLogin, getRandomString } from "../support/commands/general";
 const username = Cypress.env("TEST_USERNAME");
 
 const projectTestConfig = {
-  shouldCreateProject: true,
+  projectAlreadyExists: false,
   projectName: generatorProjectName("publicProject"),
 };
 
 // ? Uncomment to debug using an existing project
-// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectAlreadyExists = true;
 // projectTestConfig.projectName = "cypress-publicproject-8e01a2e0a8c1";
 
 const projectIdentifier: ProjectIdentifier = {
@@ -25,28 +25,9 @@ const projectIdentifier: ProjectIdentifier = {
 const sessionId = ["publicProject", getRandomString()];
 
 describe("Basic public project functionality", () => {
-  before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-
-    // Create a project for the local spec
-    if (projectTestConfig.shouldCreateProject) {
-      cy.visit("/");
-      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
-      cy.request("ui-server/api/user").then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body).property("username").to.not.be.empty;
-        expect(response.body).property("username").to.not.be.null;
-        expect(response.body).property("state").to.equal("active");
-      });
-      cy.createProject({ templateName: "Python", ...projectIdentifier });
-    }
+  after(() => {
+    if (!projectTestConfig.projectAlreadyExists)
+      cy.deleteProjectFromAPI(projectIdentifier);
   });
 
   beforeEach(() => {
@@ -58,6 +39,7 @@ describe("Basic public project functionality", () => {
       },
       validateLogin
     );
+    cy.createProject({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
   });
 
@@ -77,7 +59,7 @@ describe("Basic public project functionality", () => {
     cy.getProjectSection("Overview").click();
     cy.contains("README.md").should("be.visible");
     cy.contains("This is a Renku project").should("be.visible");
-    if (projectTestConfig.shouldCreateProject) {
+    if (!projectTestConfig.projectAlreadyExists) {
       cy.contains("Welcome to your new Renku project", {
         timeout: TIMEOUTS.vlong,
       }).should("be.visible");
@@ -115,7 +97,7 @@ describe("Basic public project functionality", () => {
     cy.getDataCy("project-status-icon-element").should("not.exist");
     cy.getProjectSection("Settings").click();
     cy.getDataCy("project-version-section-open").should("exist").click();
-    if (projectTestConfig.shouldCreateProject) {
+    if (!projectTestConfig.projectAlreadyExists) {
       cy.getDataCy("project-settings-migration-status")
         .contains("This project uses the latest")
         .should("exist");

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -38,6 +38,13 @@ describe("Basic public project functionality", () => {
     // Create a project for the local spec
     if (projectTestConfig.shouldCreateProject) {
       cy.visit("/");
+      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+      cy.request("ui-server/api/user").then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).property("username").to.not.be.empty;
+        expect(response.body).property("username").to.not.be.null;
+        expect(response.body).property("state").to.equal("active");
+      });
       cy.createProject({ templateName: "Python", ...projectIdentifier });
     }
   });

--- a/cypress-tests/cypress/e2e/rstudioSession.cy.ts
+++ b/cypress-tests/cypress/e2e/rstudioSession.cy.ts
@@ -40,7 +40,7 @@ describe("Basic rstudio functionality", () => {
       },
       validateLogin
     );
-    cy.createProject({ templateName: "R (", ...projectIdentifier });
+    cy.createProjectIfMissing({ templateName: "R (", ...projectIdentifier });
     cy.stopAllSessionsForProject(projectIdentifier);
   });
 

--- a/cypress-tests/cypress/e2e/rstudioSession.cy.ts
+++ b/cypress-tests/cypress/e2e/rstudioSession.cy.ts
@@ -10,12 +10,12 @@ import { validateLogin, getRandomString } from "../support/commands/general";
 const username = Cypress.env("TEST_USERNAME");
 
 const projectTestConfig = {
-  shouldCreateProject: true,
+  projectAlreadyExists: false,
   projectName: generatorProjectName("rstudioSession"),
 };
 
 // ? Uncomment to debug using an existing project
-// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectAlreadyExists = true;
 // projectTestConfig.projectName = "cypress-publicproject-4ed4fb12c5e6";
 
 const projectIdentifier: ProjectIdentifier = {
@@ -26,32 +26,8 @@ const projectIdentifier: ProjectIdentifier = {
 const sessionId = ["rstudioSession", getRandomString()];
 
 describe("Basic rstudio functionality", () => {
-  before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-
-    // Create a project
-    if (projectTestConfig.shouldCreateProject) {
-      cy.visit("/");
-      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
-      cy.request("ui-server/api/user").then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body).property("username").to.not.be.empty;
-        expect(response.body).property("username").to.not.be.null;
-        expect(response.body).property("state").to.equal("active");
-      });
-      cy.createProject({ templateName: "R (", ...projectIdentifier });
-    }
-  });
-
   after(() => {
-    if (projectTestConfig.shouldCreateProject)
+    if (!projectTestConfig.projectAlreadyExists)
       cy.deleteProjectFromAPI(projectIdentifier);
   });
 
@@ -64,6 +40,7 @@ describe("Basic rstudio functionality", () => {
       },
       validateLogin
     );
+    cy.createProject({ templateName: "R (", ...projectIdentifier });
     cy.stopAllSessionsForProject(projectIdentifier);
   });
 

--- a/cypress-tests/cypress/e2e/rstudioSession.cy.ts
+++ b/cypress-tests/cypress/e2e/rstudioSession.cy.ts
@@ -39,6 +39,13 @@ describe("Basic rstudio functionality", () => {
     // Create a project
     if (projectTestConfig.shouldCreateProject) {
       cy.visit("/");
+      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+      cy.request("ui-server/api/user").then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).property("username").to.not.be.empty;
+        expect(response.body).property("username").to.not.be.null;
+        expect(response.body).property("state").to.equal("active");
+      });
       cy.createProject({ templateName: "R (", ...projectIdentifier });
     }
   });

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -39,6 +39,13 @@ describe("Basic datasets functionality", () => {
     // Create a project for the local spec
     if (projectTestConfig.shouldCreateProject) {
       cy.visit("/");
+      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+      cy.request("ui-server/api/user").then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).property("username").to.not.be.empty;
+        expect(response.body).property("username").to.not.be.null;
+        expect(response.body).property("state").to.equal("active");
+      });
       cy.createProject({ templateName: "Python", ...projectIdentifier });
     }
 

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -9,12 +9,12 @@ import { generatorDatasetName } from "../support/commands/datasets";
 const username = Cypress.env("TEST_USERNAME");
 
 const projectTestConfig = {
-  shouldCreateProject: true,
+  projectAlreadyExists: false,
   projectName: generatorProjectName("testDatasets"),
 };
 
 // ? Uncomment to debug using an existing project
-// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectAlreadyExists = true;
 // projectTestConfig.projectName = "cypress-usedatasets-a572ce0e177d";
 
 const projectIdentifier: ProjectIdentifier = {
@@ -27,28 +27,6 @@ const sessionId = ["testDatasets", getRandomString()];
 
 describe("Basic datasets functionality", () => {
   before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-
-    // Create a project for the local spec
-    if (projectTestConfig.shouldCreateProject) {
-      cy.visit("/");
-      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
-      cy.request("ui-server/api/user").then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body).property("username").to.not.be.empty;
-        expect(response.body).property("username").to.not.be.null;
-        expect(response.body).property("state").to.equal("active");
-      });
-      cy.createProject({ templateName: "Python", ...projectIdentifier });
-    }
-
     // Intercept listing datasets
     cy.intercept("/ui-server/api/renku/*/datasets.list?git_url=*", (req) => {
       listDatasetsInvoked = true;
@@ -64,6 +42,7 @@ describe("Basic datasets functionality", () => {
       },
       validateLogin
     );
+    cy.createProject({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
 
     // Reset dataset interceptor
@@ -71,7 +50,7 @@ describe("Basic datasets functionality", () => {
   });
 
   after(() => {
-    if (projectTestConfig.shouldCreateProject)
+    if (!projectTestConfig.projectAlreadyExists)
       cy.deleteProjectFromAPI(projectIdentifier);
   });
 
@@ -86,7 +65,7 @@ describe("Basic datasets functionality", () => {
       cy.wait("@listDatasets", { timeout: TIMEOUTS.long });
 
     // A new project should not contain datasets
-    if (projectTestConfig.shouldCreateProject) {
+    if (!projectTestConfig.projectAlreadyExists) {
       cy.contains("No datasets found for this project.", {
         timeout: TIMEOUTS.vlong,
       }).should("be.visible");

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -42,7 +42,7 @@ describe("Basic datasets functionality", () => {
       },
       validateLogin
     );
-    cy.createProject({ templateName: "Python", ...projectIdentifier });
+    cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
 
     // Reset dataset interceptor

--- a/cypress-tests/cypress/e2e/updateProjects.cy.ts
+++ b/cypress-tests/cypress/e2e/updateProjects.cy.ts
@@ -21,17 +21,6 @@ const projects = {
 const sessionId = ["updateProjects", getRandomString()];
 
 describe("Fork and update old projects", () => {
-  before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-  });
-
   beforeEach(() => {
     // Restore the session
     cy.session(

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -41,7 +41,7 @@ describe("Basic public project functionality", () => {
       },
       validateLogin
     );
-    cy.createProject({ templateName: "Python", ...projectIdentifier });
+    cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
   });
 
   it("Start a new session on the project and interact with the terminal.", () => {

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -40,6 +40,13 @@ describe("Basic public project functionality", () => {
     // Create a project
     if (projectTestConfig.shouldCreateProject) {
       cy.visit("/");
+      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+      cy.request("ui-server/api/user").then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).property("username").to.not.be.empty;
+        expect(response.body).property("username").to.not.be.null;
+        expect(response.body).property("state").to.equal("active");
+      });
       cy.createProject({ templateName: "Python", ...projectIdentifier });
     }
   });

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -6,12 +6,12 @@ import { v4 as uuidv4 } from "uuid";
 const username = Cypress.env("TEST_USERNAME");
 
 const projectTestConfig = {
-  shouldCreateProject: true,
+  projectAlreadyExists: false,
   projectName: generatorProjectName("useSession"),
 };
 
 // ? Modify the config -- useful for debugging
-// projectTestConfig.shouldCreateProject = false;
+// projectTestConfig.projectAlreadyExists = true;
 // projectTestConfig.projectName = "cypress-usesession-a8c6823e40ff";
 
 const projectIdentifier = {
@@ -27,32 +27,8 @@ const projectWithoutPermissions = {
 const sessionId = ["useSession", getRandomString()];
 
 describe("Basic public project functionality", () => {
-  before(() => {
-    // Use a session to preserve login data
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLogin
-    );
-
-    // Create a project
-    if (projectTestConfig.shouldCreateProject) {
-      cy.visit("/");
-      cy.request("ui-server/api/data/user").its("status").should("eq", 200);
-      cy.request("ui-server/api/user").then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body).property("username").to.not.be.empty;
-        expect(response.body).property("username").to.not.be.null;
-        expect(response.body).property("state").to.equal("active");
-      });
-      cy.createProject({ templateName: "Python", ...projectIdentifier });
-    }
-  });
-
   after(() => {
-    if (projectTestConfig.shouldCreateProject)
+    if (!projectTestConfig.projectAlreadyExists)
       cy.deleteProjectFromAPI(projectIdentifier);
   });
 
@@ -65,6 +41,7 @@ describe("Basic public project functionality", () => {
       },
       validateLogin
     );
+    cy.createProject({ templateName: "Python", ...projectIdentifier });
   });
 
   it("Start a new session on the project and interact with the terminal.", () => {

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -3,7 +3,7 @@ import { TIMEOUTS } from "../../../config";
 export const validateLogin = {
   validate() {
     // This returns 401 when not properly logged in
-    cy.request("/ui-server/api/user");
+    cy.request("/ui-server/api/data/user");
   },
 };
 

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -2,6 +2,9 @@ import { TIMEOUTS } from "../../../config";
 
 export const validateLogin = {
   validate() {
+    // If we send a request to the user endpoint on Gitlab too quickly after we log in then
+    // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
+    // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
     cy.wait(10000);
     // This returns 401 when not properly logged in
     cy.request("ui-server/api/data/user").its("status").should("eq", 200);

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -2,8 +2,16 @@ import { TIMEOUTS } from "../../../config";
 
 export const validateLogin = {
   validate() {
+    cy.wait(10000);
     // This returns 401 when not properly logged in
-    cy.request("/ui-server/api/data/user");
+    cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+    // This is how the ui decides the user is logged in
+    cy.request("ui-server/api/user").then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).property("username").to.not.be.empty;
+      expect(response.body).property("username").to.not.be.null;
+      expect(response.body).property("state").to.equal("active");
+    });
   },
 };
 

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -99,8 +99,14 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
   })
   cy.get("header").should("be.visible");
   cy.get("footer").should("be.visible");
-  cy.wait(1000);
+  cy.wait(10000);
   cy.request("ui-server/api/data/user").its("status").should("eq", 200);
+  cy.request("ui-server/api/user").then((response) => {
+    expect(response.status).to.eq(200);
+    expect(response.body).property("username").to.not.be.empty;
+    expect(response.body).property("username").to.not.be.null;
+    expect(response.body).property("state").to.equal("active");
+  });
 }
 
 type RobustLoginProps = {

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -16,12 +16,6 @@ const renkuLogin = (credentials: { username: string; password: string }[]) => {
         .click();
     }
   });
-  cy.location().should((loc) => {
-    const baseURL = new URL(Cypress.config("baseUrl"));
-    expect(["/", ""]).to.include(loc.pathname);
-    expect(loc.search).to.eq("");
-    expect(loc.hostname).to.eq(baseURL.hostname);
-  })
 };
 
 const register = (
@@ -34,7 +28,7 @@ const register = (
 
   // ? wait to be assess whether tokens were refreshed automatically or we really need to register
   cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-  cy.request({ failOnStatusCode: false, url: "ui-server/api/user" }).then(
+  cy.request({ failOnStatusCode: false, url: "ui-server/api/data/user" }).then(
     (resp) => {
       if (resp.status === 200) return;
 
@@ -103,7 +97,7 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
     expect(loc.search).to.eq("");
     expect(loc.hostname).to.eq(baseURL.hostname);
   })
-  cy.request("ui-server/api/user").its("status").should("eq", 200);
+  cy.request("ui-server/api/data/user").its("status").should("eq", 200);
 }
 
 type RobustLoginProps = {
@@ -115,7 +109,7 @@ type RobustLoginProps = {
 
 function robustLogin(props?: RobustLoginProps) {
   // Check if we are already logged in
-  cy.request({ failOnStatusCode: false, url: "ui-server/api/user" }).then(
+  cy.request({ failOnStatusCode: false, url: "ui-server/api/data/user" }).then(
     (resp) => {
       // we are already logged in
       if (resp.status >= 200 && resp.status < 400) return;

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -97,6 +97,9 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
     expect(loc.search).to.eq("");
     expect(loc.hostname).to.eq(baseURL.hostname);
   })
+  cy.get("header").should("be.visible");
+  cy.get("footer").should("be.visible");
+  cy.wait(1000);
   cy.request("ui-server/api/data/user").its("status").should("eq", 200);
 }
 

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -99,6 +99,9 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
   })
   cy.get("header").should("be.visible");
   cy.get("footer").should("be.visible");
+  // If we send a request to the user endpoint on Gitlab too quickly after we log in then
+  // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
+  // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
   cy.wait(10000);
   cy.request("ui-server/api/data/user").its("status").should("eq", 200);
   cy.request("ui-server/api/user").then((response) => {

--- a/cypress-tests/cypress/support/commands/projects.ts
+++ b/cypress-tests/cypress/support/commands/projects.ts
@@ -69,39 +69,46 @@ interface NewProjectProps extends ProjectIdentifier {
 }
 
 function createProject(newProjectProps: NewProjectProps) {
-  cy.visit("/projects/new");
-  cy.getDataCy("field-group-title")
-    .should("be.visible")
-    .clear()
-    .type(newProjectProps.name);
-  if (newProjectProps.namespace) {
-    cy.get("#namespace-input")
-      .should("be.visible")
-      .clear()
-      .type(newProjectProps.namespace);
-  }
+  const namespace = newProjectProps.namespace ?? Cypress.env("TEST_USERNAME");
+  const slug = encodeURIComponent(`${namespace}/${newProjectProps.name}`);
+  cy.request({failOnStatusCode: false, method: "GET", url: `/ui-server/api/projects/${slug}`}).then((response) => {
+    if (response.status != 200) {
+      cy.visit("/projects/new");
+      cy.getDataCy("field-group-title")
+        .should("be.visible")
+        .clear()
+        .type(newProjectProps.name);
+      if (newProjectProps.namespace) {
+        cy.get("#namespace-input")
+          .should("be.visible")
+          .clear()
+          .type(newProjectProps.namespace);
+      }
 
-  if (newProjectProps.templateName)
-    cy.contains(newProjectProps.templateName).should("be.visible").click();
+      if (newProjectProps.templateName)
+        cy.contains(newProjectProps.templateName).should("be.visible").click();
 
-  if (newProjectProps.visibility) {
-    cy.getDataCy(`visibility-${newProjectProps.visibility}`)
-      .should("be.visible")
-      .click();
-  }
-
-  // The button may take some time before it is clickable
-  cy.get("[data-cy=create-project-button]", { timeout: TIMEOUTS.vlong })
-    .should("be.enabled")
-    .click();
-  cy.url({ timeout: TIMEOUTS.vlong }).should(
-    "contain",
-    newProjectProps.name.toLowerCase()
-  );
-  cy.get(`[data-cy="header-project"]`, { timeout: TIMEOUTS.vlong }).should(
-    "be.visible"
-  );
-  cy.get("ul.nav-pills-underline").should("be.visible");
+      if (newProjectProps.visibility) {
+        cy.getDataCy(`visibility-${newProjectProps.visibility}`)
+          .should("be.visible")
+          .click();
+      }
+      // The button may take some time before it is clickable
+      cy.get("[data-cy=create-project-button]", { timeout: TIMEOUTS.vlong })
+        .should("be.enabled")
+        .click();
+    } else {
+      cy.visit(`projects/${namespace}/${newProjectProps.name}`);
+    }
+    cy.url({ timeout: TIMEOUTS.vlong }).should(
+      "contain",
+      newProjectProps.name.toLowerCase()
+    );
+    cy.get(`[data-cy="header-project"]`, { timeout: TIMEOUTS.vlong }).should(
+      "be.visible"
+    );
+    cy.get("ul.nav-pills-underline").should("be.visible");
+  });
 }
 
 function deleteProjectFromAPI(identifier: ProjectIdentifier) {

--- a/cypress-tests/cypress/support/commands/projects.ts
+++ b/cypress-tests/cypress/support/commands/projects.ts
@@ -68,7 +68,7 @@ interface NewProjectProps extends ProjectIdentifier {
   visibility?: "public" | "private" | "internal";
 }
 
-function createProject(newProjectProps: NewProjectProps) {
+function createProjectIfMissing(newProjectProps: NewProjectProps) {
   const namespace = newProjectProps.namespace ?? Cypress.env("TEST_USERNAME");
   const slug = encodeURIComponent(`${namespace}/${newProjectProps.name}`);
   cy.request({failOnStatusCode: false, method: "GET", url: `/ui-server/api/projects/${slug}`}).then((response) => {
@@ -272,7 +272,7 @@ function waitMetadataIndexing(justTriggered = true, goToSettings = true) {
 }
 
 export default function registerProjectCommands() {
-  Cypress.Commands.add("createProject", createProject);
+  Cypress.Commands.add("createProjectIfMissing", createProjectIfMissing);
   Cypress.Commands.add("deleteProject", deleteProject);
   Cypress.Commands.add("deleteProjectFromAPI", deleteProjectFromAPI);
   Cypress.Commands.add("forkProject", forkProject);
@@ -289,7 +289,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      createProject(newProjectProps: NewProjectProps);
+      createProjectIfMissing(newProjectProps: NewProjectProps);
       deleteProject(identifier: ProjectIdentifier, loadProject?: boolean);
       deleteProjectFromAPI(identifier: ProjectIdentifier);
       forkProject(identifier: ProjectIdentifier, newName: string);

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -1005,14 +1005,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.17.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
-      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -1045,6 +1045,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -1070,6 +1071,11 @@
       "peerDependencies": {
         "cypress": ">=2.1.0"
       }
+    },
+    "node_modules/cypress/node_modules/@types/node": {
+      "version": "16.18.96",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
+      "integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -2548,6 +2554,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -3863,13 +3877,13 @@
       }
     },
     "cypress": {
-      "version": "12.17.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
-      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "requires": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -3902,6 +3916,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -3909,6 +3924,13 @@
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.96",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
+          "integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ=="
+        }
       }
     },
     "cypress-localstorage-commands": {
@@ -4986,6 +5008,11 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "proxy-from-env": {
       "version": "1.0.0",


### PR DESCRIPTION
I think the reason for the failures when things run in parallel is that the tests do not wait sufficiently long for the redirects of the login process to finish. And they try to visit a page before the user has fully logged in.

Hopefully the check of the url after the login process finishes is enough to remedy this. 

/deploy

The changes that helped are:
- Adding a wait right after the login completes, for some reason the main problem was that after the login was complete calling gitlab still randomly resulted in 401s half the time. But after waiting for 10s Gitlab does not respond with 401s.
- Removing the login from the before hook and adding it to every beforeEach hook. I did the same with the project creation. This is better because beforeEach hooks are retried where as a single failure in the before hooks cannot be retried and results in the test failing.