### PR TITLE
fix: update admin documentation on GitLab

### DIFF
--- a/docs/how-to-guides/admin/gitlab.rst
+++ b/docs/how-to-guides/admin/gitlab.rst
@@ -50,7 +50,7 @@ Callback URLs:
 
 .. code-block:: console
 
-  https://<your-renku-dns>/login/redirect/gitlab
+  https://<your-renku-dns>/api/auth/callback
   https://<your-renku-dns>/api/auth/gitlab/token
 
 Scopes:


### PR DESCRIPTION
Following the release of the new API Gateway, the redirect URLs configuration for external GitLab instances needs to be updated.