### PR TITLE
fix: increase timeout for authz k8s probes

### DIFF
--- a/helm-chart/renku/templates/authz/deployment.yaml
+++ b/helm-chart/renku/templates/authz/deployment.yaml
@@ -108,6 +108,8 @@ spec:
                 - -addr=127.0.0.1:50051
                 - -tls
                 - -tls-server-name={{ template "renku.fullname" . }}-authz
+            timeoutSeconds: 3
+            periodSeconds: 10
           readinessProbe:
             exec:
               command:
@@ -116,6 +118,8 @@ spec:
                 - -addr=127.0.0.1:50051
                 - -tls
                 - -tls-server-name={{ template "renku.fullname" . }}-authz
+            timeoutSeconds: 3
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.authz.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
The authz deployment was in a restart loop because the liveness checks was failing with a timeout. The default is 1s and that did not work. The period is left the same as the default but I added it just so that we make sure we do not get into a situation where the period is lower than the timeout.