### PR TITLE
feat: Allow db common to be hardcoded

### DIFF
--- a/helm-chart/renku/templates/renku-common-db-secret.yaml
+++ b/helm-chart/renku/templates/renku-common-db-secret.yaml
@@ -5,6 +5,9 @@
 {{- if $secret }}
 {{- $db_password = index $secret.data "password" }}
 {{- end -}}
+{{- if .Values.global.db.common.password }}
+{{- $db_password = .Values.global.db.common.password | b64enc | quote }}
+{{- end -}}
 
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
# What 
This allows the db common to be hardcoded in the value file. For instance, it will allow idempotence

# why 
This will solve a problem met when using, for example, sealed secret 

# Further thought

I am not sure if this is a good idea, or if one should remove the whole secret management when a secret is provided by the user and let the user manage the secret by himself, leading to a more flexible way of managing this particular secret. 
