### PR TITLE
fix: update renku-notebooks to 1.25.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,23 @@
 .. _changelog:
 
+0.52.1
+------
+
+Renku ``0.52.1`` fixes a bug in Renku 2.0 sessions where sessions could not start if
+the parent project listed zero repositories and one or more cloud storages to mount.
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+- **Notebooks**: Do not add storage mounts patches when a session has no repository (`#1892 <https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1892>`_)
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-notebooks 1.25.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.25.1>`_
+
 0.52.0
 ------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1001,7 +1001,7 @@ notebooks:
     targetCPUUtilizationPercentage: 50
   image:
     repository: renku/renku-notebooks
-    tag: "1.25.0"
+    tag: "1.25.1"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1119,15 +1119,15 @@ notebooks:
   gitRpcServer:
     image:
       name: renku/git-rpc-server
-      tag: "1.25.0"
+      tag: "1.25.1"
   gitHttpsProxy:
     image:
       name: renku/git-https-proxy
-      tag: "1.25.0"
+      tag: "1.25.1"
   gitClone:
     image:
       name: renku/git-clone
-      tag: "1.25.0"
+      tag: "1.25.1"
   service:
     type: ClusterIP
     port: 80
@@ -1180,12 +1180,12 @@ notebooks:
     sessionTypes: ["registered"]
     image:
       repository: renku/renku-notebooks-tests
-      tag: "1.25.0"
+      tag: "1.25.1"
       pullPolicy: IfNotPresent
   k8sWatcher:
     image:
       repository: renku/k8s-watcher
-      tag: "1.25.0"
+      tag: "1.25.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1
@@ -1197,12 +1197,12 @@ notebooks:
   secretsMount:
     image:
       repository: renku/secrets-mount
-      tag: "1.25.0"
+      tag: "1.25.1"
   ssh:
     enabled: false
     image:
       repository: renku/ssh-jump-host
-      tag: "1.25.0"
+      tag: "1.25.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1


### PR DESCRIPTION
`renku-notebooks` bugfix release 1.25.1 brings in the following fixes:

* fix: do not add storage mounts patches when a session has no repository ([#1892](https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1892))

/deploy