### PR TITLE
fix: Allow to configure jwt issuer urls for search-api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,12 @@
 0.53.1
 ------
 
+Internal Changes
+~~~~~~~~~~~~~~~~
 
+**🐞 Bug Fixes**
+
+- **Search Services**: Fix for allowing to configure JWT issuer url whitelist in values file
 
 0.53.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,15 @@ Internal Changes
 
 **🐞 Bug Fixes**
 
-- **Search Services**: Fix for allowing to configure JWT issuer url whitelist in values file
+- **Search Services**: Fix for allowing to configure JWT issuer url
+  whitelist in values file and making this setting mandatory to the
+  search-api service.
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-search 0.3.0 <https://github.com/SwissDataScienceCenter/renku-search/releases/tag/v0.3.0>`_
+
 
 0.53.0
 ------

--- a/helm-chart/renku/templates/search/search-api-deployment.yaml
+++ b/helm-chart/renku/templates/search/search-api-deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: "500ms"
             - name: RS_SOLR_LOG_MESSAGE_BODIES
               value: "false"
+            - name: "RS_JWT_ALLOWED_ISSUER_URL_PATTERNS"
+              value: "{{ .Values.search.searchApi.jwt.allowedIssuerUrls }}"
             - name: JAVA_OPTS
               value: "-Xmx{{ .Values.search.searchApi.jvmXmx }} -XX:+UseZGC -XX:+ZGenerational"
           ports:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1391,7 +1391,7 @@ search:
     replicas: 1
     image:
       repository: renku/search-api
-      tag: "0.2.0"
+      tag: "0.3.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -1406,7 +1406,7 @@ search:
     replicas: 1
     image:
       repository: renku/search-provision
-      tag: "0.2.0"
+      tag: "0.3.0"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1400,6 +1400,8 @@ search:
       requests:
         memory: 256Mi
     jvmXmx: 256M
+    jwt:
+      allowedIssuerUrls:
   searchProvision:
     replicas: 1
     image:

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,6 +5,14 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
+## Upgrading to Renku 0.53.1
+
+* NEW `search.searchApi.jwt.allowedIssuerUrls` must be set to the
+  expected jwt issuer urls. A wildcard `*`can be used to match parts
+  of an url, like a sub domain. It is a list, where elements are
+  separated by a comma. Examples: `*.renkulab.io`
+  `renkulab.io,*.renku.ch`
+
 ## Upgrading to Renku 0.53.0
 
 The `data-service` configuration has been updated to support trusting reverse proxies.


### PR DESCRIPTION
The search verifies JWT tokens using the pulbic key from their issuer. A setting can be specified which urls are expected issuers.