### PR TITLE
feat: add support for session secrets in Renku 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ compute systems, from a Renku session in a standardized and shareable manner. Co
 secrets is easy too: configure a single session secret slot to ensure that the secret shows up
 the same way for everyone, and each person enters their own value.
 
+This release removes the Gitlab omnibus Helm chart that we created and used to have as a dependency
+of the Renku Helm chart. We have been discouraging anyone from using
+this chart in production and we specified this in our documentation as well.
+
+If you are using the internal Gitlab Helm chart then ensure to migrate to a separate
+Gitlab deployment as specified in our `documentation <https://renku.readthedocs.io/en/stable/how-to-guides/admin/gitlab.html#migrate-from-renku-bundled-omnibus-gitlab-to-cloud-native-gitlab-helm-chart>`_.
+before installing this or any subsequent Renku version. Gitlab publishes an official Helm chart and
+that is what should be used for deploying Gitlab with Helm.
+
 User-Facing Changes
 ~~~~~~~~~~~~~~~~~~~
 
@@ -21,15 +30,6 @@ Internal Changes
 **New Features**
 
 - **Data services**: Support saving session secrets in Renku 2.0 projects and mounting them in sessions.
-
-This release removes the Gitlab omnibus Helm chart that we created and used to have as a dependency
-of the Renku Helm chart. We have been discouraging anyone from using
-this chart in production and we specified this in our documentation as well.
-
-If you are using the internal Gitlab Helm chart then ensure to migrate to a separate
-Gitlab deployment as specified in our `documentation <https://renku.readthedocs.io/en/stable/how-to-guides/admin/gitlab.html#migrate-from-renku-bundled-omnibus-gitlab-to-cloud-native-gitlab-helm-chart>`_.
-before installing this or any subsequent Renku version. Gitlab publishes an official Helm chart and
-that is what should be used for deploying Gitlab with Helm.
 
 **Improvements**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Individual Components
 
 - `renku-data-services 0.28.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.28.0>`_
 - `renku-search 0.7.0 <https://github.com/SwissDataScienceCenter/renku-search/releases/tag/v0.7.0>`_
+- `renku-ui 3.43.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.43.0>`_
 
 
 0.61.1
@@ -82,7 +83,6 @@ Individual components
 - `amalthea 0.14.5 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.14.5>`_
 - `amalthea 0.14.6 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.14.6>`_
 - `renku-data-services 0.27.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.27.1>`_
-- `renku-ui 3.43.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.43.0>`_
 
 
 0.61.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ User-Facing Changes
 
 **🌟 New Features**
 
-- **UI**: Configure and save session secrets in Renku 2.0 projects and use them in sessions (TODO).
+- **UI**: Configure and save session secrets in Renku 2.0 projects and use them in sessions (`#3413 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3413>`__).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,7 @@ Individual components
 - `amalthea 0.14.5 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.14.5>`_
 - `amalthea 0.14.6 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.14.6>`_
 - `renku-data-services 0.27.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.27.1>`_
+- `renku-ui 3.43.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.43.0>`_
 
 
 0.61.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@
 0.62.0
 ------
 
-Session secrets make it possible to connect to protected resources, such as databases or external
-compute systems, from a Renku session in a standardized and shareable manner. Collaborating with
-secrets is easy too: configure a single session secret slot to ensure that the secret shows up
-the same way for everyone, and each person enters their own value.
+This release introduces two new key features: session secrets and copying projects. 
+Session secrets make it possible to connect to protected resources, such as databases or
+external compute systems, from a Renku session in a standardized and shareable manner.
+Collaborating with secrets is easy too: configure a single session secret slot to ensure
+that the secret shows up the same way for everyone, and each person enters their own value.
+The copy projects feature makes it easy for course instructors to distribute course materials
+to students.
 
 This release removes the Gitlab omnibus Helm chart that we created and used to have as a dependency
 of the Renku Helm chart. We have been discouraging anyone from using

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ User-Facing Changes
 
 **Improvements**
 
-- **UI**: Add a new simpler option for creating PolyBox and Switchdrive data connectors (`#3396 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3396>`__).
+- **UI**: Add a new simpler option for creating PolyBox and SwitchDrive data connectors (`#3396 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3396>`__).
 - **UI**: Simplify the project and group creation interactions in Renku 2.0 to a simple modal (`#3399 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3399>`__).
 - **UI**: Introduce a refreshed design for the dashboard in Renku 2.0 (`#3407 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3407>`__).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,24 @@
 0.62.0
 ------
 
-TODO: session secrets in Renku 2.0
+‘Session secrets’ make it possible to connect to protected resources, such as databases or external
+compute systems, from a Renku session in a standardized and shareable manner. Collaborating with
+secrets is easy too: configure a single session secret ‘slot’ to ensure that the secret shows up
+the same way for everyone, and each person enters their own value.
+
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🌟 New Features**
+
+- **UI**: Configure and save session secrets in Renku 2.0 projects and use them in sessions (TODO).
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**New Features**
+
+- **Data services**: Support saving session secrets in Renku 2.0 projects and mounting them in sessions.
 
 This release removes the Gitlab omnibus Helm chart that we created and used to have as a dependency
 of the Renku Helm chart. We have been discouraging anyone from using

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,12 @@ User-Facing Changes
 
 - **UI**: Configure and save session secrets in Renku 2.0 projects and use them in sessions (`#3413 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3413>`__).
 
+**Improvements**
+
+- **UI**: Add a new simpler option for creating PolyBox and Switchdrive data connectors (`#3396 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3396>`__).
+- **UI**: Simplify the project and group creation interactions in Renku 2.0 to a simple modal (`#3399 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3399>`__).
+- **UI**: Introduce a refreshed design for the dashboard in Renku 2.0 (`#3407 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3407>`__).
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,9 @@
 0.62.0
 ------
 
-‘Session secrets’ make it possible to connect to protected resources, such as databases or external
+Session secrets make it possible to connect to protected resources, such as databases or external
 compute systems, from a Renku session in a standardized and shareable manner. Collaborating with
-secrets is easy too: configure a single session secret ‘slot’ to ensure that the secret shows up
+secrets is easy too: configure a single session secret slot to ensure that the secret shows up
 the same way for everyone, and each person enters their own value.
 
 User-Facing Changes
@@ -31,9 +31,6 @@ Gitlab deployment as specified in our `documentation <https://renku.readthedocs.
 before installing this or any subsequent Renku version. Gitlab publishes an official Helm chart and
 that is what should be used for deploying Gitlab with Helm.
 
-Internal Changes
-~~~~~~~~~~~~~~~~
-
 **Improvements**
 
 - **Infrastructure Components**: ``redis`` has been upgraded from version ``7.0.7`` to ``7.4.1``
@@ -49,6 +46,7 @@ Internal Changes
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
+- `renku-data-services 0.28.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.28.0>`_
 - `renku-search 0.7.0 <https://github.com/SwissDataScienceCenter/renku-search/releases/tag/v0.7.0>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@
 0.62.0
 ------
 
+TODO: session secrets in Renku 2.0
+
 This release removes the Gitlab omnibus Helm chart that we created and used to have as a dependency
 of the Renku Helm chart. We have been discouraging anyone from using
 this chart in production and we specified this in our documentation as well.

--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -992,6 +992,33 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  # Needed for secret mounting
+  name: ingress-to-data-service-from-v2-sessions
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: renku-data-service
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/created-by: controller-manager
+              app.kubernetes.io/name: AmaltheaSession
+      ports:
+        - protocol: TCP
+          port: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: egress-from-renku-v1-sessions
 spec:
   egress:
@@ -1063,6 +1090,12 @@ spec:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
+    - to:
+      # Allow access to data service, needed for secret mounting
+      - podSelector:
+          matchLabels:
+            app: renku-data-service
+            release: {{ .Release.Name }}
   podSelector:
     matchLabels:
       app.kubernetes.io/created-by: controller-manager

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1459,14 +1459,14 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.27.1"
+    tag: "0.28.0"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.27.1"
+      tag: "0.28.0"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1519,7 +1519,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.27.1"
+    tag: "0.28.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -519,7 +519,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "3.42.0"
+      tag: "3.43.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -708,7 +708,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "3.42.0"
+      tag: "3.43.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""


### PR DESCRIPTION
Closes #3832.

Add support for session secret slots and session secrets in Renku 2.0.

/deploy