### PR TITLE
chore: update renku actions 1.11.1

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.1
         env:
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set version
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.1
         env:
           CHART_DIR: helm-chart/
           CHART_NAME: renku

--- a/.github/workflows/publish-master-merges.yaml
+++ b/.github/workflows/publish-master-merges.yaml
@@ -35,7 +35,7 @@ jobs:
       - id: set-version
         run: |
           echo "publish_version=${{ steps.bump-semver.outputs.new_version }}.$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.11.1
         env:
           CHART_DIR: helm-chart/
           CHART_TAG: "--tag ${{env.publish_version}}"

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.2
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.1
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4.1.2
       - name: renku build and deploy
         if: needs.check-deploy.outputs.pr-contains-string == 'true'
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.1
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -120,7 +120,7 @@ jobs:
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.1
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: ci-renku-${{ github.event.number }}
@@ -148,7 +148,7 @@ jobs:
           ]
 
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.11.1
         if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
         with:
           e2e-target: ${{ matrix.tests }}
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.1
         env:
           HELM_RELEASE_REGEX: "^ci-renku-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/renku-dev-test.yaml
+++ b/.github/workflows/renku-dev-test.yaml
@@ -8,7 +8,7 @@ jobs:
       github.event.client_payload.message == 'Helm test succeeded' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.1
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku


### PR DESCRIPTION
This should make the cypress tests run more reliably.

/deploy