### PR TITLE
fix: increase timeout for Authzed DB health probes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Internal Changes
 - **Data services**: Order resource classes by GPU, CPU, RAM and storage
 - **Data services**: Following redirects when sending requests to git repositories
 - **Data services**: Allow unsetting secrets for cloud storage
+- **Helm chart**: Increase the connection timeout for the Authzed database health checks
 
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~

--- a/helm-chart/renku/templates/authz/deployment.yaml
+++ b/helm-chart/renku/templates/authz/deployment.yaml
@@ -108,6 +108,8 @@ spec:
                 - -addr=127.0.0.1:50051
                 - -tls
                 - -tls-server-name={{ template "renku.fullname" . }}-authz
+                - -connect-timeout
+                - "3s"
             timeoutSeconds: 3
             periodSeconds: 10
           readinessProbe:
@@ -118,6 +120,8 @@ spec:
                 - -addr=127.0.0.1:50051
                 - -tls
                 - -tls-server-name={{ template "renku.fullname" . }}-authz
+                - -connect-timeout
+                - "3s"
             timeoutSeconds: 3
             periodSeconds: 10
           resources:


### PR DESCRIPTION
The timeout in k8s was increasesd in a recent PR. But this increases the timeout of the CLI we call in the Authzed DB image to actuall do the health checks. And since this CLI had a default timeout of 1s it was timing out even before the k8s timeout could take effect. We noticed that Authzed on renkulab.io was in a restart loop because of this.