### PR TITLE
fix: update csi rclone to 0.3.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,15 @@
 0.65.0
 ------
 
+NOTE to administrators: This Renku version includes an update of the CSI Rclone driver which 
+will result in the unmounting of cloud storage in all running user sessions.
 
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+**Bug Fixes**
+
+- **CSI Rclone**: Update liveness probe image version to fix restart loops.
 
 0.64.0
 ------

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.5"
+    version: "0.3.6"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"


### PR DESCRIPTION
Updates the CSI rclone helm chart to fix an issue with restarting liveness probes on the rclone daemonset pods.