### PR TITLE
feat: turn off notebook service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,17 +23,18 @@ Internal Changes
 
 **Improvements**
 
-- **Data services**: Handle Renku v1 sessions
-- **Gateway**: Route Renku v1 sessions through data services
-- **Notebooks**: Use the correct user labels when caching sessions
-- **Helm chart**: Set the notebooks replica count to zero because it is replaced by the data services
-- **Helm chart**: Add RBAC rules for Shipwright and Tekton resources in the Kubernetes cache
+- **Data services**: Handle Renku v1 sessions.
+- **Gateway**: Route Renku v1 sessions through data services.
+- **Notebooks**: Use the correct user labels when caching sessions.
+- **Helm chart**: Set the notebooks replica count to zero because it is replaced by the data services.
+- **Helm chart**: Add RBAC rules for Shipwright and Tekton resources in the Kubernetes cache.
 
 
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-data-services 0.35.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.35.0>`_
+- `renku-data-services 0.35.1 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.35.1>`_
 - `renku-notebooks 1.28.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.28.0>`_
 - `renku-notebooks 1.29.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.0>`_
 - `renku-notebooks 1.29.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.1>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Internal Changes
 
 - **Data services**: Handle Renku v1 sessions
 - **Gateway**: Route Renku v1 sessions through data services
+- **Notebooks**: Use the correct user labels when caching sessions
+
 
 
 Individual Components
@@ -37,6 +39,7 @@ Individual Components
 - `renku-notebooks 1.29.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.2>`_
 - `renku-ui 3.48.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.48.0>`_
 - `renku-gateway 1.4.0 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/tag/1.4.0>`_
+- `renku-notebooks 1.30.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.30.0>`_
 
 
 0.65.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,12 @@ Internal Changes
 - **Data services**: Support creating session environments based on code repositories.
 - **Notebooks**: Cache Shipwright BuildRuns and Tekton TaskRuns for image builds.
 
+**Improvements**
+
+- **Data services**: Handle Renku v1 sessions
+- **Gateway**: Route Renku v1 sessions through data services
+
+
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -30,6 +36,7 @@ Individual Components
 - `renku-notebooks 1.29.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.1>`_
 - `renku-notebooks 1.29.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.2>`_
 - `renku-ui 3.48.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.48.0>`_
+- `renku-gateway 1.4.0 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/tag/1.4.0>`_
 
 
 0.65.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Internal Changes
 - **Data services**: Handle Renku v1 sessions
 - **Gateway**: Route Renku v1 sessions through data services
 - **Notebooks**: Use the correct user labels when caching sessions
-
+- **Helm chart**: Set the notebooks replica count to zero because it is replaced by the data services
 - **Helm chart**: Add RBAC rules for Shipwright and Tekton resources in the Kubernetes cache
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Internal Changes
 - **Gateway**: Route Renku v1 sessions through data services
 - **Notebooks**: Use the correct user labels when caching sessions
 
+- **Helm chart**: Add RBAC rules for Shipwright and Tekton resources in the Kubernetes cache
 
 
 Individual Components

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,9 +38,10 @@ Individual Components
 - `renku-notebooks 1.29.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.0>`_
 - `renku-notebooks 1.29.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.1>`_
 - `renku-notebooks 1.29.2 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.29.2>`_
+- `renku-notebooks 1.30.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.30.0>`_
+- `renku-notebooks 1.30.1 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.30.1>`_
 - `renku-ui 3.48.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.48.0>`_
 - `renku-gateway 1.4.0 <https://github.com/SwissDataScienceCenter/renku-gateway/releases/tag/1.4.0>`_
-- `renku-notebooks 1.30.0 <https://github.com/SwissDataScienceCenter/renku-notebooks/releases/tag/1.30.0>`_
 
 
 0.65.0

--- a/helm-chart/renku/templates/notebooks/deployment.yaml
+++ b/helm-chart/renku/templates/notebooks/deployment.yaml
@@ -76,8 +76,6 @@ spec:
               {{ end }}
             - name: K8S_WATCHER_PORT
               value: "8080"
-            - name: K8S_WATCHER_USER_ID_LABEL
-              value: renku.io/safe-username
           ports:
             - name: http
               containerPort: 8080

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -839,7 +839,7 @@ notebooks:
       environment:
       ## Sample rate is used for performance monitoring in sentry
       sampleRate: 0.2
-  replicaCount: 2
+  replicaCount: 0
   ## Configure autoscaling
   autoscaling:
     enabled: false

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -848,7 +848,7 @@ notebooks:
     targetCPUUtilizationPercentage: 50
   image:
     repository: renku/renku-notebooks
-    tag: "1.29.2"
+    tag: "1.30.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -967,15 +967,15 @@ notebooks:
   gitRpcServer:
     image:
       name: renku/git-rpc-server
-      tag: "1.29.2"
+      tag: "1.30.0"
   gitHttpsProxy:
     image:
       name: renku/git-https-proxy
-      tag: "1.29.2"
+      tag: "1.30.0"
   gitClone:
     image:
       name: renku/git-clone
-      tag: "1.29.2"
+      tag: "1.30.0"
   service:
     type: ClusterIP
     port: 80
@@ -1028,12 +1028,12 @@ notebooks:
     sessionTypes: ["registered"]
     image:
       repository: renku/renku-notebooks-tests
-      tag: "1.29.2"
+      tag: "1.30.0"
       pullPolicy: IfNotPresent
   k8sWatcher:
     image:
       repository: renku/k8s-watcher
-      tag: "1.29.2"
+      tag: "1.30.0"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1
@@ -1045,12 +1045,12 @@ notebooks:
   secretsMount:
     image:
       repository: renku/secrets-mount
-      tag: "1.29.2"
+      tag: "1.30.0"
   ssh:
     enabled: false
     image:
       repository: renku/ssh-jump-host
-      tag: "1.29.2"
+      tag: "1.30.0"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1459,14 +1459,14 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.35.0"
+    tag: "0.35.1"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.35.0"
+      tag: "0.35.1"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1546,7 +1546,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.35.0"
+    tag: "0.35.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -848,7 +848,7 @@ notebooks:
     targetCPUUtilizationPercentage: 50
   image:
     repository: renku/renku-notebooks
-    tag: "1.30.0"
+    tag: "1.30.1"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -967,15 +967,15 @@ notebooks:
   gitRpcServer:
     image:
       name: renku/git-rpc-server
-      tag: "1.30.0"
+      tag: "1.30.1"
   gitHttpsProxy:
     image:
       name: renku/git-https-proxy
-      tag: "1.30.0"
+      tag: "1.30.1"
   gitClone:
     image:
       name: renku/git-clone
-      tag: "1.30.0"
+      tag: "1.30.1"
   service:
     type: ClusterIP
     port: 80
@@ -1028,12 +1028,12 @@ notebooks:
     sessionTypes: ["registered"]
     image:
       repository: renku/renku-notebooks-tests
-      tag: "1.30.0"
+      tag: "1.30.1"
       pullPolicy: IfNotPresent
   k8sWatcher:
     image:
       repository: renku/k8s-watcher
-      tag: "1.30.0"
+      tag: "1.30.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1
@@ -1045,12 +1045,12 @@ notebooks:
   secretsMount:
     image:
       repository: renku/secrets-mount
-      tag: "1.30.0"
+      tag: "1.30.1"
   ssh:
     enabled: false
     image:
       repository: renku/ssh-jump-host
-      tag: "1.30.0"
+      tag: "1.30.1"
       pullPolicy: IfNotPresent
     resources: {}
     replicaCount: 1

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1146,7 +1146,7 @@ gateway:
   secretKey:
   image:
     repository: renku/renku-gateway
-    tag: "1.3.2"
+    tag: "1.4.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -11,8 +11,6 @@ Please follow this convention when adding a new row
   This feature is experimental - enable at your own risk! It depends on Shipwright (version >= 0.15.x) 
   which must be installed independently from the Renku Helm chart.
 
-## Upgrading to Renku 0.62.0
-
 * EDIT ``notebooks.replicaCount`` - set to zero by default because the data service is handling all sessions now, the notebook service will be fully decomissioned and removed from the helm chart in a subsequent PR.
 
 ## Upgrading to Renku 0.62.0

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -13,7 +13,7 @@ Please follow this convention when adding a new row
 
 ## Upgrading to Renku 0.62.0
 
-* EDIT ``notebooks.replicaCount`` - set to zero by default because the data service is handling all sessions now, the notebook service will be fully decomissioned and remove from the helm chart in a subsequent PR.
+* EDIT ``notebooks.replicaCount`` - set to zero by default because the data service is handling all sessions now, the notebook service will be fully decomissioned and removed from the helm chart in a subsequent PR.
 
 ## Upgrading to Renku 0.62.0
 

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -13,6 +13,10 @@ Please follow this convention when adding a new row
 
 ## Upgrading to Renku 0.62.0
 
+* EDIT ``notebooks.replicaCount`` - set to zero by default because the data service is handling all sessions now, the notebook service will be fully decomissioned and remove from the helm chart in a subsequent PR.
+
+## Upgrading to Renku 0.62.0
+
 * DELETE ``gitlab.*`` - all values related to the bundled GitLab have been removed. GitLab must from now on be provided as an external service and is no longer supplied as a part of the Renku Helm chart.
 * NEW `search.sentry.environment|dsn|enabled` to set the sentry environment for the search services
 


### PR DESCRIPTION
This turns off the notebook service and uses the data service to manage JupyterServers.

/deploy

I tested in another throwaway CI deployment that when we update the sessions from v1 and v2 sessions are still visible to users. For both registered and anonymous users.