### PR TITLE
fix: cloning repositories in sessions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,26 @@
 .. _changelog:
 
+0.51.1
+------
+
+Renku ``0.51.1`` fixes a bug where sessions were not considering the case (upper or lower) of the
+project name that was being cloned when a session is started. This resulted in the working directory
+being set to one location and the project cloned in another. This bug only affected projects where
+users have manually changed their project paths to include uppercase characters or for projects that
+were not created through Renku but were imported after creation.
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+- **Notebooks**: Use the case sensitive project name when cloning repositories at startup
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-notebooks 1.22.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.22.1>`_
+
 0.51.0
 ------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -990,7 +990,7 @@ notebooks:
     targetCPUUtilizationPercentage: 50
   image:
     repository: renku/renku-notebooks
-    tag: "1.22.0"
+    tag: "1.22.1"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1108,15 +1108,15 @@ notebooks:
   gitRpcServer:
     image:
       name: renku/git-rpc-server
-      tag: "1.22.0"
+      tag: "1.22.1"
   gitHttpsProxy:
     image:
       name: renku/git-https-proxy
-      tag: "1.22.0"
+      tag: "1.22.1"
   gitClone:
     image:
       name: renku/git-clone
-      tag: "1.22.0"
+      tag: "1.22.1"
   service:
     type: ClusterIP
     port: 80
@@ -1169,12 +1169,12 @@ notebooks:
     sessionTypes: ["registered"]
     image:
       repository: renku/renku-notebooks-tests
-      tag: "1.22.0"
+      tag: "1.22.1"
       pullPolicy: IfNotPresent
   k8sWatcher:
     image:
       repository: renku/k8s-watcher
-      tag: "1.22.0"
+      tag: "1.22.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1
@@ -1187,7 +1187,7 @@ notebooks:
     enabled: false
     image:
       repository: renku/ssh-jump-host
-      tag: "1.22.0"
+      tag: "1.22.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1


### PR DESCRIPTION
Steven from the academic team encountered this issue.

With the update of the notebook service to handle multiple repos the path where the project is cloned was set to a different parameter from gitlab which seems to ignore the case of the letter in the name. But a lot of other parameters - most important of which is the working directory for the session - was set to the case sensitive value from gitlab.

This resulted in projects which have a path with upper and lowercase letters to be cloned in the wrong directory.

For more info see the PR in the notebook service.

/deploy