### PR TITLE
fix: bump renku-ui to 3.40.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ User-Facing Changes
 
 - **UI**: Fix styles for the edit launcher environment list (`#3360 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3360>`__).
 - **UI**: Allow opening a project from Renku 2.0 search if the namespace is missing in the result (`#3353 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3353>`__).
+- **UI**: TODO: bugfix 3.40.1
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,6 @@ User-Facing Changes
 - **UI**: Fix styles for the edit launcher environment list (`#3360 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3360>`__).
 - **UI**: Allow opening a project from Renku 2.0 search if the namespace is missing in the result (`#3353 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3353>`__).
 - **UI**: Fix update file and download buttons in Renku 1.0 (`#3363 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3363>`__).
-- **UI**: TODO: bugfix 3.40.1
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -654,7 +654,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "3.40.0"
+      tag: "3.40.1"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -843,7 +843,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "3.40.0"
+      tag: "3.40.1"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""


### PR DESCRIPTION
Fixes a bug with data connectors where typing a slug would not be taken into account and using uppercase letter in the name would cause issues.

/deploy