### PR TITLE
release 0.56.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,23 @@
 .. _changelog:
 
+0.56.1
+------
+
+Renku ``0.56.1`` fixes a bug where Amalthea would not start when the prometheus metrics or the 
+audit log export functionality is enabled.
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+- * **Amalthea**: Fix failing startup when prometheus metrics or audit log is enabled.
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `amalthea 0.12.3 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.12.3>`_
+
 0.56.0
 ------
 

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -23,7 +23,7 @@ dependencies:
     alias: jena
   - name: amalthea
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.12.2"
+    version: "0.12.3"
   - name: dlf-chart
     repository: "https://swissdatasciencecenter.github.io/datashim/"
     version: "0.3.9-renku-2"


### PR DESCRIPTION
Addresses a bug where Amalthea would not start when prometheus metrics or the audit log export functionality is enabled.
