### PR TITLE
fix: bump renku-gateway to 1.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,11 +18,13 @@ Internal Changes
 **Bug Fixes**
 
 - **UI**: Fix the UI server being stuck in a crash loop at startup when Sentry is enabled (`#3318 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3318>`__).
+- **Gateway**: Fix getting HTTP error 500 when logging in (`#723 <https://github.com/SwissDataScienceCenter/renku-gateway/pull/723>`__).
 
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-ui 3.35.1 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.35.1>`_
+- `renku-gateway 1.0.3 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/tag/1.0.3>`_
 
 0.57.0
 ------

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1290,7 +1290,7 @@ gateway:
   secretKey:
   image:
     repository: renku/renku-gateway
-    tag: "1.0.2"
+    tag: "1.0.3"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
Gateway: fix getting HTTP error 500 when logging in.

/deploy