### PR TITLE
chore: low security session cookies for debugging

### DIFF
--- a/helm-chart/renku/templates/gateway/configmap.yaml
+++ b/helm-chart/renku/templates/gateway/configmap.yaml
@@ -9,7 +9,12 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yaml: |
-    debugMode: {{ .Values.gateway.debug | default false }}
+    debugMode: {{ .Values.gateway.development | default false }}
+    {{- if (.Values.gateway.development | default false) }}
+    runningEnvironment: development
+    {{- else }}
+    runningEnvironment: production
+    {{- end }}
     server:
       port: 8080
       host: 0.0.0.0
@@ -35,6 +40,7 @@ data:
         - issuer: {{ printf "%s/realms/%s" (include "renku.keycloakUrl" . | trimSuffix "/") (include "renku.keycloak.realm" .) }}
           audience: renku
           authorizedParty: renku-cli
+      unsafeCookieTemplate: {{ .Values.gateway.enableUnsafeSessionCookies | default false }}
     revproxy:
       renkuBaseUrl: {{ include "renku.baseUrl" . | quote }}
       externalGitlabUrl: {{ .Values.global.gitlab.url | default "" | quote }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1121,6 +1121,9 @@ gateway:
   ## Set to true to enable the developement mode. This has negative security
   ## implications and should never be done in a production setting.
   development: false
+  ## Unsafe session cookies, allows the gateway to accept session cookies from different domains
+  ## and from javascript. It is unsafe to enable this in production.
+  enableUnsafeSessionCookies: false
   ## To protect the backend services from an excessive amount of API calls
   ## issued by one client, one can enforce rate limits here. The limits apply
   ## based on the IP address of the client.


### PR DESCRIPTION
/deploy renku-ui=chore-run-ui-client-without-telepresence renku-gateway=add-unsafe-session-cookie-option-for-dev extra-values=gateway.development=true,gateway.enableUnsafeSessionCookies=true