### PR TITLE
feat: allow creation of global envs on first service start

### DIFF
--- a/helm-chart/renku/templates/data-service/configmap_environments.yaml
+++ b/helm-chart/renku/templates/data-service/configmap_environments.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.dataService.environments.seed -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "renku.fullname" . }}-initial-environments
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  initial.json: |
+    {{ .Values.dataService.environments.initialEnvironments | default list | toJson }}
+{{- end -}}

--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -122,6 +122,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: SESSIONS_INITIAL_ENVIRONMENTS_PATH
+              value: /etc/environments/initial.json              
             - name: SESSIONS_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -138,6 +140,11 @@ spec:
             - mountPath: "/secrets/publicKey"
               name: secret-service-public-key
               readOnly: true
+            {{- if .Values.dataService.environments.seed }}
+            - mountPath: "/etc/environments"
+              name: initial-environments
+              readOnly: true
+            {{- end }}
             {{- include "certificates.volumeMounts.system" . | nindent 12 }}
           livenessProbe:
             httpGet:
@@ -177,6 +184,11 @@ spec:
         - name: server-options
           configMap:
             name: {{ template "renku.fullname" . }}-server-options
+        {{- if .Values.dataService.environments.seed }}
+        - name: initial-environments
+          configMap:
+            name: {{ template "renku.fullname" . }}-initial-environments
+        {{- end }}
         - name: encryption-key
           secret:
             secretName: {{ template "renku.fullname" . }}-secrets-storage

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1493,6 +1493,57 @@ dataService:
   affinity: {}
   # This defines the maximum number of pinned projects in user preferences
   maxPinnedProjects: 5
+  # Settings for global session environments
+  environments:
+  # If this is set, default global session environments will be created on first start
+    seed: false
+    # Environments to create
+    initialEnvironments:
+    - name: Python/Jupyter
+      description: Standard python environment
+      container_image: renku/renkulab-py:3.10-0.23.0
+      default_url: /lab
+      working_directory: /home/jovyan/work
+      mount_directory: /home/jovyan/work
+      port: 8888
+      uid: 1000
+      gid: 100
+      command:
+        - sh
+        - -c
+      args:
+        - >
+          /entrypoint.sh jupyter server --ServerApp.ip=0.0.0.0 --ServerApp.port=8888 --ServerApp.base_url=$RENKU_BASE_URL_PATH --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_remote_access=true --ContentsManager.allow_hidden=true --ServerApp.allow_origin=* --ServerApp.root_dir="/home/jovyan/work"
+    - name: R/Rstudio
+      description: Standard R environment
+      container_image: renku/renkulab-r:4.3.1-0.23.0
+      default_url: /rstudio
+      working_directory: /home/jovyan/work
+      mount_directory: /home/jovyan/work
+      port: 8888
+      uid: 1000
+      gid: 100
+      command:
+        - sh
+        - -c
+      args:
+        - >
+          /entrypoint.sh jupyter server --ServerApp.ip=0.0.0.0 --ServerApp.port=8888 --ServerApp.base_url=$RENKU_BASE_URL_PATH --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_remote_access=true --ContentsManager.allow_hidden=true --ServerApp.allow_origin=* --ServerApp.root_dir="/home/jovyan/work"
+    - name: Code server
+      description: Python environment with VSCode-like frontend
+      container_image: registry.renkulab.io/rok.roskar/vscode-example:f7b1a71
+      default_url: /vscode
+      working_directory: /home/jovyan/work
+      mount_directory: /home/jovyan/work
+      port: 8888
+      uid: 1000
+      gid: 100
+      command:
+        - sh
+        - -c
+      args:
+        - >
+          /entrypoint.sh jupyter server --ServerApp.ip=0.0.0.0 --ServerApp.port=8888 --ServerApp.base_url=$RENKU_BASE_URL_PATH --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_remote_access=true --ContentsManager.allow_hidden=true --ServerApp.allow_origin=* --ServerApp.root_dir="/home/jovyan/work"
   # Trusted proxies configuration
   # See: https://sanic.dev/en/guide/advanced/proxy-headers.md
   trustedProxies:


### PR DESCRIPTION
note: we want to set `dataService.environments.seed` to `true` for dev deployments for this to do something.

needs https://github.com/SwissDataScienceCenter/renku-data-services/pull/637