### PR TITLE
fix: upgrade renku data service to 0.15.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,7 @@
 0.54.1
 ------
 
-Renku ``0.54.1`` introduces a bug fix to an issue where sessions with users secrets could not be properly
-resumed after hibernation.
+Renku ``0.54.1`` introduces a few bug fixes in the notebooks and data services components.
 
 User-Facing Changes
 ~~~~~~~~~~~~~~~~~~~
@@ -12,11 +11,13 @@ User-Facing Changes
 **🐞 Bug Fixes**
 
 - **Notebooks**: Patch the correct environment variables when a session is resumed after being hibernated
+- **Data Services**: Assign the correct project permissions to group members
 
 Individual components
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- `renku-notebooks 1.25.3 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.25.3>`_
+- `renku-data-services 0.15.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.15.1>`__
+- `renku-notebooks 1.25.3 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.25.3>`__
 
 
 0.54.0

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1603,14 +1603,14 @@ platformInit:
 dataService:
   image:
     repository: renku/renku-data-service
-    tag: "0.15.0"
+    tag: "0.15.1"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.15.0"
+      tag: "0.15.1"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1663,7 +1663,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.15.0"
+    tag: "0.15.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
Fixes a bug where group members cannot access all projects that are part of the group because the group permissions did not fully cascade to projects.

/deploy