### PR TITLE
test: fix projectBasics and groupBasics

### DIFF
--- a/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/groupBasics.cy.ts
@@ -9,26 +9,35 @@ import {
 
 const sessionId = ["groupBasics", getRandomString()];
 
-beforeEach(() => {
-  // Restore the session (login)
-  cy.session(
-    sessionId,
-    () => {
-      cy.robustLogin();
-    },
-    validateLoginV2,
-  );
-});
-
 describe("Group - create, edit and delete", () => {
   // Define some group details
-  const groupNameRandomPart = getRandomString();
-  const groupName = `group/$test-${groupNameRandomPart}`;
-  const groupSlug = `group-test-${groupNameRandomPart}`;
   const groupDescription = "This is a test group from Cypress";
+  let groupNameRandomPart;
+  let groupName;
+  let groupSlug;
+
+  function resetRequiredResources() {
+    groupNameRandomPart = getRandomString();
+    groupName = `group/$test-${groupNameRandomPart}`;
+    groupSlug = `group-test-${groupNameRandomPart}`;
+  }
+
+  beforeEach(() => {
+    // Restore the session (login)
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Define new group details to avoid conflicts on retries
+    resetRequiredResources();
+  });
 
   // Cleanup the group after the test -- useful on failure
-  after(() => {
+  afterEach(() => {
     getGroupFromAPI(groupSlug).then((response) => {
       if (response.status === 200) {
         deleteGroupFromAPI(groupSlug);

--- a/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
+++ b/cypress-tests/cypress/e2e/v2/projectBasics.cy.ts
@@ -12,31 +12,41 @@ import {
 
 const sessionId = ["projectBasics", getRandomString()];
 
-beforeEach(() => {
-  // Restore the session (login)
-  cy.session(
-    sessionId,
-    () => {
-      cy.robustLogin();
-    },
-    validateLoginV2,
-  );
-});
-
 describe("Project - create, edit and delete", () => {
   // Define some project details
-  const projectNameRandomPart = getRandomString();
-  const projectName = `project/$test-${projectNameRandomPart}`;
-  const projectPath = `project-test-${projectNameRandomPart}`;
   const projectDescription = "This is a test project from Cypress";
-  const projectIdentifier: ProjectIdentifierV2 = {
-    slug: projectPath,
-    id: null,
-    namespace: null,
-  };
+  let projectNameRandomPart: string;
+  let projectName;
+  let projectPath;
+  let projectIdentifier: ProjectIdentifierV2;
+
+  function resetRequiredResources() {
+    projectNameRandomPart = getRandomString();
+    projectName = `project/$test-${projectNameRandomPart}`;
+    projectPath = `project-test-${projectNameRandomPart}`;
+    projectIdentifier = {
+      slug: projectPath,
+      id: null,
+      namespace: null,
+    };
+  }
+
+  beforeEach(() => {
+    // Restore the session (login)
+    cy.session(
+      sessionId,
+      () => {
+        cy.robustLogin();
+      },
+      validateLoginV2,
+    );
+
+    // Define new project details to avoid conflicts on retries
+    resetRequiredResources();
+  });
 
   // Cleanup the project after the test -- useful on failure
-  after(() => {
+  afterEach(() => {
     getProjectByNamespaceAPIV2(projectIdentifier).then((response) => {
       if (response.status === 200) {
         projectIdentifier.id = response.body.id;


### PR DESCRIPTION
This fixes the projectBasics and groupBasics tests logic on projects/groups creation and deletion to avoid possible collisions when tests fail and re-run.

/deploy renku-ui=lorenzo/cypress-renku-2.0-data-cy