### PR TITLE
tests: add cypress tests for Renku 2.0

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -1,4 +1,4 @@
-name: Deploy and Test PR
+name: Test PR
 on:
   pull_request:
     types:
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test-docs:
+    name: Documentation
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +49,7 @@ jobs:
           path: docs/_build/html/
 
   check-deploy:
+    name: Anylize deploy string
     runs-on: ubuntu-22.04
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
@@ -70,6 +72,7 @@ jobs:
           pr_ref: ${{ github.event.number }}
 
   deploy-pr:
+    name: Deploy
     if: github.event.action != 'closed'
     needs: [check-deploy]
     runs-on: ubuntu-22.04
@@ -120,6 +123,7 @@ jobs:
             You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
 
   test-pr:
+    name: Legacy Scala tests
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
@@ -133,7 +137,8 @@ jobs:
           s3-results-secret-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_SECRET_KEY }}
           test-timeout-mins: "120"
 
-  test-pr-cypress:
+  legacy-cypress-acceptance-tests:
+    name: Legacy Cypress tests
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
 
@@ -149,15 +154,7 @@ jobs:
             useSession,
             checkWorkflows,
             rstudioSession,
-            v2/anonymousNavigation,
-            v2/dashboardV2,
-            v2/groupBasics,
-            v2/projectBasics,
-            v2/projectResources,
-            v2/searchEntities,
-            v2/sessionBasics,
           ]
-
     steps:
       - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.0
         if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
@@ -166,8 +163,36 @@ jobs:
           renku-reference: ${{ github.ref }}
           renku-release: ci-renku-${{ github.event.number }}
           test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+
+  cypress-acceptance-tests:
+    name: Cypress tests
+    needs: [check-deploy, deploy-pr]
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          [
+            anonymousNavigation,
+            dashboardV2,
+            groupBasics,
+            projectBasics,
+            projectResources,
+            searchEntities,
+            sessionBasics,
+          ]
+    steps:
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.0
+        if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
+        with:
+          e2e-folder: cypress/e2e/v2/
+          e2e-target: ${{ matrix.tests }}
+          renku-reference: ${{ github.ref }}
+          renku-release: ci-renku-${{ github.event.number }}
+          test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+
   deploy-string-no-custom-version:
-    name: Check that deploy string doesn't specify a custom component version
+    name: Ensure no custom components
     needs: [check-deploy]
     runs-on: ubuntu-22.04
     steps:
@@ -188,6 +213,7 @@ jobs:
         with:
           script: core.setFailed('Cannot merge release PR if it still has custom versions in deploy string.')
   cleanup:
+    name: Cleanup
     if: github.event.action == 'closed'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -149,12 +149,13 @@ jobs:
             useSession,
             checkWorkflows,
             rstudioSession,
+            v2/anonymousNavigation,
             v2/dashboardV2,
-            v2/projectBasics,
             v2/groupBasics,
+            v2/projectBasics,
             v2/projectResources,
             v2/searchEntities,
-            v2/anonymousNavigation
+            v2/sessionBasics,
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -149,7 +149,7 @@ jobs:
             useSession,
             checkWorkflows,
             rstudioSession,
-            dashboardV2,
+            v2/dashboardV2,
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -49,7 +49,7 @@ jobs:
           path: docs/_build/html/
 
   check-deploy:
-    name: Anylize deploy string
+    name: Analyze deploy string
     runs-on: ubuntu-22.04
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -153,6 +153,7 @@ jobs:
             v2/projectBasics,
             v2/groupBasics,
             v2/projectResources,
+            v2/searchEntities
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -150,6 +150,7 @@ jobs:
             checkWorkflows,
             rstudioSession,
             v2/dashboardV2,
+            v2/projectBasics,
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -151,6 +151,7 @@ jobs:
             rstudioSession,
             v2/dashboardV2,
             v2/projectBasics,
+            v2/groupBasics,
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -152,6 +152,7 @@ jobs:
             v2/dashboardV2,
             v2/projectBasics,
             v2/groupBasics,
+            v2/projectResources,
           ]
 
     steps:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -153,7 +153,8 @@ jobs:
             v2/projectBasics,
             v2/groupBasics,
             v2/projectResources,
-            v2/searchEntities
+            v2/searchEntities,
+            v2/anonymousNavigation
           ]
 
     steps:

--- a/cypress-tests/.eslintrc.json
+++ b/cypress-tests/.eslintrc.json
@@ -5,69 +5,35 @@
     "project": "tsconfig.json",
     "sourceType": "module"
   },
-  "plugins": [
-    "@typescript-eslint",
-    "cypress"
-  ],
+  "plugins": ["@typescript-eslint", "cypress", "no-only-tests"],
   "rules": {
-    "max-len": ["warn", 120],
     "no-eval": "error",
-    "quotes": ["warn", "double", {
-      "allowTemplateLiterals": true,
-      "avoidEscape": true
-    }],
-    "@typescript-eslint/no-unused-vars": ["warn", {
-      "vars": "all",
-      "args": "none",
-      "ignoreRestSiblings": false,
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_"
-    }],
+    "no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "args": "none",
+        "ignoreRestSiblings": false
+      }
+    ],
     "no-console": "warn",
-    "curly": ["warn", "multi-or-nest", "consistent"],
-    "indent": ["warn", 2, {
-      "ignoredNodes": ["TemplateLiteral"],
-      "SwitchCase": 1
-    }],
-    "semi": ["warn", "always"],
-    "space-before-blocks": ["warn", "always"],
-    "no-multi-spaces": "warn",
-    "brace-style": ["warn", "stroustrup", {
-      "allowSingleLine": true
-    }],
-    "max-nested-callbacks": ["warn", 3],
+    "max-nested-callbacks": ["warn", 4],
     "no-alert": "error",
     "no-else-return": "warn",
     "jest/expect-expect": "off",
-    "comma-spacing": "warn",
-    "block-spacing": ["warn", "always"],
-    "key-spacing": "warn",
-    "no-trailing-spaces": "warn",
-    "object-curly-spacing": ["warn", "always"],
-    "space-infix-ops": "warn",
-    "space-unary-ops": ["warn", {
-      "words": true,
-      "nonwords": false
-    }],
-    "keyword-spacing": ["warn", {
-      "before": true
-    }],
-    "no-multiple-empty-lines": ["warn", {
-      "max": 2,
-      "maxEOF": 1
-    }],
-    "eol-last": 1,
     "cypress/no-assigning-return-values": "error",
     "cypress/no-unnecessary-waiting": "error",
     "cypress/assertion-before-screenshot": "warn",
     "cypress/no-force": "warn",
     "cypress/no-async-tests": "error",
-    "cypress/no-pause": "error"
+    "cypress/no-pause": "error",
+    "no-only-tests/no-only-tests": "error"
   },
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:cypress/recommended"
+    "plugin:cypress/recommended",
+    "prettier"
   ]
 }

--- a/cypress-tests/README.md
+++ b/cypress-tests/README.md
@@ -2,23 +2,34 @@
 
 This section includes a set of acceptance tests for RenkuLab. The tests are
 written using [Cypress](https://www.cypress.io), run in Chrome, and the main target
-is the web interface of RenkuLab.
+is the web interface of [RenkuLab](https://renkulab.io).
+
+## Test coverage
+
+The tests aim to cover the most common user interactions with RenkuLab. The
+goal is to ensure that the most important features work as expected and new
+features or changes do not introduce regressions.
+
+Other details specific to the web interface (like the UI design, responsiveness,
+error handling, etc.) are tested in the unit and integration tests of the
+[Renku UI repository](https://github.com/SwissDataScienceCenter/renku-ui).
 
 ## Running the tests
 
-You need a fully working RenkuLab deployment to run the tests against. You will also
-need a user account for the deployment.
+You need a fully working RenkuLab deployment to run the tests against, and a user
+account for the deployment.
 
-If you wish to run the tests locally, you will need to clone the repository and have a
+To run the tests locally, you will need to clone this repository and have a
 recent version of Node.js installed. Then follow these steps:
 
-- Create a `cypress.env.json` file with the necessary user credentials. You can use the
-  `cypress.env.template.json` file as a template.
 - Install the dependencies with `npm install`.
-- Run the tests with `npm run e2e`. If you prefer not to use the GUI, you can run the
-  tests in headless mode with `npm run e2e:headless`.
+- Either create a `cypress.env.json` file with the necessary user and deployment
+  details (you can start from the `cypress.env.template.json` template) or be sure
+  to set all the environment variables listed below.
+- Run the tests with `npm run e2e` or one of the many available flags. For example,
+  you can run the tests without the GUI with `npm run e2e:headless`.
 
-Here is a list of the environment variable that you should set in the
+Here is a list of the environment variables that you should set in the
 `cypress.env.json` file:
 
 | VARIABLE        | USE                                                   |
@@ -30,29 +41,16 @@ Here is a list of the environment variable that you should set in the
 | TEST_LAST_NAME  | Last name.                                            |
 | TEST_USERNAME   | Username. Usually, it's the email without the domain. |
 
-> Tip: you might prefer not to save you password in plain text in the `cypress.env.json`
-> file. In that case, you can use the `TEST_PASSWORD` variable to the command line when
-> running the tests. For example `TEST_PASSWORD=mySecretPassword npm run e2e`.`
+> Tip: you might prefer _not_ to save you password in plain text in the `cypress.env.json`
+> file.
 
 ## Integration with CI pipeline
 
-The primary purpose of the tests is to spot regressions early on new pull requests.
+We require these tests to pass before merging any feature branch to the release branch.
+The primary purpose is to spot regressions early and avoid leaving the burden of
+fixing them to the release manager.
+
 Most Renku repositories have a CI pipeline that runs the tests automatically for every
-commit. That requires deploying a full RenkuLab instance using the
-`/deploy #persist` command. The tests are run automatically in headless mode unless
-the flag `#notest` is included.
-
-You can read more details in the documentation in the
-[renku-actions repository](https://github.com/SwissDataScienceCenter/renku-actions/tree/master/test-renku-cypress).
-
-Mind that including the `#persist` flag is currently necessary since the deployment
-is deleted automatically after running a separate set of acceptance tests; the Cypress
-tests generally run much quicker but they are not guaranteed to finish on time.
-Re-running single tests would also fail when the deployment is deleted.
-
-## Limitations
-
-- Using the electron browser from Cypress will not work because a few features in
-  RenkuLab do not work with that (E.G: RStudio does not load at all).
-- Tests currently do not run on Firefox. Please use [Chrome](https://www.google.com/chrome)
-  or [Chromium](https://www.chromium.org) instead.
+commit. That requires deploying a full RenkuLab instance using the `/deploy` string
+in the PR description. Tests can be excluded by adding the `#notest` flag.
+You can read more details in the [renku-actions repository](https://github.com/SwissDataScienceCenter/renku-actions/tree/master/test-renku-cypress).

--- a/cypress-tests/README.md
+++ b/cypress-tests/README.md
@@ -22,7 +22,7 @@ Here is a list of the environment variable that you should set in the
 `cypress.env.json` file:
 
 | VARIABLE        | USE                                                   |
-|-----------------|-------------------------------------------------------|
+| --------------- | ----------------------------------------------------- |
 | BASE_URL        | Full URL of the target environment.                   |
 | TEST_EMAIL      | The email used to register on Keycloak.               |
 | TEST_PASSWORD   | Password.                                             |
@@ -31,8 +31,8 @@ Here is a list of the environment variable that you should set in the
 | TEST_USERNAME   | Username. Usually, it's the email without the domain. |
 
 > Tip: you might prefer not to save you password in plain text in the `cypress.env.json`
-  file. In that case, you can use the `TEST_PASSWORD` variable to the command line when
-  running the tests. For example `TEST_PASSWORD=mySecretPassword npm run e2e`.`
+> file. In that case, you can use the `TEST_PASSWORD` variable to the command line when
+> running the tests. For example `TEST_PASSWORD=mySecretPassword npm run e2e`.`
 
 ## Integration with CI pipeline
 
@@ -55,4 +55,4 @@ Re-running single tests would also fail when the deployment is deleted.
 - Using the electron browser from Cypress will not work because a few features in
   RenkuLab do not work with that (E.G: RStudio does not load at all).
 - Tests currently do not run on Firefox. Please use [Chrome](https://www.google.com/chrome)
-  or [Chromium](https://www.chromium.org) instead. 
+  or [Chromium](https://www.chromium.org) instead.

--- a/cypress-tests/config.ts
+++ b/cypress-tests/config.ts
@@ -1,6 +1,7 @@
 // Timeouts for cypesss in miliseconds
 export const TIMEOUTS = {
   minimal: 1_000,
+  shorter: 2_000,
   short: 5_000,
   standard: 20_000,
   long: 60_000,

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     // ? If we try to set up `baseUrl` here, process.env.BASE_URL isn't available
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
     setupNodeEvents(on, config) {
-      return { ...config, baseUrl: config.env.BASE_URL || "https://dev.renku.ch" };
+      return {
+        ...config,
+        baseUrl: config.env.BASE_URL || "https://dev.renku.ch",
+      };
     },
   },
   env: {

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -3,10 +3,14 @@ import { TIMEOUTS } from "./config";
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.BASE_URL || "https://dev.renku.ch",
+    // ? If we try to set up `baseUrl` here, process.env.BASE_URL isn't available
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
+    setupNodeEvents(on, config) {
+      return { ...config, baseUrl: config.env.BASE_URL || "https://dev.renku.ch" };
+    },
   },
   env: {
+    BASE_URL: process.env.BASE_URL,
     TEST_EMAIL: process.env.TEST_EMAIL,
     TEST_PASSWORD: process.env.TEST_PASSWORD,
     TEST_FIRST_NAME: process.env.TEST_FIRST_NAME,

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -15,11 +15,11 @@ export default defineConfig({
   },
   retries: {
     runMode: 2,
-    openMode: null
+    openMode: null,
   },
   defaultCommandTimeout: TIMEOUTS.standard,
   chromeWebSecurity: false,
   viewportWidth: 1280,
   viewportHeight: 960,
-  videoUploadOnPasses: false
+  videoUploadOnPasses: false,
 });

--- a/cypress-tests/cypress.config.ts
+++ b/cypress-tests/cypress.config.ts
@@ -3,7 +3,8 @@ import { TIMEOUTS } from "./config";
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.BASE_URL || "https://dev.renku.ch"
+    baseUrl: process.env.BASE_URL || "https://dev.renku.ch",
+    specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
   },
   env: {
     TEST_EMAIL: process.env.TEST_EMAIL,

--- a/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
+++ b/cypress-tests/cypress/e2e/checkWorkflows.cy.ts
@@ -17,7 +17,7 @@ describe("Workflows pages", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
   });
 
@@ -27,7 +27,7 @@ describe("Workflows pages", () => {
     // Go the the workflows page and check the details of a workflow
     cy.getProjectSection("Workflows").click();
     cy.get("[data-cy=workflows-page]", { timeout: TIMEOUTS.long }).should(
-      "be.visible"
+      "be.visible",
     );
     cy.getDataCy("workflows-browser")
       .should("be.visible")

--- a/cypress-tests/cypress/e2e/privateProject.cy.ts
+++ b/cypress-tests/cypress/e2e/privateProject.cy.ts
@@ -36,7 +36,7 @@ describe("Basic public project functionality", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     cy.createProjectIfMissing({
       templateName: "Python",
@@ -55,7 +55,9 @@ describe("Basic public project functionality", () => {
     cy.searchForProject(projectIdentifier, true);
 
     // Check as an anonymous user
-    cy.session(["anonymous", getRandomString()], () => {});
+    cy.session(["anonymous", getRandomString()], () => {
+      cy.log("Anonyomous session setup");
+    });
     cy.visit("/");
     cy.get("#nav-hamburger").should("be.visible").click();
     cy.searchForProject(projectIdentifier, false);
@@ -91,7 +93,9 @@ describe("Basic public project functionality", () => {
     // Search the project as both logged in and logged out.
     cy.searchForProject(projectIdentifier, true);
     // Check as an anonymous user
-    cy.session(["anonymous", getRandomString()], () => {});
+    cy.session(["anonymous", getRandomString()], () => {
+      cy.log("Anonyomous session setup");
+    });
     cy.visit("/");
     cy.get("#nav-hamburger").should("be.visible").click();
     cy.searchForProject(projectIdentifier, false);

--- a/cypress-tests/cypress/e2e/publicProject.cy.ts
+++ b/cypress-tests/cypress/e2e/publicProject.cy.ts
@@ -37,7 +37,7 @@ describe("Basic public project functionality", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
@@ -49,7 +49,9 @@ describe("Basic public project functionality", () => {
     cy.searchForProject(projectIdentifier);
 
     // Check as an anonymous user
-    cy.session(["anonymous", getRandomString()], () => {});
+    cy.session(["anonymous", getRandomString()], () => {
+      cy.log("Anonyomous session setup");
+    });
     cy.visit("/");
     cy.get("#nav-hamburger").should("be.visible").click();
     cy.searchForProject(projectIdentifier);
@@ -113,10 +115,10 @@ describe("Basic public project functionality", () => {
     cy.get("div#tree-content").contains("metadata").should("exist").click();
     cy.getProjectPageLink(
       projectIdentifier,
-      "/files/blob/.renku/metadata/project"
+      "/files/blob/.renku/metadata/project",
     ).click();
     cy.contains(
-      '"@renku_data_type": "renku.domain_model.project.Project"'
+      '"@renku_data_type": "renku.domain_model.project.Project"',
     ).should("exist");
     cy.get("div#tree-content").contains("README.md").should("exist").click();
     cy.contains("This is a Renku project")
@@ -127,7 +129,7 @@ describe("Basic public project functionality", () => {
   it("Can view and modify sessions settings", () => {
     cy.intercept("/ui-server/api/renku/*/config.set").as("configSet");
     cy.intercept("/ui-server/api/renku/*/config.show?git_url=*").as(
-      "getConfig"
+      "getConfig",
     );
 
     // Make sure the renku.ini is in a pristine state

--- a/cypress-tests/cypress/e2e/rstudioSession.cy.ts
+++ b/cypress-tests/cypress/e2e/rstudioSession.cy.ts
@@ -38,7 +38,7 @@ describe("Basic rstudio functionality", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     cy.createProjectIfMissing({ templateName: "R (", ...projectIdentifier });
     cy.stopAllSessionsForProject(projectIdentifier);
@@ -82,6 +82,6 @@ describe("Basic rstudio functionality", () => {
       // Stops the session
       cy.pauseSession();
       cy.deleteSession();
-    }
+    },
   );
 });

--- a/cypress-tests/cypress/e2e/testDatasets.cy.ts
+++ b/cypress-tests/cypress/e2e/testDatasets.cy.ts
@@ -28,7 +28,7 @@ const sessionId = ["testDatasets", getRandomString()];
 describe("Basic datasets functionality", () => {
   before(() => {
     // Intercept listing datasets
-    cy.intercept("/ui-server/api/renku/*/datasets.list?git_url=*", (req) => {
+    cy.intercept("/ui-server/api/renku/*/datasets.list?git_url=*", () => {
       listDatasetsInvoked = true;
     }).as("listDatasets");
   });
@@ -40,7 +40,7 @@ describe("Basic datasets functionality", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
     cy.visitAndLoadProject(projectIdentifier);
@@ -76,7 +76,7 @@ describe("Basic datasets functionality", () => {
     cy.getDataCy("input-title").type(generatedDatasetName.name);
 
     cy.getDataCy("input-keywords").type(
-      keywords.reduce((text, value) => `${text}${value}{enter}`, "")
+      keywords.reduce((text, value) => `${text}${value}{enter}`, ""),
     );
     cy.get("div.ck.ck-editor__main div.ck.ck-content")
       .should("exist")

--- a/cypress-tests/cypress/e2e/updateProjects.cy.ts
+++ b/cypress-tests/cypress/e2e/updateProjects.cy.ts
@@ -28,7 +28,7 @@ describe("Fork and update old projects", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
   });
 
@@ -125,9 +125,9 @@ describe("Fork and update old projects", () => {
     let commitFetched = false;
     cy.intercept(
       "/ui-server/api/projects/*/repository/commits?ref_name=master&per_page=100&page=1",
-      (req) => {
+      () => {
         commitFetched = true;
-      }
+      },
     ).as("getCommits");
     cy.getDataCy("project-overview-nav")
       .contains("a", "Commits")

--- a/cypress-tests/cypress/e2e/useSession.cy.ts
+++ b/cypress-tests/cypress/e2e/useSession.cy.ts
@@ -39,7 +39,7 @@ describe("Basic public project functionality", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     cy.createProjectIfMissing({ templateName: "Python", ...projectIdentifier });
   });
@@ -56,7 +56,7 @@ describe("Basic public project functionality", () => {
 
     // Start a session with options
     let serversInvoked = false;
-    cy.intercept("/ui-server/api/notebooks/servers*", (req) => {
+    cy.intercept("/ui-server/api/notebooks/servers*", () => {
       serversInvoked = true;
     }).as("getServers");
     cy.getProjectSection("Sessions").click();
@@ -84,7 +84,7 @@ describe("Basic public project functionality", () => {
       .contains("Starting Session")
       .should("exist");
     cy.get(".progress-box .progress-title", { timeout: TIMEOUTS.vlong }).should(
-      "not.exist"
+      "not.exist",
     );
 
     // Verify the "Connect" button works as well
@@ -101,7 +101,7 @@ describe("Basic public project functionality", () => {
     cy.getIframe("iframe#session-iframe").within(() => {
       // Open the terminal and check the repo is not ahead
       cy.get(".jp-Launcher-content", { timeout: TIMEOUTS.long }).should(
-        "be.visible"
+        "be.visible",
       );
       cy.get(".jp-Launcher-section").should("be.visible");
       cy.get('.jp-LauncherCard[title="Start a new terminal session"]')
@@ -112,7 +112,7 @@ describe("Basic public project functionality", () => {
       cy.get(".xterm-helper-textarea")
         .click()
         .type(
-          `renku run --name ${workflow.name} echo "123" > ${workflow.output}{enter}`
+          `renku run --name ${workflow.name} echo "123" > ${workflow.output}{enter}`,
         );
       cy.get("#filebrowser")
         .should("be.visible")
@@ -167,7 +167,9 @@ describe("Basic public project functionality", () => {
 
   it("Start a new session as anonymous user.", () => {
     // Do not re-use the logged-in session
-    cy.session(["anonymous", getRandomString()], () => {});
+    cy.session(["anonymous", getRandomString()], () => {
+      cy.log("Anonyomous session setup");
+    });
 
     // Log out and go to the project again
     cy.visit("/");
@@ -222,7 +224,7 @@ describe("Basic public project functionality", () => {
     cy.request({ url: "ui-server/api/notebooks/version" }).then((resp) => {
       if (!resp.body.versions[0].data.cloudstorageEnabled) {
         cy.log(
-          "Skipping the test since the deployment doesn't support Cloud Storage"
+          "Skipping the test since the deployment doesn't support Cloud Storage",
         );
         return;
       }
@@ -239,6 +241,7 @@ describe("Basic public project functionality", () => {
       // Add a S3 storage configuration if it doesn't exist
       cy.wait("@getProjectCloudStorage").then(({ response }) => {
         const storages = response.body as { storage: { name: string } }[];
+        // eslint-disable-next-line max-nested-callbacks
         if (storages.find(({ storage }) => storage.name === "data_s3")) {
           return;
         }
@@ -287,7 +290,7 @@ describe("Basic public project functionality", () => {
           .click();
 
         cy.getDataCy("cloud-storage-edit-body").contains(
-          "storage data_s3 has been successfully added"
+          "storage data_s3 has been successfully added",
         );
         cy.getDataCy("cloud-storage-edit-close-button")
           .should("be.visible")
@@ -327,7 +330,7 @@ describe("Basic public project functionality", () => {
       // Verify that the S3 data is mounted
       cy.getIframe("iframe#session-iframe").within(() => {
         cy.get(".jp-DirListing-content", { timeout: TIMEOUTS.long }).should(
-          "be.visible"
+          "be.visible",
         );
         cy.get(".jp-DirListing-item")
           .contains("data_s3")
@@ -340,7 +343,7 @@ describe("Basic public project functionality", () => {
           .dblclick();
 
         cy.get(".jp-FileEditor", { timeout: TIMEOUTS.long }).should(
-          "be.visible"
+          "be.visible",
         );
         cy.get(".jp-FileEditor")
           .contains("The GIAB s3 bucket and URLs")

--- a/cypress-tests/cypress/e2e/v2/anonymousNavigation.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/anonymousNavigation.cy.ts
@@ -1,0 +1,210 @@
+import {
+  getRandomString,
+  getUserData,
+  validateLoginV2,
+} from "../../support/commands/general";
+import { User } from "../../support/types/user.types";
+import {
+  createProjectIfMissingAPIV2,
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+} from "../../support/utils/projectsV2.utils";
+import { verifySearchIndexing } from "../../support/utils/search.utils";
+
+const anonymousSession = {
+  id: ["anonymousNavigation-anonymousUser", getRandomString()],
+  setup: () => {
+    cy.log("Anonymous session");
+  },
+};
+const loggedSession = {
+  id: ["anonymousNavigation-loggedUser", getRandomString()],
+  setup: () => {
+    cy.log("Logged in session");
+    cy.robustLogin();
+  },
+};
+
+describe("Anonymous users can only access public resources", () => {
+  // Define some project details
+  let randomString: string;
+  let privateProjectName: string;
+  let publicProjectName: string;
+
+  function resetRequiredResources() {
+    randomString = getRandomString();
+    privateProjectName = `anon-private-${randomString}`;
+    publicProjectName = `anon-public-${randomString}`;
+  }
+
+  // Restore the session (login) and create the required projects
+  beforeEach(() => {
+    // Login
+    cy.session(loggedSession.id, loggedSession.setup, validateLoginV2);
+
+    // Create projects with new names to be sure re-runs don't break.
+    resetRequiredResources();
+    getUserData().then((user: User) => {
+      for (const proj of [privateProjectName, publicProjectName]) {
+        createProjectIfMissingAPIV2({
+          name: proj,
+          namespace: user.username,
+          slug: proj,
+          visibility: proj.includes("public") ? "public" : "private",
+        }).then((response) => {
+          // eslint-disable-line max-nested-callbacks
+          if (response.status >= 400) {
+            throw new Error("Failed to create project");
+          }
+        });
+      }
+    });
+
+    // Verify the resources are searchable
+    verifySearchIndexing(randomString, 2);
+  });
+
+  // Cleanup the project after the test
+  afterEach(() => {
+    // Login -- mind we might be logged out
+    cy.session(loggedSession.id, loggedSession.setup, validateLoginV2);
+
+    // Delete the projects
+    getUserData().then((user: User) => {
+      [privateProjectName, publicProjectName].forEach((proj) => {
+        getProjectByNamespaceAPIV2({
+          namespace: user.username,
+          slug: proj,
+          // eslint-disable-next-line max-nested-callbacks
+        }).then((response) => {
+          if (response.status === 200) {
+            deleteProjectFromAPIV2({
+              id: response.body.id,
+              slug: proj,
+            });
+          }
+        });
+      });
+    });
+  });
+
+  it("Navigate to projects and search for them", () => {
+    // Assess the projects exist and are search-able for the logged user
+    cy.visit("/v2");
+    cy.getDataCy("navbar-link-search").click();
+    cy.intercept(
+      new RegExp(`(?:/ui-server)?/api/search/query\\?q=.*?${randomString}.*`),
+    ).as("searchQuery");
+    cy.getDataCy("search-input").clear().type(randomString);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 2)
+      .each((card) => {
+        cy.wrap(card).should("contain", randomString);
+      });
+
+    // Log out and search for the projects as an anonymous user
+    cy.session(anonymousSession.id, anonymousSession.setup);
+    cy.visit("/v2");
+    cy.getDataCy("navbar-login").should("be.visible");
+    cy.getDataCy("navbar-link-search").click();
+    cy.intercept(
+      new RegExp(`(?:/ui-server)?/api/search/query\\?q=.*?${randomString}.*`),
+    ).as("searchQuery");
+    cy.getDataCy("search-input").clear().type(randomString);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length", 1).contains(randomString);
+    cy.getDataCy("search-card").getDataCy("search-card-entity-link").click();
+    cy.getDataCy("project-name").should("contain", publicProjectName);
+    cy.getDataCy("project-settings-link").click();
+    cy.getDataCy("project-update-button").should("not.exist");
+
+    // Login, check the private project and change visibility
+    cy.url().then((url) => {
+      cy.session(loggedSession.id, loggedSession.setup, validateLoginV2);
+      cy.visit(url);
+      cy.getDataCy("project-update-button").should("be.visible");
+
+      cy.getDataCy("navbar-link-search").click();
+      cy.getDataCy("search-input").clear().type(randomString);
+      cy.getDataCy("search-button").click();
+      cy.wait("@searchQuery");
+      cy.getDataCy("search-card")
+        .should("have.length", 2)
+        .each((card) => {
+          cy.wrap(card).should("contain", randomString);
+        });
+      cy.getDataCy("search-card")
+        .filter(`:contains("${privateProjectName}")`)
+        .find(`[data-cy=search-card-entity-link]`)
+        .click();
+      cy.getDataCy("project-name").should("contain", privateProjectName);
+      cy.getDataCy("project-settings-link").click();
+
+      cy.get("#project-visibility-private").should("be.checked");
+      cy.getDataCy("project-visibility-public").click();
+
+      cy.intercept("PATCH", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
+        "updateProject",
+      );
+      cy.getDataCy("project-update-button").click();
+      cy.wait("@updateProject");
+      cy.getDataCy("project-settings-general")
+        .get(".alert-success")
+        .contains("The project has been successfully updated.");
+    });
+
+    // Verify the previously private project is now publicly visible
+    cy.session(anonymousSession.id, anonymousSession.setup);
+    cy.visit("/v2");
+    cy.getDataCy("navbar-login").should("be.visible");
+    cy.getDataCy("navbar-link-search").click();
+    cy.getDataCy("search-input").clear().type(randomString);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 2)
+      .each((card) => {
+        cy.wrap(card).should("contain", randomString);
+      });
+
+    cy.getDataCy("search-card")
+      .filter(`:contains("${publicProjectName}")`)
+      .find(`[data-cy=search-card-entity-link]`)
+      .click();
+
+    // Login, check the public project and change visibility
+    cy.url().then((url) => {
+      cy.session(loggedSession.id, loggedSession.setup, validateLoginV2);
+      cy.visit(url);
+      cy.getDataCy("project-settings-link").click();
+
+      cy.get("#project-visibility-public").should("be.checked");
+      cy.getDataCy("project-visibility-private").click();
+
+      cy.intercept("PATCH", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
+        "updateProject",
+      );
+      cy.getDataCy("project-update-button").click();
+      cy.wait("@updateProject");
+      cy.getDataCy("project-settings-general")
+        .get(".alert-success")
+        .contains("The project has been successfully updated.");
+    });
+
+    // Verify the previously public project is now invisible
+    cy.session(anonymousSession.id, anonymousSession.setup);
+    cy.visit("/v2");
+    cy.getDataCy("navbar-login").should("be.visible");
+    cy.getDataCy("navbar-link-search").click();
+    cy.getDataCy("search-input").clear().type(randomString);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 1)
+      .should("not.contain", publicProjectName)
+      .should("contain", privateProjectName);
+  });
+});

--- a/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
@@ -1,10 +1,12 @@
-import { getRandomString, validateLogin } from "../support/commands/general";
-import { generatorProjectName } from "../support/commands/projects";
+import { getRandomString, validateLogin } from "../../support/commands/general";
+import { generatorProjectName } from "../../support/commands/projects";
 import {
   createProjectIfMissingAPIV2,
-  deleteProjectFromAPIV2, getProjectByNamespaceAPIV2,
-  getUserNamespaceAPIV2, ProjectIdentifierV2
-} from "../support/utils/projectsV2.utils";
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+  getUserNamespaceAPIV2,
+  ProjectIdentifierV2,
+} from "../../support/utils/projectsV2.utils";
 const projectTestConfig = {
   projectAlreadyExists: false,
   projectName: generatorProjectName("dashboardV2"),
@@ -21,13 +23,15 @@ describe("Dashboard v2 - Authenticated user", () => {
   };
 
   after(() => {
-    if (!projectTestConfig.projectAlreadyExists && projectIdentifier.id != null){
+    if (
+      !projectTestConfig.projectAlreadyExists &&
+      projectIdentifier.id != null
+    ) {
       deleteProjectFromAPIV2(projectIdentifier);
       getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
         expect(response.status).to.equal(404);
       });
     }
-
   });
 
   beforeEach(() => {
@@ -47,25 +51,37 @@ describe("Dashboard v2 - Authenticated user", () => {
           name: `${prefixProjectTitle} ${projectIdentifier.slug}`,
           namespace,
           slug: projectIdentifier.slug,
-        }).then((project) => projectIdentifier.id=project.id)
+        }).then((project) => (projectIdentifier.id = project.id));
       } else {
-        cy.log('No user namespace found, project cannot be created.');
+        cy.log("No user namespace found, project cannot be created.");
       }
     });
   });
 
   it("Can see own project on the dashboard", () => {
     cy.visit("v2");
-    cy.getDataCy("dashboard-project-list").find("a").should("have.length.at.least", 1);
-    cy.getDataCy("dashboard-project-list").find("a").should("contain.text", `${prefixProjectTitle} ${projectIdentifier.slug}`);
-    cy.getDataCy("dashboard-project-list").find("a").should("contain.text", projectIdentifier.slug);
+    cy.getDataCy("dashboard-project-list")
+      .find("a")
+      .should("have.length.at.least", 1);
+    cy.getDataCy("dashboard-project-list")
+      .find("a")
+      .should(
+        "contain.text",
+        `${prefixProjectTitle} ${projectIdentifier.slug}`
+      );
+    cy.getDataCy("dashboard-project-list")
+      .find("a")
+      .should("contain.text", projectIdentifier.slug);
   });
 
   it("Can find project in the search results", () => {
     cy.visit("v2");
     cy.getDataCy("view-my-projects-btn").click();
     cy.getDataCy("search-card").should("have.length.at.least", 1);
-    cy.getDataCy("search-card").should("contain.text", `${prefixProjectTitle} ${projectIdentifier.slug}`);
+    cy.getDataCy("search-card").should(
+      "contain.text",
+      `${prefixProjectTitle} ${projectIdentifier.slug}`
+    );
   });
 });
 
@@ -73,6 +89,9 @@ describe("Dashboard v2 - Non-Authenticated user", () => {
   it("Cannot see projects and groups on Dashboard when logged out", () => {
     cy.visit("v2");
     cy.getDataCy("user-container").should("be.visible");
-    cy.getDataCy("user-container").should("contain.text", "You are not logged in.");
+    cy.getDataCy("user-container").should(
+      "contain.text",
+      "You are not logged in."
+    );
   });
 });

--- a/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
@@ -1,11 +1,11 @@
 import { getRandomString, validateLogin } from "../../support/commands/general";
 import { generatorProjectName } from "../../support/commands/projects";
+import { ProjectIdentifierV2 } from "../../support/types/project.types";
 import {
   createProjectIfMissingAPIV2,
   deleteProjectFromAPIV2,
   getProjectByNamespaceAPIV2,
   getUserNamespaceAPIV2,
-  ProjectIdentifierV2,
 } from "../../support/utils/projectsV2.utils";
 const projectTestConfig = {
   projectAlreadyExists: false,

--- a/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/dashboardV2.cy.ts
@@ -41,7 +41,7 @@ describe("Dashboard v2 - Authenticated user", () => {
       () => {
         cy.robustLogin();
       },
-      validateLogin
+      validateLogin,
     );
     getUserNamespaceAPIV2().then((namespace) => {
       if (namespace) {
@@ -67,7 +67,7 @@ describe("Dashboard v2 - Authenticated user", () => {
       .find("a")
       .should(
         "contain.text",
-        `${prefixProjectTitle} ${projectIdentifier.slug}`
+        `${prefixProjectTitle} ${projectIdentifier.slug}`,
       );
     cy.getDataCy("dashboard-project-list")
       .find("a")
@@ -80,7 +80,7 @@ describe("Dashboard v2 - Authenticated user", () => {
     cy.getDataCy("search-card").should("have.length.at.least", 1);
     cy.getDataCy("search-card").should(
       "contain.text",
-      `${prefixProjectTitle} ${projectIdentifier.slug}`
+      `${prefixProjectTitle} ${projectIdentifier.slug}`,
     );
   });
 });
@@ -91,7 +91,7 @@ describe("Dashboard v2 - Non-Authenticated user", () => {
     cy.getDataCy("user-container").should("be.visible");
     cy.getDataCy("user-container").should(
       "contain.text",
-      "You are not logged in."
+      "You are not logged in.",
     );
   });
 });

--- a/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
@@ -36,17 +36,6 @@ describe("Group - create, edit and delete", () => {
     resetRequiredResources();
   });
 
-  // Restore the session (login)
-  beforeEach(() => {
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLoginV2,
-    );
-  });
-
   // Cleanup the group after the test -- useful on failure
   afterEach(() => {
     getGroupFromAPI(groupSlug).then((response) => {

--- a/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
@@ -9,23 +9,23 @@ import {
 
 const sessionId = ["groupBasics", getRandomString()];
 
-beforeEach(() => {
-  // Restore the session (login)
-  cy.session(
-    sessionId,
-    () => {
-      cy.robustLogin();
-    },
-    validateLoginV2,
-  );
-});
-
 describe("Group - create, edit and delete", () => {
   // Define some group details
   const groupNameRandomPart = getRandomString();
   const groupName = `group/$test-${groupNameRandomPart}`;
   const groupSlug = `group-test-${groupNameRandomPart}`;
   const groupDescription = "This is a test group from Cypress";
+
+  // Restore the session (login)
+  beforeEach(() => {
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+  });
 
   // Cleanup the group after the test -- useful on failure
   after(() => {

--- a/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
@@ -11,10 +11,30 @@ const sessionId = ["groupBasics", getRandomString()];
 
 describe("Group - create, edit and delete", () => {
   // Define some group details
-  const groupNameRandomPart = getRandomString();
-  const groupName = `group/$test-${groupNameRandomPart}`;
-  const groupSlug = `group-test-${groupNameRandomPart}`;
   const groupDescription = "This is a test group from Cypress";
+  let groupNameRandomPart;
+  let groupName;
+  let groupSlug;
+
+  function resetRequiredResources() {
+    groupNameRandomPart = getRandomString();
+    groupName = `group/$test-${groupNameRandomPart}`;
+    groupSlug = `group-test-${groupNameRandomPart}`;
+  }
+
+  beforeEach(() => {
+    // Restore the session (login)
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Define new group details to avoid conflicts on retries
+    resetRequiredResources();
+  });
 
   // Restore the session (login)
   beforeEach(() => {
@@ -28,7 +48,7 @@ describe("Group - create, edit and delete", () => {
   });
 
   // Cleanup the group after the test -- useful on failure
-  after(() => {
+  afterEach(() => {
     getGroupFromAPI(groupSlug).then((response) => {
       if (response.status === 200) {
         deleteGroupFromAPI(groupSlug);

--- a/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
@@ -1,0 +1,95 @@
+import {
+  getRandomString,
+  validateLoginV2,
+} from "../../support/commands/general";
+import {
+  deleteGroupFromAPI,
+  getGroupFromAPI,
+} from "../../support/utils/group.utils";
+
+const sessionId = ["groupBasics", getRandomString()];
+
+beforeEach(() => {
+  // Restore the session (login)
+  cy.session(
+    sessionId,
+    () => {
+      cy.robustLogin();
+    },
+    validateLoginV2,
+  );
+});
+
+describe("Group - create, edit and delete", () => {
+  // Define some group details
+  const groupNameRandomPart = getRandomString();
+  const groupName = `group/$test-${groupNameRandomPart}`;
+  const groupSlug = `group-test-${groupNameRandomPart}`;
+  const groupDescription = "This is a test group from Cypress";
+
+  // Cleanup the group after the test -- useful on failure
+  after(() => {
+    getGroupFromAPI(groupSlug).then((response) => {
+      if (response.status === 200) {
+        deleteGroupFromAPI(groupSlug);
+      }
+    });
+  });
+
+  it("Group - create, edit and delete", () => {
+    // Create a new group
+    cy.visit("/v2");
+    cy.getDataCy("navbar-new-entity").click();
+    cy.getDataCy("navbar-group-new").click();
+    cy.getDataCy("group-creation-form").should("exist");
+    cy.getDataCy("group-name-input").type(groupName);
+    cy.getDataCy("group-slug-toggle").click();
+    cy.getDataCy("group-slug-input").should("have.value", groupSlug);
+    cy.getDataCy("group-description-input").type(groupDescription);
+    cy.getDataCy("group-url-preview").contains(`/${groupSlug}`);
+    cy.intercept("POST", /(?:\/ui-server)?\/api\/data\/groups/).as(
+      "createGroup",
+    );
+    cy.getDataCy("group-create-button").click();
+    cy.wait("@createGroup");
+    cy.getDataCy("group-name").should("contain", groupName);
+
+    // Change settings
+    const modifiedGroupName = `${groupName} - modified`;
+    const modifiedGroupDescription = `${groupDescription} - modified`;
+    cy.getDataCy("nav-link-settings").click();
+    cy.getDataCy("group-name-input").should("have.value", groupName);
+    cy.getDataCy("group-name-input").clear().type(modifiedGroupName);
+    cy.getDataCy("group-description-input").should(
+      "have.value",
+      groupDescription,
+    );
+    cy.getDataCy("group-description-input")
+      .clear()
+      .type(modifiedGroupDescription);
+    cy.intercept("PATCH", /(?:\/ui-server)?\/api\/data\/groups\/[^/]+/).as(
+      "updateGroup",
+    );
+    cy.getDataCy("group-update-button").click();
+    cy.wait("@updateGroup");
+    cy.getDataCy("group-name").should("contain", modifiedGroupName);
+    cy.getDataCy("group-description").should(
+      "contain",
+      modifiedGroupDescription,
+    );
+
+    // Delete group
+    cy.getDataCy("nav-link-settings").click();
+    cy.getDataCy("group-delete-button").click();
+    cy.getDataCy("group-delete-confirm-button").should("not.be.enabled");
+    cy.getDataCy("delete-confirmation-input").type(groupSlug);
+    cy.intercept("DELETE", /(?:\/ui-server)?\/api\/data\/groups\/[^/]+/).as(
+      "deleteGroups",
+    );
+    cy.getDataCy("group-delete-confirm-button").should("be.enabled").click();
+    cy.wait("@deleteGroups");
+    getGroupFromAPI(groupSlug).then((response) => {
+      expect(response.status).to.equal(404);
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
     () => {
       cy.robustLogin();
     },
-    validateLoginV2
+    validateLoginV2,
   );
 });
 
@@ -60,9 +60,11 @@ describe("Project - create, edit and delete", () => {
       cy.getDataCy("project-visibility-public").click();
       cy.getDataCy("project-description-input").type(projectDescription);
       cy.getDataCy("project-url-preview").contains(
-        `/${username}/${projectPath}`
+        `/${username}/${projectPath}`,
       );
-      cy.intercept("POST", /(?:\/ui-server)?\/api\/data\/projects/).as("createProject");
+      cy.intercept("POST", /(?:\/ui-server)?\/api\/data\/projects/).as(
+        "createProject",
+      );
       cy.getDataCy("project-create-button").click();
       cy.wait("@createProject");
       cy.getDataCy("project-name").should("contain", projectName);
@@ -76,7 +78,7 @@ describe("Project - create, edit and delete", () => {
 
       cy.getDataCy("project-description-input").should(
         "have.value",
-        projectDescription
+        projectDescription,
       );
       cy.getDataCy("project-description-input")
         .clear()
@@ -86,7 +88,7 @@ describe("Project - create, edit and delete", () => {
       cy.getDataCy("project-visibility-private").click();
 
       cy.intercept("PATCH", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
-        "updateProject"
+        "updateProject",
       );
       cy.getDataCy("project-update-button").click();
       cy.wait("@updateProject");
@@ -96,7 +98,7 @@ describe("Project - create, edit and delete", () => {
       cy.getDataCy("project-name").should("contain", modifiedProjectName);
       cy.getDataCy("project-description").should(
         "contain",
-        modifiedProjectDescription
+        modifiedProjectDescription,
       );
 
       // Delete project
@@ -105,7 +107,7 @@ describe("Project - create, edit and delete", () => {
       cy.getDataCy("project-delete-button").should("not.be.enabled");
       cy.getDataCy("delete-confirmation-input").type(projectPath);
       cy.intercept("DELETE", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
-        "deleteProject"
+        "deleteProject",
       );
       cy.getDataCy("project-delete-button").should("be.enabled").click();
       cy.wait("@deleteProject");

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -45,17 +45,6 @@ describe("Project - create, edit and delete", () => {
     resetRequiredResources();
   });
 
-  // Restore the session (login)
-  beforeEach(() => {
-    cy.session(
-      sessionId,
-      () => {
-        cy.robustLogin();
-      },
-      validateLoginV2,
-    );
-  });
-
   // Cleanup the project after the test -- useful on failure
   afterEach(() => {
     getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -12,17 +12,6 @@ import {
 
 const sessionId = ["projectBasics", getRandomString()];
 
-beforeEach(() => {
-  // Restore the session (login)
-  cy.session(
-    sessionId,
-    () => {
-      cy.robustLogin();
-    },
-    validateLoginV2,
-  );
-});
-
 describe("Project - create, edit and delete", () => {
   // Define some project details
   const projectNameRandomPart = getRandomString();
@@ -34,6 +23,17 @@ describe("Project - create, edit and delete", () => {
     id: null,
     namespace: null,
   };
+
+  // Restore the session (login)
+  beforeEach(() => {
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+  });
 
   // Cleanup the project after the test -- useful on failure
   after(() => {

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -14,15 +14,36 @@ const sessionId = ["projectBasics", getRandomString()];
 
 describe("Project - create, edit and delete", () => {
   // Define some project details
-  const projectNameRandomPart = getRandomString();
-  const projectName = `project/$test-${projectNameRandomPart}`;
-  const projectPath = `project-test-${projectNameRandomPart}`;
   const projectDescription = "This is a test project from Cypress";
-  const projectIdentifier: ProjectIdentifierV2 = {
-    slug: projectPath,
-    id: null,
-    namespace: null,
-  };
+  let projectNameRandomPart: string;
+  let projectName;
+  let projectPath;
+  let projectIdentifier: ProjectIdentifierV2;
+
+  function resetRequiredResources() {
+    projectNameRandomPart = getRandomString();
+    projectName = `project/$test-${projectNameRandomPart}`;
+    projectPath = `project-test-${projectNameRandomPart}`;
+    projectIdentifier = {
+      slug: projectPath,
+      id: null,
+      namespace: null,
+    };
+  }
+
+  beforeEach(() => {
+    // Restore the session (login)
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Define new project details to avoid conflicts on retries
+    resetRequiredResources();
+  });
 
   // Restore the session (login)
   beforeEach(() => {
@@ -36,7 +57,7 @@ describe("Project - create, edit and delete", () => {
   });
 
   // Cleanup the project after the test -- useful on failure
-  after(() => {
+  afterEach(() => {
     getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
       if (response.status === 200) {
         projectIdentifier.id = response.body.id;

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -1,0 +1,117 @@
+import {
+  getRandomString,
+  getUserData,
+  validateLoginV2,
+} from "../../support/commands/general";
+import { ProjectIdentifierV2 } from "../../support/types/project.types";
+import { User } from "../../support/types/user.types";
+import {
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+} from "../../support/utils/projectsV2.utils";
+
+const sessionId = ["projectBasics", getRandomString()];
+
+beforeEach(() => {
+  // Restore the session (login)
+  cy.session(
+    sessionId,
+    () => {
+      cy.robustLogin();
+    },
+    validateLoginV2
+  );
+});
+
+describe("Project - create, edit and delete", () => {
+  // Define some project details
+  const projectNameRandomPart = getRandomString();
+  const projectName = `project/$test-${projectNameRandomPart}`;
+  const projectPath = `project-test-${projectNameRandomPart}`;
+  const projectDescription = "This is a test project from Cypress";
+  const projectIdentifier: ProjectIdentifierV2 = {
+    slug: projectPath,
+    id: null,
+    namespace: null,
+  };
+
+  // Cleanup the project after the test -- useful on failure
+  after(() => {
+    getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
+      if (response.status === 200) {
+        projectIdentifier.id = response.body.id;
+        projectIdentifier.namespace = response.body.namespace;
+        deleteProjectFromAPIV2(projectIdentifier);
+      }
+    });
+  });
+
+  it("Project - create, edit and delete", () => {
+    // Create a new project
+    cy.visit("/v2");
+    getUserData().then((user: User) => {
+      const username = user.username;
+      cy.getDataCy("navbar-new-entity").click();
+      cy.getDataCy("navbar-project-new").click();
+      cy.getDataCy("project-creation-form").should("exist");
+      cy.getDataCy("project-name-input").type(projectName);
+      cy.getDataCy("project-slug-toggle").click();
+      cy.getDataCy("project-slug-input").should("have.value", projectPath);
+      cy.getDataCy("project-visibility-public").click();
+      cy.getDataCy("project-description-input").type(projectDescription);
+      cy.getDataCy("project-url-preview").contains(
+        `/${username}/${projectPath}`
+      );
+      cy.intercept("POST", /(?:\/ui-server)?\/api\/data\/projects/).as("createProject");
+      cy.getDataCy("project-create-button").click();
+      cy.wait("@createProject");
+      cy.getDataCy("project-name").should("contain", projectName);
+
+      // Change settings
+      const modifiedProjectName = `${projectName} - modified`;
+      const modifiedProjectDescription = `${projectDescription} - modified`;
+      cy.getDataCy("project-settings-link").click();
+      cy.getDataCy("project-name-input").should("have.value", projectName);
+      cy.getDataCy("project-name-input").clear().type(modifiedProjectName);
+
+      cy.getDataCy("project-description-input").should(
+        "have.value",
+        projectDescription
+      );
+      cy.getDataCy("project-description-input")
+        .clear()
+        .type(modifiedProjectDescription);
+
+      cy.get("#project-visibility-public").should("be.checked");
+      cy.getDataCy("project-visibility-private").click();
+
+      cy.intercept("PATCH", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
+        "updateProject"
+      );
+      cy.getDataCy("project-update-button").click();
+      cy.wait("@updateProject");
+      cy.getDataCy("project-settings-general")
+        .get(".alert-success")
+        .contains("The project has been successfully updated.");
+      cy.getDataCy("project-name").should("contain", modifiedProjectName);
+      cy.getDataCy("project-description").should(
+        "contain",
+        modifiedProjectDescription
+      );
+
+      // Delete project
+      cy.getDataCy("project-settings-link").click();
+      cy.getDataCy("project-delete");
+      cy.getDataCy("project-delete-button").should("not.be.enabled");
+      cy.getDataCy("delete-confirmation-input").type(projectPath);
+      cy.intercept("DELETE", /(?:\/ui-server)?\/api\/data\/projects\/[^/]+/).as(
+        "deleteProject"
+      );
+      cy.getDataCy("project-delete-button").should("be.enabled").click();
+      cy.wait("@deleteProject");
+      getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
+        expect(response.status).to.equal(404);
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/v2/projectResources.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectResources.cy.ts
@@ -1,0 +1,214 @@
+import {
+  getRandomString,
+  getUserData,
+  validateLoginV2,
+} from "../../support/commands/general";
+import { ProjectIdentifierV2 } from "../../support/types/project.types";
+import { User } from "../../support/types/user.types";
+import {
+  createProjectIfMissingAPIV2,
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+} from "../../support/utils/projectsV2.utils";
+
+const sessionId = ["projectResources", getRandomString()];
+
+describe("Project resources - work with code, data, environments", () => {
+  // Define some project details
+  const projectNameRandomPart = getRandomString();
+  const projectName = `project-resources-${projectNameRandomPart}`;
+  const projectDescription =
+    "This is a test project from Cypress to test working with code, data, environments";
+  const projectIdentifier: ProjectIdentifierV2 = {
+    slug: projectName,
+    id: null,
+    namespace: null,
+  };
+
+  // Create a project and keep that around for the rest of the tests
+  before(() => {
+    // Login
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Create the project and save its deetails
+    getUserData().then((user: User) => {
+      projectIdentifier.namespace = user.username;
+      createProjectIfMissingAPIV2({
+        description: projectDescription,
+        name: projectName,
+        namespace: user.username,
+        slug: projectName,
+        visibility: "private",
+      }).then((project) => (projectIdentifier.id = project.id));
+    });
+  });
+
+  // Restore the session (login)
+  beforeEach(() => {
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+  });
+
+  // Cleanup the project after the test -- useful on failure
+  after(() => {
+    getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
+      if (response.status === 200) {
+        projectIdentifier.id = response.body.id;
+        projectIdentifier.namespace = response.body.namespace;
+        deleteProjectFromAPIV2(projectIdentifier);
+      }
+    });
+  });
+
+  const visitCurrentProject = () => {
+    // There should a link on the dashboard for a newly created project
+    cy.visit("/v2");
+    cy.getDataCy("dashboard-project-list")
+      .get(
+        `a[href*="/${projectIdentifier.namespace}/${projectIdentifier.slug}"]`,
+      )
+      .click();
+    cy.getDataCy("project-name").should("contain", projectName);
+  };
+
+  it("Add and modify data connectors", () => {
+    const name = `giab-${getRandomString()}`;
+
+    // Add data connector
+    visitCurrentProject();
+    cy.getDataCy("add-data-connector").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
+    cy.getDataCy("data-connector-edit-next-button").should("be.disabled");
+    cy.getDataCy("data-storage-s3").click();
+    cy.getDataCy("data-provider-AWS").click();
+    cy.getDataCy("data-connector-edit-next-button").click();
+
+    cy.getDataCy("data-connector-source-path").should("be.empty").type("giab");
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("cloud-storage-connection-success").should("be.visible");
+    cy.getDataCy("add-data-connector-continue-button").click();
+
+    cy.getDataCy("data-connector-name-input").should("be.empty").type(name);
+    cy.getDataCy("data-connector-slug-input").should("have.value", name);
+    cy.getDataCy("data-connector-mount-input").should("have.value", name);
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.getDataCy("data-connector-edit-success").should("be.visible");
+    cy.getDataCy("data-connector-edit-close-button").click();
+
+    // ? Currently, data connectors newly linked might not appear immediately
+    visitCurrentProject();
+    cy.getDataCy("data-connector-box")
+      .find(`[data-cy=data-connector-name]`)
+      .contains(name);
+
+    // Edit data connector
+    const newName = `${name} edited`;
+
+    cy.getDataCy("data-connector-box")
+      .find(`[data-cy=data-connector-name]`)
+      .contains(name)
+      .click();
+    cy.getDataCy("data-connector-edit").click();
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button").click();
+
+    cy.getDataCy("data-connector-name-input")
+      .should("have.value", name)
+      .clear()
+      .type(newName);
+    cy.getDataCy("data-connector-slug-input").should("have.value", name);
+    cy.getDataCy("data-connector-mount-input").should("have.value", name);
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.getDataCy("data-connector-edit-success").should("be.visible");
+    cy.getDataCy("data-connector-edit-close-button").click();
+
+    // ? Currently, data connectors newly linked might not appear immediately
+    visitCurrentProject();
+    cy.getDataCy("data-connector-box")
+      .find(`[data-cy=data-connector-name]`)
+      .contains(newName);
+  });
+
+  it("Add and modify code repositories", () => {
+    const repoUrl = "https://github.com/SwissDataScienceCenter/renku-ui.git";
+    const repoName = "renku-ui";
+    const repoUrlEdited =
+      "https://github.com/SwissDataScienceCenter/renku-data-services.git";
+    const repoNameEdited = "renku-data-services";
+
+    // Add code repository
+    visitCurrentProject();
+    cy.getDataCy("add-code-repository").click();
+    cy.getDataCy("project-add-repository-url").should("be.empty").type(repoUrl);
+    cy.getDataCy("add-code-repository-modal-button").click();
+    cy.getDataCy("code-repositories-box")
+      .find("[data-cy=code-repository-item]")
+      .contains(repoName);
+    cy.contains("[data-cy=code-repository-item]", repoName).contains(
+      "Pull only",
+    );
+
+    // Edit code repository
+    cy.contains("[data-cy=code-repository-item]", repoName)
+      .find("[data-cy=code-repository-edit]")
+      .click();
+    cy.getDataCy("project-edit-repository-url")
+      .should("have.value", repoUrl)
+      .clear()
+      .type(repoUrlEdited);
+    cy.getDataCy("edit-code-repository-modal-button").click();
+    cy.getDataCy("code-repositories-box")
+      .find("[data-cy=code-repository-item]")
+      .contains(repoNameEdited);
+    cy.contains("[data-cy=code-repository-item]", repoNameEdited).contains(
+      "Pull only",
+    );
+  });
+
+  it("Add and modify session environments", () => {
+    const sessionImage = "alpine:latest";
+    const sessionUrl = "/test";
+    const sessionName = `vscode-${getRandomString()}`;
+
+    // Add session environment
+    visitCurrentProject();
+    cy.getDataCy("add-session-launcher").click();
+    cy.getDataCy("existing-custom-button").click();
+    cy.getDataCy("custom-image-input").should("be.empty").type(sessionImage);
+    cy.getDataCy("environment-advanced-settings-toggle").click();
+    cy.getDataCy("session-launcher-field-default_url").clear().type(sessionUrl);
+    cy.getDataCy("next-session-button").click();
+    cy.getDataCy("launcher-name-input").should("be.empty").type(sessionName);
+    cy.getDataCy("add-session-button").click();
+    cy.getDataCy("session-launcher-creation-success").should("be.visible");
+    cy.getDataCy("close-cancel-button").click();
+
+    // Edit session environment
+    cy.getDataCy("sessions-box")
+      .contains("[data-cy=session-launcher-item]", sessionName)
+      .click();
+    cy.getDataCy("session-view-menu-edit").click();
+    cy.getDataCy("edit-session-name")
+      .should("have.value", sessionName)
+      .clear()
+      .type(`${sessionName}-edited`);
+    cy.getDataCy("edit-session-button").click();
+    cy.getDataCy("session-launcher-update-success").should("be.visible");
+    cy.getDataCy("close-cancel-button").click();
+    cy.getDataCy("sessions-box").contains(
+      "[data-cy=session-launcher-item]",
+      sessionName,
+    );
+  });
+});

--- a/cypress-tests/cypress/e2e/v2/searchEntities.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/searchEntities.cy.ts
@@ -1,0 +1,192 @@
+import { TIMEOUTS } from "../../../config";
+import {
+  getRandomString,
+  getUserData,
+  validateLoginV2,
+} from "../../support/commands/general";
+import { User } from "../../support/types/user.types";
+import {
+  createGroupIfMissingAPI,
+  deleteGroupFromAPI,
+  getGroupFromAPI,
+} from "../../support/utils/group.utils";
+import {
+  createProjectIfMissingAPIV2,
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+} from "../../support/utils/projectsV2.utils";
+
+const sessionId = ["searchEntities", getRandomString()];
+
+describe("Search for resources: groups, projects, users", () => {
+  // Define projects and groups details
+  // ? Random string is currently the only way to get good results from search
+  // ? since searching for multiple words may return a bunch a unexpected results.
+  const stringRandomOne = getRandomString();
+  const stringRandomTwo = getRandomString();
+  const stringFirst = "first";
+  const stringSecond = "second";
+  const stringProject = "project";
+  const stringGroup = "group";
+  const projects = {
+    first: `${stringProject}-${stringFirst}-${stringRandomOne}`,
+    second: `${stringProject}-${stringSecond}-${stringRandomTwo}`,
+  };
+  const groups = {
+    first: `${stringGroup}-${stringFirst}-${stringRandomTwo}`,
+    second: `${stringGroup}-${stringSecond}-${stringRandomOne}`,
+  };
+  let userNamespace: string;
+
+  // Create the requires resources
+  before(() => {
+    // Login
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Create groups and projects -- fail early if any of the resources are not created
+    getUserData().then((user: User) => {
+      userNamespace = user.username;
+      for (const proj of [projects.first, projects.second]) {
+        createProjectIfMissingAPIV2({
+          name: proj,
+          namespace: user.username,
+          slug: proj,
+        }).then((response) => {
+          if (response.status >= 400) {
+            throw new Error("Failed to create project");
+          }
+        });
+      }
+      for (const grp of [groups.first, groups.second]) {
+        createGroupIfMissingAPI({
+          name: grp,
+          slug: grp,
+        }).then((response) => {
+          if (response.status >= 400) {
+            throw new Error("Failed to create group");
+          }
+        });
+      }
+    });
+
+    // ? This isn't ideal, but groups need a little time to be indexed in search and this avoids
+    // ? occasionally failing tests
+    cy.wait(TIMEOUTS.short);
+  });
+
+  // Restore the session (login)
+  beforeEach(() => {
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+  });
+
+  // Cleanup the resources after the test
+  after(() => {
+    [projects.first, projects.second].forEach((proj) => {
+      getProjectByNamespaceAPIV2({
+        slug: proj,
+        namespace: userNamespace,
+      }).then((response) => {
+        if (response.status === 200) {
+          deleteProjectFromAPIV2({
+            id: response.body.id,
+            slug: proj,
+          });
+        }
+      });
+    });
+    [groups.first, groups.second].forEach((grp) => {
+      getGroupFromAPI(grp).then((response) => {
+        if (response.status === 200) {
+          deleteGroupFromAPI(grp);
+        }
+      });
+    });
+  });
+
+  it("Can search for entities and filter works", () => {
+    cy.visit("/v2");
+
+    // Search for string
+    cy.getDataCy("navbar-link-search").click();
+    cy.intercept(
+      new RegExp(
+        `(?:/ui-server)?/api/search/query.*`,
+      ),
+    ).as("searchQuery");
+    cy.getDataCy("search-input").clear().type(stringRandomOne);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 2)
+      .each((card) => {
+        cy.wrap(card).should("contain", stringRandomOne);
+      });
+    cy.getDataCy("search-input").clear().type(stringRandomTwo);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 2)
+      .each((card) => {
+        cy.wrap(card).should("contain", stringRandomTwo);
+      });
+
+    // Filter for projects and groups
+    cy.getDataCy("search-filter-type-group").filter(":visible").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length", 1).contains(groups.first);
+
+    cy.getDataCy("search-input").clear().type(stringRandomOne);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length", 1).contains(groups.second);
+
+    cy.getDataCy("search-filter-type-group").filter(":visible").click();
+    cy.getDataCy("search-filter-type-project").filter(":visible").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length", 1).contains(projects.first);
+
+    // Search with filters
+    const complexSearch = `type:group,project ${stringRandomOne} ${stringRandomTwo}`;
+    cy.getDataCy("search-input").clear().type(complexSearch);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card")
+      .should("have.length", 4)
+      .each((card) => {
+        cy.wrap(card).should(($card) => {
+          const text = $card.text();
+          expect(text).to.match(
+            new RegExp(`${stringRandomOne}|${stringRandomTwo}`)
+          );
+        });
+      });
+
+    // Filter by date
+    cy.getDataCy("search-filter-created-older-than-90-days")
+      .filter(":visible")
+      .click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length", 0);
+    cy.getDataCy("search-filter-created-last-week").filter(":visible").click();
+
+    // Can search for users -- can't guarantee we match an exact number here
+    const userSearch = "type:user";
+    cy.getDataCy("search-filter-created-all").filter(":visible").click();
+    cy.getDataCy("search-input").clear().type(userSearch);
+    cy.getDataCy("search-button").click();
+    cy.wait("@searchQuery");
+    cy.getDataCy("search-card").should("have.length.at.least", 1);
+  });
+});

--- a/cypress-tests/cypress/e2e/v2/sessionBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/sessionBasics.cy.ts
@@ -1,0 +1,203 @@
+import { TIMEOUTS } from "../../../config";
+import {
+  getRandomString,
+  getUserData,
+  validateLoginV2,
+} from "../../support/commands/general";
+import { ProjectIdentifierV2 } from "../../support/types/project.types";
+import { User } from "../../support/types/user.types";
+import {
+  createProjectIfMissingAPIV2,
+  deleteProjectFromAPIV2,
+  getProjectByNamespaceAPIV2,
+} from "../../support/utils/projectsV2.utils";
+
+const sessionId = ["sessionBasics", getRandomString()];
+
+describe("Start a session that consumes project resources", () => {
+  // Define required resources
+  let projectNameRandomPart: string;
+  let projectName;
+  let projectIdentifier: ProjectIdentifierV2;
+
+  function resetRequiredResources() {
+    projectNameRandomPart = getRandomString();
+    projectName = `session-basics-${projectNameRandomPart}`;
+    projectIdentifier = {
+      slug: projectName,
+      id: null,
+      namespace: null,
+    };
+  }
+
+  beforeEach(() => {
+    // Restore the session (login)
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Create a project
+    resetRequiredResources();
+    getUserData().then((user: User) => {
+      projectIdentifier.namespace = user.username;
+      createProjectIfMissingAPIV2({
+        name: projectName,
+        namespace: user.username,
+        slug: projectName,
+      }).then((project) => (projectIdentifier.id = project.id));
+    });
+  });
+
+  // Cleanup the project after the test
+  after(() => {
+    getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
+      if (response.status === 200) {
+        projectIdentifier.id = response.body.id;
+        projectIdentifier.namespace = response.body.namespace;
+        deleteProjectFromAPIV2(projectIdentifier);
+      }
+    });
+  });
+
+  it("Start a session with VSCode and check it has the necessary resources", () => {
+    const dataConnectorName = `giab-${getRandomString()}`;
+    const dataContainerFolder = "data_RNAseq";
+    const repositoryName = "renku-ui";
+    const repositoryFolder = "client";
+    const session = {
+      arguments: '["/entrypoint.sh"]',
+      command: '["bash"]',
+      image: "renku/renkulab-vscodium-python-runimage:ubuntu-59fcea4",
+      mountdir: "/home/ubuntu/work",
+      name: "vscode-launcher",
+      url: "/",
+      workdir: "/home/ubuntu/work",
+    };
+
+    // Access the project and create some resources.
+    cy.visit("/v2");
+    cy.getDataCy("dashboard-project-list")
+      .get(
+        `a[href*="/${projectIdentifier.namespace}/${projectIdentifier.slug}"]`,
+      )
+      .click();
+    cy.getDataCy("project-name").should("contain", projectName);
+
+    cy.getDataCy("add-data-connector").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
+    cy.getDataCy("data-storage-s3").click();
+    cy.getDataCy("data-provider-AWS").click();
+    cy.getDataCy("data-connector-edit-next-button").click();
+    cy.getDataCy("data-connector-source-path").clear().type("giab");
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button").click();
+    cy.getDataCy("data-connector-name-input").clear().type(dataConnectorName);
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.getDataCy("data-connector-edit-success").should("be.visible");
+    cy.getDataCy("data-connector-edit-close-button").click();
+    // ? data connectors don't refresh properly yet so we need to reload the page
+    cy.reload();
+    cy.getDataCy("data-connector-box")
+      .find(`[data-cy=data-connector-name]`)
+      .contains(dataConnectorName);
+
+    cy.getDataCy("add-code-repository").click();
+    cy.getDataCy("project-add-repository-url")
+      .clear()
+      .type("https://github.com/SwissDataScienceCenter/renku-ui.git");
+    cy.getDataCy("add-code-repository-modal-button").click();
+    cy.getDataCy("code-repositories-box")
+      .find("[data-cy=code-repository-item]")
+      .contains(repositoryName);
+    cy.contains("[data-cy=code-repository-item]", repositoryName).contains(
+      "Pull only",
+    );
+
+    cy.getDataCy("add-session-launcher").click();
+    cy.getDataCy("existing-custom-button").click();
+    cy.getDataCy("custom-image-input").clear().type(session.image);
+    cy.getDataCy("environment-advanced-settings-toggle").click();
+    cy.getDataCy("session-launcher-field-default_url")
+      .clear()
+      .type(session.url);
+    cy.getDataCy("session-launcher-field-mount_directory")
+      .clear()
+      .type(session.mountdir);
+    cy.getDataCy("session-launcher-field-working_directory")
+      .clear()
+      .type(session.workdir);
+    cy.getDataCy("session-launcher-field-command")
+      .clear()
+      .type(session.command);
+    cy.getDataCy("session-launcher-field-args")
+      .clear()
+      .type(session.arguments, { parseSpecialCharSequences: false });
+    cy.getDataCy("next-session-button").click();
+    cy.getDataCy("launcher-name-input").clear().type(session.name);
+    cy.getDataCy("add-session-button").click();
+    cy.getDataCy("session-launcher-creation-success").should("be.visible");
+    cy.getDataCy("close-cancel-button").click();
+
+    // Start a pristine session
+    cy.getDataCy("sessions-box")
+      .contains("[data-cy=session-launcher-item]", session.name)
+      .then(($el) => {
+        const $resume = $el.find("[data-cy=resume-session-button]");
+        const $open = $el.find("[data-cy=open-session]");
+        if ($resume.length > 0 || $open.length > 0) {
+          cy.wrap($el).find("[data-cy=button-with-menu-dropdown]").click();
+          cy.wrap($el).find("[data-cy=delete-session-button]").click();
+          cy.getDataCy("delete-session-modal-button").click();
+        }
+      });
+    cy.getDataCy("sessions-box")
+      .contains("[data-cy=session-launcher-item]", session.name)
+      .find("[data-cy=start-session-button]", {
+        timeout: TIMEOUTS.long,
+      })
+      .click();
+    cy.getDataCy("session-status-starting");
+    cy.get("[data-cy=session-status-starting]", {
+      timeout: TIMEOUTS.long,
+    }).should("be.visible");
+    cy.getDataCy("session-header").contains(session.name);
+    cy.get("[data-cy=session-iframe]", { timeout: TIMEOUTS.vlong }).should(
+      "be.visible",
+    );
+
+    // Check the project resources are available in the session.
+    cy.getIframe("[data-cy=session-iframe]").within(() => {
+      // ? Mind the following commands target the VSCode web interface where we have little control.
+      function findAndExpandFolder(name: string, depth: number) {
+        cy.contains(`[role=treeitem][aria-level="${depth}"]`, name).then(
+          ($el) => {
+            if ($el.attr("aria-expanded") === "false") {
+              // ? Forcing clicks is a bad practice but VScode has unpredictable behavior for its popups.
+              // eslint-disable-next-line cypress/no-force
+              cy.wrap($el).click({ force: true });
+            }
+          },
+        );
+      }
+      cy.get("#workbench\\.view\\.explorer", { timeout: TIMEOUTS.long }).within(
+        () => {
+          // Check the repository content
+          findAndExpandFolder(repositoryName, 1);
+          cy.get(
+            `[role="treeitem"][aria-level="2"][aria-label="${repositoryFolder}"]`,
+          ).should("exist");
+
+          // Check the S3 bucket content
+          findAndExpandFolder(dataConnectorName, 1);
+          cy.get(
+            `[role="treeitem"][aria-level="2"][aria-label="${dataContainerFolder}"]`,
+          ).should("exist");
+        },
+      );
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
+++ b/cypress-tests/cypress/e2e/verifyInfrastructure.cy.ts
@@ -11,13 +11,13 @@ function retryRequest(
   service: string,
   limit = 10,
   delaySeconds = 30,
-  retries = 1
+  retries = 1,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Cypress.Response<any> {
   if (retries > limit) {
     const minutes = Math.floor((limit * delaySeconds) / 60);
     throw new Error(
-      `Backend service "${service}" not responding within ${minutes} minutes at URL ${url}.`
+      `Backend service "${service}" not responding within ${minutes} minutes at URL ${url}.`,
     );
   }
 
@@ -28,7 +28,7 @@ function retryRequest(
     if (resp.status < 400 && !resp.body.error) return resp.body;
 
     cy.wait(delaySeconds * 1000).then(() =>
-      retryRequest(url, service, limit, delaySeconds, retries + 1)
+      retryRequest(url, service, limit, delaySeconds, retries + 1),
     );
   });
   return null;
@@ -44,7 +44,7 @@ describe("Verify the infrastructure is ready", () => {
     retryRequest("api/auth/login", "Gateway");
     retryRequest(
       `ui-server/api/allows-iframe/${encodeURIComponent("https://google.com")}`,
-      "UI server"
+      "UI server",
     );
     retryRequest("config.json", "UI client");
 
@@ -60,7 +60,7 @@ describe("Verify the infrastructure is ready", () => {
     const gitUrl =
       "https://gitlab.dev.renku.ch/renku-ui-tests/renku-project-v10";
     const coreUrl = `/ui-server/api/renku/config.show?git_url=${encodeURIComponent(
-      gitUrl
+      gitUrl,
     )}`;
     cy.request(coreUrl).then((resp) => {
       if (resp.status >= 400 || !("result" in resp.body))

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -1,4 +1,5 @@
 import { TIMEOUTS } from "../../../config";
+import { User } from "../types/user.types";
 
 export const validateLogin = {
   validate() {
@@ -6,7 +7,7 @@ export const validateLogin = {
     // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
     // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(10_000);
+    cy.wait(TIMEOUTS.short);
     // This returns 401 when not properly logged in
     cy.request("ui-server/api/data/user").its("status").should("eq", 200);
     // This is how the ui decides the user is logged in
@@ -18,6 +19,38 @@ export const validateLogin = {
     });
   },
 };
+
+export const validateLoginV2 = {
+  validate() {
+    cy.request("api/data/user").then((response) => {
+      expect(response.status).to.eq(200);
+
+      expect(response.body).property("id").to.not.be.empty;
+      expect(response.body).property("id").to.not.be.null;
+      expect(response.body).property("username").to.not.be.empty;
+      expect(response.body).property("username").to.not.be.null;
+    });
+  },
+};
+
+export function getUserData(): Cypress.Chainable<User> {
+  return cy.request("api/data/user").as("getUserData").then((response) => {
+    expect(response.status).to.eq(200);
+    expect(response.body).property("username").to.exist;
+    expect(response.body).property("username").to.not.be.empty;
+    expect(response.body).property("username").to.not.be.null;
+
+    return {
+      id: response.body.id,
+      username: response.body.username,
+      email: response.body.email,
+      first_name: response.body.first_name,
+      last_name: response.body.last_name,
+      is_admin: response.body.is_admin,
+    } as User;
+  });
+}
+
 
 export const getIframe = (selector: string) => {
   // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/blogs__iframes/cypress/support/e2e.js

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -34,23 +34,25 @@ export const validateLoginV2 = {
 };
 
 export function getUserData(): Cypress.Chainable<User> {
-  return cy.request("api/data/user").as("getUserData").then((response) => {
-    expect(response.status).to.eq(200);
-    expect(response.body).property("username").to.exist;
-    expect(response.body).property("username").to.not.be.empty;
-    expect(response.body).property("username").to.not.be.null;
+  return cy
+    .request("api/data/user")
+    .as("getUserData")
+    .then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).property("username").to.exist;
+      expect(response.body).property("username").to.not.be.empty;
+      expect(response.body).property("username").to.not.be.null;
 
-    return {
-      id: response.body.id,
-      username: response.body.username,
-      email: response.body.email,
-      first_name: response.body.first_name,
-      last_name: response.body.last_name,
-      is_admin: response.body.is_admin,
-    } as User;
-  });
+      return {
+        id: response.body.id,
+        username: response.body.username,
+        email: response.body.email,
+        first_name: response.body.first_name,
+        last_name: response.body.last_name,
+        is_admin: response.body.is_admin,
+      } as User;
+    });
 }
-
 
 export const getIframe = (selector: string) => {
   // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/blogs__iframes/cypress/support/e2e.js
@@ -70,7 +72,9 @@ function getDataCy(value: string, exist?: boolean) {
 }
 
 export function getRandomString(length = 8) {
-  return Math.random().toString(20).substring(2, length);
+  return Math.random()
+    .toString(20)
+    .substring(2, length + 2);
 }
 
 export default function registerGeneralCommands() {

--- a/cypress-tests/cypress/support/commands/general.ts
+++ b/cypress-tests/cypress/support/commands/general.ts
@@ -5,7 +5,8 @@ export const validateLogin = {
     // If we send a request to the user endpoint on Gitlab too quickly after we log in then
     // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
     // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
-    cy.wait(10000);
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(10_000);
     // This returns 401 when not properly logged in
     cy.request("ui-server/api/data/user").its("status").should("eq", 200);
     // This is how the ui decides the user is logged in
@@ -35,8 +36,8 @@ function getDataCy(value: string, exist?: boolean) {
   return cy.get(`[data-cy=${value}]`);
 }
 
-export function getRandomString(length: number=8) {
-  return Math.random().toString(20).substr(2, length)
+export function getRandomString(length = 8) {
+  return Math.random().toString(20).substring(2, length);
 }
 
 export default function registerGeneralCommands() {

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -4,7 +4,7 @@ const renkuLogin = (credentials: { username: string; password: string }[]) => {
       cy.get("#username").type(credential.username);
       cy.get("#password").type(credential.password, { log: false });
       cy.get("#kc-login").click();
-    }
+    },
   );
   cy.url().then((url) => {
     const parsedUrl = new URL(url);
@@ -21,7 +21,7 @@ const register = (
   email: string,
   password: string,
   firstName?: string,
-  lastName?: string
+  lastName?: string,
 ) => {
   cy.visit("/api/auth/login");
 
@@ -61,7 +61,7 @@ const register = (
         .should("be.visible")
         .should("be.enabled")
         .click();
-    }
+    },
   );
 };
 
@@ -101,7 +101,8 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
   // If we send a request to the user endpoint on Gitlab too quickly after we log in then
   // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
   // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
-  cy.wait(10000);
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(10_000);
   cy.request("ui-server/api/data/user").its("status").should("eq", 200);
   cy.request("ui-server/api/user").then((response) => {
     expect(response.status).to.eq(200);
@@ -135,7 +136,7 @@ function robustLogin(props?: RobustLoginProps) {
       };
 
       return registerAndVerify(localProps);
-    }
+    },
   );
 }
 
@@ -155,7 +156,7 @@ declare global {
         email: string,
         password: string,
         firstName?: string,
-        lastName?: string
+        lastName?: string,
       );
       registerAndVerify(props: RegisterAndVerifyProps);
       robustLogin(props?: RobustLoginProps);

--- a/cypress-tests/cypress/support/commands/login.ts
+++ b/cypress-tests/cypress/support/commands/login.ts
@@ -1,3 +1,5 @@
+import { TIMEOUTS } from "../../../config";
+
 const renkuLogin = (credentials: { username: string; password: string }[]) => {
   cy.wrap(credentials, { log: false }).each(
     (credential: { password: string; username: string }) => {
@@ -102,7 +104,7 @@ function registerAndVerify(props: RegisterAndVerifyProps) {
   // it sometimes randomly responds with 401 and sometimes with 200 (as expected). This wait period seems to
   // allow Gitlab to "settle" after the login and properly recognize the token and respond with 200.
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(10_000);
+  cy.wait(TIMEOUTS.short);
   cy.request("ui-server/api/data/user").its("status").should("eq", 200);
   cy.request("ui-server/api/user").then((response) => {
     expect(response.status).to.eq(200);

--- a/cypress-tests/cypress/support/commands/projects.ts
+++ b/cypress-tests/cypress/support/commands/projects.ts
@@ -15,7 +15,7 @@ export function generatorProjectName(name: string): string {
 }
 
 export function fullProjectIdentifier(
-  identifier: ProjectIdentifier
+  identifier: ProjectIdentifier,
 ): Required<ProjectIdentifier> {
   return { namespace: Cypress.env("TEST_USERNAME"), ...identifier };
 }
@@ -26,7 +26,7 @@ export function projectUrlFromIdentifier(id: ProjectIdentifier) {
 
 export function projectPageLinkSelector(
   identifier: ProjectIdentifier,
-  subpage: string
+  subpage: string,
 ) {
   const subpageUrl = projectSubpageUrl(identifier, subpage);
   return `a[href='${subpageUrl}']`;
@@ -39,7 +39,7 @@ function getProjectPageLink(identifier: ProjectIdentifier, subpage: string) {
 
 function projectSubpageUrl(identifier: ProjectIdentifier, subpage: string) {
   const projectUrl = projectUrlFromIdentifier(
-    fullProjectIdentifier(identifier)
+    fullProjectIdentifier(identifier),
   );
   const subPath = subpage.startsWith("/") ? subpage : `/${subpage}`;
   return `${projectUrl}${subPath}`;
@@ -71,7 +71,11 @@ interface NewProjectProps extends ProjectIdentifier {
 function createProjectIfMissing(newProjectProps: NewProjectProps) {
   const namespace = newProjectProps.namespace ?? Cypress.env("TEST_USERNAME");
   const slug = encodeURIComponent(`${namespace}/${newProjectProps.name}`);
-  cy.request({failOnStatusCode: false, method: "GET", url: `/ui-server/api/projects/${slug}`}).then((response) => {
+  cy.request({
+    failOnStatusCode: false,
+    method: "GET",
+    url: `/ui-server/api/projects/${slug}`,
+  }).then((response) => {
     if (response.status != 200) {
       cy.visit("/projects/new");
       cy.getDataCy("field-group-title")
@@ -102,10 +106,10 @@ function createProjectIfMissing(newProjectProps: NewProjectProps) {
     }
     cy.url({ timeout: TIMEOUTS.vlong }).should(
       "contain",
-      newProjectProps.name.toLowerCase()
+      newProjectProps.name.toLowerCase(),
     );
     cy.get(`[data-cy="header-project"]`, { timeout: TIMEOUTS.vlong }).should(
-      "be.visible"
+      "be.visible",
     );
     cy.get("ul.nav-pills-underline").should("be.visible");
   });
@@ -122,7 +126,7 @@ function deleteProjectFromAPI(identifier: ProjectIdentifier) {
 
 function deleteProject(
   identifier: ProjectIdentifier,
-  navigateToProject = false
+  navigateToProject = false,
 ) {
   if (navigateToProject) cy.visitAndLoadProject(identifier);
 
@@ -135,7 +139,7 @@ function deleteProject(
 
   const slug = identifier.namespace + "/" + identifier.name;
   cy.intercept("DELETE", `/ui-server/api/kg/projects/${slug}`).as(
-    "deleteProject"
+    "deleteProject",
   );
 
   // Delete the project
@@ -162,7 +166,7 @@ function deleteProject(
 function forkProject(identifier: ProjectIdentifier, newName: string) {
   // open the Fork project modal
   let projectsInvoked = false;
-  cy.intercept("/ui-server/api/graphql", (req) => {
+  cy.intercept("/ui-server/api/graphql", () => {
     projectsInvoked = true;
   }).as("getProjects");
   cy.getDataCy("project-overview-content")
@@ -198,7 +202,7 @@ function forkProject(identifier: ProjectIdentifier, newName: string) {
 
   // check the new project is ready
   cy.intercept("ui-server/api/renku/cache.migrations_check*").as(
-    "getMigrationsCheck"
+    "getMigrationsCheck",
   );
   cy.wait("@getMigrationsCheck", { timeout: TIMEOUTS.long });
 
@@ -211,13 +215,13 @@ function forkProject(identifier: ProjectIdentifier, newName: string) {
 
 function visitAndLoadProject(
   identifier: ProjectIdentifier,
-  skipOutdated = false
+  skipOutdated = false,
 ) {
   // load project and wait for the relevant resources to be loaded
   cy.intercept("/ui-server/api/user").as("getUser");
   cy.intercept("/ui-server/api/renku/*/datasets.list*").as("getDatasets");
   let versionInvoked = false;
-  cy.intercept("/ui-server/api/renku/versions", (req) => {
+  cy.intercept("/ui-server/api/renku/versions", () => {
     versionInvoked = true;
   }).as("getVersion");
   cy.intercept("/ui-server/api/projects/*").as("getProject");
@@ -300,7 +304,7 @@ declare global {
       visitProjectPageLink(identifier: ProjectIdentifier, subpage: string);
       visitAndLoadProject(
         identifier: ProjectIdentifier,
-        skipOutdated?: boolean
+        skipOutdated?: boolean,
       );
       waitMetadataIndexing(justTriggered?: boolean, goToSettings?: boolean);
     }

--- a/cypress-tests/cypress/support/commands/sessions.ts
+++ b/cypress-tests/cypress/support/commands/sessions.ts
@@ -31,7 +31,7 @@ function waitForImageToBuild() {
 
 function stopAllSessionsForProject(
   identifier: ProjectIdentifier,
-  loadPage = true
+  loadPage = true,
 ) {
   const id = fullProjectIdentifier(identifier);
   cy.intercept("/ui-server/api/notebooks/servers*").as("getSessions");
@@ -104,15 +104,15 @@ function quickstartSession() {
     .contains("Starting Session")
     .should("exist");
   cy.get(".progress-box .progress-title", { timeout: TIMEOUTS.vlong }).should(
-    "not.exist"
+    "not.exist",
   );
   cy.getIframe("iframe#session-iframe").within(() => {
     cy.get(".jp-Launcher-content", { timeout: TIMEOUTS.long }).should(
-      "be.visible"
+      "be.visible",
     );
     cy.get(".jp-Launcher-section").should("be.visible");
     cy.get('.jp-LauncherCard[title="Start a new terminal session"]').should(
-      "be.visible"
+      "be.visible",
     );
   });
 }

--- a/cypress-tests/cypress/support/e2e.ts
+++ b/cypress-tests/cypress/support/e2e.ts
@@ -12,6 +12,6 @@ registerProjectCommands();
 registerSessionCommands();
 registerDatasetsCommands();
 
-Cypress.on("uncaught:exception", (err) => {
+Cypress.on("uncaught:exception", () => {
   return false;
 });

--- a/cypress-tests/cypress/support/types/group.types.ts
+++ b/cypress-tests/cypress/support/types/group.types.ts
@@ -1,0 +1,9 @@
+export type GroupIdentifier = {
+  id?: string;
+  slug: string;
+};
+
+export interface NewGroupBody extends GroupIdentifier {
+  description?: string;
+  name: string;
+}

--- a/cypress-tests/cypress/support/types/project.types.ts
+++ b/cypress-tests/cypress/support/types/project.types.ts
@@ -1,0 +1,10 @@
+export type ProjectIdentifierV2 = {
+  id?: string;
+  namespace?: string;
+  slug: string;
+};
+
+export interface NewProjectV2Body extends ProjectIdentifierV2 {
+  name: string;
+  visibility?: "public" | "private";
+}

--- a/cypress-tests/cypress/support/types/project.types.ts
+++ b/cypress-tests/cypress/support/types/project.types.ts
@@ -5,6 +5,7 @@ export type ProjectIdentifierV2 = {
 };
 
 export interface NewProjectV2Body extends ProjectIdentifierV2 {
+  description?: string;
   name: string;
   visibility?: "public" | "private";
 }

--- a/cypress-tests/cypress/support/types/user.types.ts
+++ b/cypress-tests/cypress/support/types/user.types.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  is_admin: boolean;
+}

--- a/cypress-tests/cypress/support/utils/group.utils.ts
+++ b/cypress-tests/cypress/support/utils/group.utils.ts
@@ -1,0 +1,23 @@
+export function getGroupFromAPI(
+  slug: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Cypress.Chainable<any | null> {
+  return cy
+    .request({
+      failOnStatusCode: false,
+      method: "GET",
+      url: `api/data/groups/${slug}`,
+    })
+    .as("getGroup");
+}
+
+/** Delete a project by using only the API. */
+export function deleteGroupFromAPI(slug: string) {
+  return cy
+    .request({
+      failOnStatusCode: false,
+      method: "DELETE",
+      url: `api/data/groups/${slug}`,
+    })
+    .as("deleteGroup");
+}

--- a/cypress-tests/cypress/support/utils/group.utils.ts
+++ b/cypress-tests/cypress/support/utils/group.utils.ts
@@ -1,3 +1,5 @@
+import { NewGroupBody } from "../types/group.types";
+
 export function getGroupFromAPI(
   slug: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,4 +22,20 @@ export function deleteGroupFromAPI(slug: string) {
       url: `api/data/groups/${slug}`,
     })
     .as("deleteGroup");
+}
+
+export function createGroupIfMissingAPI(newGrouptBody: NewGroupBody) {
+  return getGroupFromAPI(newGrouptBody.slug).then((response) => {
+    if (response.status != 200) {
+      return cy.request({
+        method: "POST",
+        url: "api/data/groups",
+        body: newGrouptBody,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+    return response.body;
+  });
 }

--- a/cypress-tests/cypress/support/utils/projectsV2.utils.ts
+++ b/cypress-tests/cypress/support/utils/projectsV2.utils.ts
@@ -1,13 +1,4 @@
-export type ProjectIdentifierV2 = {
-  slug: string;
-  namespace?: string;
-  id?: string;
-};
-
-export interface NewProjectV2Props extends ProjectIdentifierV2 {
-  visibility?: "public" | "private";
-  name: string;
-}
+import { NewProjectV2Body, ProjectIdentifierV2 } from "../types/project.types";
 
 /** Get the namespace of the logged in user from the API. */
 export function getUserNamespaceAPIV2(): Cypress.Chainable<string | null> {
@@ -44,14 +35,14 @@ export function getProjectByNamespaceAPIV2(
 
 /** Create a project (if the project is missing) by using only the API. */
 export function createProjectIfMissingAPIV2(
-  newProjectProps: NewProjectV2Props,
+  newProjectBody: NewProjectV2Body,
 ) {
-  return getProjectByNamespaceAPIV2(newProjectProps).then((response) => {
+  return getProjectByNamespaceAPIV2(newProjectBody).then((response) => {
     if (response.status != 200) {
       return cy.request({
         method: "POST",
         url: "api/data/projects",
-        body: newProjectProps,
+        body: newProjectBody,
         headers: {
           "Content-Type": "application/json",
         },

--- a/cypress-tests/cypress/support/utils/projectsV2.utils.ts
+++ b/cypress-tests/cypress/support/utils/projectsV2.utils.ts
@@ -34,9 +34,7 @@ export function getProjectByNamespaceAPIV2(
 }
 
 /** Create a project (if the project is missing) by using only the API. */
-export function createProjectIfMissingAPIV2(
-  newProjectBody: NewProjectV2Body,
-) {
+export function createProjectIfMissingAPIV2(newProjectBody: NewProjectV2Body) {
   return getProjectByNamespaceAPIV2(newProjectBody).then((response) => {
     if (response.status != 200) {
       return cy.request({

--- a/cypress-tests/cypress/support/utils/projectsV2.utils.ts
+++ b/cypress-tests/cypress/support/utils/projectsV2.utils.ts
@@ -11,38 +11,54 @@ export interface NewProjectV2Props extends ProjectIdentifierV2 {
 
 /** Get the namespace of the logged in user from the API. */
 export function getUserNamespaceAPIV2(): Cypress.Chainable<string | null> {
-  return cy.request({ failOnStatusCode: false, method: "GET", url: `api/data/namespaces?minimum_role=owner` })
+  return cy
+    .request({
+      failOnStatusCode: false,
+      method: "GET",
+      url: `api/data/namespaces?minimum_role=owner`,
+    })
     .then((response) => {
       if (response.status === 200) {
-        const userNamespace = response.body?.filter((namespace) => namespace.namespace_kind === "user");
-        return userNamespace && userNamespace.length > 0 ? userNamespace[0].slug : null;
+        const userNamespace = response.body?.filter(
+          (namespace) => namespace.namespace_kind === "user",
+        );
+        return userNamespace && userNamespace.length > 0
+          ? userNamespace[0].slug
+          : null;
       }
       return null;
     });
 }
 
 /** Get a project by using only the API. */
-export function getProjectByNamespaceAPIV2(newProjectProps: ProjectIdentifierV2): Cypress.Chainable<any | null> {
-  return cy.request({ failOnStatusCode: false, method: "GET", url: `api/data/namespaces/${newProjectProps.namespace}/projects/${newProjectProps.slug}` });
+export function getProjectByNamespaceAPIV2(
+  newProjectProps: ProjectIdentifierV2,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Cypress.Chainable<any | null> {
+  return cy.request({
+    failOnStatusCode: false,
+    method: "GET",
+    url: `api/data/namespaces/${newProjectProps.namespace}/projects/${newProjectProps.slug}`,
+  });
 }
 
 /** Create a project (if the project is missing) by using only the API. */
-export function createProjectIfMissingAPIV2(newProjectProps: NewProjectV2Props) {
-  return getProjectByNamespaceAPIV2(newProjectProps)
-    .then((response) => {
-      if (response.status != 200) {
-        return cy.request({
-          method: "POST",
-          url: "api/data/projects",
-          body: newProjectProps,
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        });
-      } else {
-        return response.body;
-      }
-    });
+export function createProjectIfMissingAPIV2(
+  newProjectProps: NewProjectV2Props,
+) {
+  return getProjectByNamespaceAPIV2(newProjectProps).then((response) => {
+    if (response.status != 200) {
+      return cy.request({
+        method: "POST",
+        url: "api/data/projects",
+        body: newProjectProps,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+    return response.body;
+  });
 }
 
 /** Delete a project by using only the API. */

--- a/cypress-tests/cypress/support/utils/search.utils.ts
+++ b/cypress-tests/cypress/support/utils/search.utils.ts
@@ -1,0 +1,40 @@
+import { TIMEOUTS } from "../../../config";
+
+type Matcher = "eq" | "gte";
+
+export function verifySearchIndexing(
+  query: string,
+  expectedItems: number, // ? mind there is a limit from paging!
+  {
+    maxAttempts = 5,
+    loopDelay = TIMEOUTS.shorter,
+    matcher = "eq",
+  }: { maxAttempts?: number; loopDelay?: number; matcher?: Matcher } = {},
+): Cypress.Chainable<boolean> {
+  cy.log(
+    `Verifying the search engine has indexed resources matching "${query}".`,
+  );
+
+  function attempt(tries: number): Cypress.Chainable<boolean> {
+    return cy.request(`/api/search/query?q=${query}`).then((response) => {
+      const success =
+        matcher === "eq"
+          ? response.body.items && response.body.items.length === expectedItems
+          : response.body.items && response.body.items.length >= expectedItems;
+      if (success) {
+        cy.log("Search indexing complete.");
+        return cy.wrap(true);
+      } else if (tries <= maxAttempts) {
+        cy.wait(loopDelay).then(() => attempt(tries + 1));
+      } else {
+        cy.log(
+          `Expected ${matcher === "gte" ? "at least " : ""}${expectedItems} items but found ${response.body.items ? response.body.items.length : "none"}.`,
+        );
+        throw new Error(
+          `Search indexing faild after ${maxAttempts} attempts every ${Math.floor(loopDelay / 1_000)} seconds.`,
+        );
+      }
+    });
+  }
+  return attempt(1);
+}

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -20,7 +20,10 @@
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "eslint": "^8.28.0",
-        "eslint-plugin-cypress": "^2.12.1"
+        "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-cypress": "^2.12.1",
+        "eslint-plugin-no-only-tests": "^3.3.0",
+        "prettier": "^3.4.2"
       }
     },
     "../../notebooks-cypress-tests": {
@@ -1244,6 +1247,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
+      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "build/bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-cypress": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
@@ -1263,6 +1279,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2541,6 +2567,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {
@@ -4079,6 +4121,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
+      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-plugin-cypress": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
@@ -4095,6 +4144,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.1.1",
@@ -5002,6 +5057,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true
     },
     "pretty-bytes": {

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -8,8 +8,8 @@
     "e2e:run": "cypress run --e2e --browser=chrome",
     "e2e:headless": "cypress run --e2e --browser=chrome --headless",
     "e2e:ci": "cypress run --e2e --browser=chrome --headless --spec",
-    "lint": "eslint . --ext .ts",
-    "parallel-run": "ts-node cypress/scripts/github-parallel-run.ts"
+    "lint": "eslint . --max-warnings=0",
+    "format": "prettier -w ."
   },
   "author": "Swiss Data Science Center",
   "dependencies": {
@@ -25,6 +25,9 @@
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.28.0",
-    "eslint-plugin-cypress": "^2.12.1"
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-no-only-tests": "^3.3.0",
+    "prettier": "^3.4.2"
   }
 }

--- a/cypress-tests/tsconfig.json
+++ b/cypress-tests/tsconfig.json
@@ -1,22 +1,11 @@
 {
-  "include": [
-    "cypress/**/*.ts",
-    "index.ts",
-    "cypress.config.ts",
-    "config.ts",
-  ],
+  "include": ["cypress/**/*.ts", "index.ts", "cypress.config.ts", "config.ts"],
   "module": "commonjs",
   "compilerOptions": {
     "target": "es5",
     "declaration": true,
-    "types": [
-      "cypress",
-      "node",
-    ],
-    "lib": [
-      "es5",
-      "dom"
-    ],
-    "outDir": "dist",
+    "types": ["cypress", "node"],
+    "lib": ["es5", "dom"],
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
This PR adds acceptance tests for Cypress 2.0.

:information_source: Mind that all commits have been reviewed separately, except the initial part to update how we lint/format (b620dea1cd28175d56f5d49bb53eec33793575fa) and the next commit formatting all the existing files.

/deploy

fix #3874
