### PR TITLE
chore: update renku-ui to 3.46.0 and renku-data-services to 0.31.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@
 User-Facing Changes
 ~~~~~~~~~~~~~~~~~~~
 
-**Improvements**
+**🌟 New Features**
 
 - **UI**: Early access to Renku 2.0 now available for users to try out. (`#3474 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3474>`__).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,21 @@
 0.64.0
 ------
 
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**Improvements**
+
+- **UI**: Early access to Renku 2.0 now available for users to try out. (`#3474 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3474>`__).
+
+**🐞 Bug Fixes**
+
+- **UI**: Display all data connector password fields (`#3477 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3477>`__).
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-ui 3.46.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.46.0>`_
 
 
 0.63.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,14 +9,37 @@ User-Facing Changes
 **🌟 New Features**
 
 - **UI**: Early access to Renku 2.0 now available for users to try out. (`#3474 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3474>`__).
+- **UI**: Configure disk storage for Renku 2.0 sessions launchers. (`#3463 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3463>`__).
+
+**✨ Improvements**
+
+- **UI**: Cleanup the project and group settings pages (`#3472 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3472>`__).
+- **UI**: Hide the edit button when the user does not have permissions (`#3462 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3462>`__).
 
 **🐞 Bug Fixes**
 
 - **UI**: Display all data connector password fields (`#3477 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3477>`__).
 
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**New Features**
+
+- **Data services**: Support saving disk storage size for session launchers.
+
+**Bug Fixes**
+
+- **Data services**: Fix patching wrong environment variables when resuming sessions.
+- **Data services**: Allow mount and work directories to be reset for session environments.
+- **Data services**: Do not call data service through the network from itself.
+- **Data services**: Make HEAD responses emtpy
+- **Data services**: Merge all apispecs correctly.
+
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
+- `renku-data-services 0.30.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.30.0>`_
+- `renku-data-services 0.31.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.31.0>`_
 - `renku-ui 3.46.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.46.0>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,8 +32,8 @@ Internal Changes
 - **Data services**: Fix patching wrong environment variables when resuming sessions.
 - **Data services**: Allow mount and work directories to be reset for session environments.
 - **Data services**: Do not call data service through the network from itself.
-- **Data services**: Make HEAD responses emtpy
-- **Data services**: Merge all apispecs correctly.
+- **Data services**: Make HEAD responses empty
+- **Data services**: Merge all API files correctly.
 
 Individual Components
 ~~~~~~~~~~~~~~~~~~~~~

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -519,7 +519,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "3.45.0"
+      tag: "3.46.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -708,7 +708,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "3.45.0"
+      tag: "3.46.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1459,14 +1459,14 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.29.0"
+    tag: "0.31.0"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.29.0"
+      tag: "0.31.0"
       pullPolicy: IfNotPresent
     total:
       resources: {}
@@ -1519,7 +1519,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.29.0"
+    tag: "0.31.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
This PR introduces the following updates:

- Early Access: Implements changes to enable early access to Renku 2.0
- Disk Storage Configuration in Renku 2.0 sessions 
- Fix hide the edit button when the user does not have permissions
- Fix show all data connector password fields 


/deploy