### PR TITLE
[ignore] test csi rclone oauth

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.0"
+    version: "0.3.1-dev1"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.1-dev1"
+    version: "0.3.1-dev4"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -218,7 +218,7 @@ global:
   csi-rclone:
     # Set to true to install csi-rclone alongside renku
     # Make sure to configure the csi-rclone section below correctly in that case.
-    install: false
+    install: true
 ## Ingress configuration
 ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
@@ -944,10 +944,9 @@ dlf-chart:
   dataset-operator-chart:
     enabled: true
 csi-rclone:
-  {}
   # This section is only relevant if you are installing csi-rclone as part of Renku
   ## Name of the csi storage class to use for RClone/Cloudstorage. Should be unique per cluster.
-  # storageClassName: csi-rclone
+  storageClass: csi-rclone-oauth
   # csiNodepluginRclone:
   #   nodeSelector: {}
   # Set tolerations if you have taints on your user session nodes. The csi has to run on every node
@@ -957,9 +956,9 @@ csi-rclone:
 notebooks:
   cloudstorage:
     ## If enabled this will allow mounting of rclone cloudstorage
-    enabled: false
+    enabled: true
     ## should match csi-rclone.storageClassName if you use a custom name
-    # storageClass: csi-rclone
+    storageClass: csi-rclone-oauth
     s3:
       installDatashim: false
   # configuration for user session persistent volumes


### PR DESCRIPTION
/deploy #notest renku-data-services=feat-add-support-for-oauth renku-ui=test-gdrive extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-oauth,csi-rclone.storageClassName=csi-rclone-oauth,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule