### PR TITLE
fix: bump data-services to 0.24.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ User-Facing Changes
 **🐞 Bug Fixes**
 
 - **Data services**: Allow project editors to send patches with the current namespace (`#483 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/483>`__).
+- **Data services**: Allow project editors to send patches with the current visibility (`#484 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/484>`__).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,30 @@
 .. _changelog:
 
+0.59.2
+------
+
+Renku ``0.59.2`` is a bugfix release that fixes a bug in Renku 2.0 where project editors could not edit project information.
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+- **Data services**: Allow project editors to send patches with the current namespace (`#483 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/483>`__).
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Improvements**
+
+- **Data services**: Return 409 error when creating a project with a conflicting slug (`#471 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/471>`__).
+- **Data services**: Change all serial id columns to be GENERATED AS IDENTITY (`#461 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/461>`__).
+- **Data services**: Include ``is_admin`` in the self ``/user`` endpoint (`#472 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/472>`__).
+
+**Bug Fixes**
+
+- **Data services**: Handle spaces in ``provider_id`` for connected services (`#482 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/482>`__).
+
 0.59.1
 ------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,11 @@ Internal Changes
 
 - **Data services**: Handle spaces in ``provider_id`` for connected services (`#482 <https://github.com/SwissDataScienceCenter/renku-data-services/pull/482>`__).
 
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-data-services 0.24.2 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.24.2>`__
+
 0.59.1
 ------
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1579,14 +1579,14 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.24.1"
+    tag: "0.24.2"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.24.1"
+      tag: "0.24.2"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1639,7 +1639,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.24.1"
+    tag: "0.24.2"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1579,14 +1579,14 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.24.0"
+    tag: "0.24.1"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.24.0"
+      tag: "0.24.1"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1639,7 +1639,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.24.0"
+    tag: "0.24.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
Fixes an issue where project editors could not edit projects in Renku 2.0 (from the "General Settings" form).

/deploy