### PR TITLE
feat: enable migrate project with private images from the Renku Gitlab registry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ User-Facing Changes
 
 - **UI**: Data connectors can be owned by projects.
 - **Data services**: Private images from the Renku Gitlab registry can be used in V2 sessions.
+- **UI**: Projects with private images from the Renku Gitlab registry can now be migrated from Renku v1 to Renku 2.0 (`#3603 <https://github.com/SwissDataScienceCenter/renku-ui/pull/3603>`__)
 
 **🐞 Bug Fixes**
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -528,7 +528,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "3.51.0"
+      tag: "3.52.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -717,7 +717,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "3.51.0"
+      tag: "3.52.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""


### PR DESCRIPTION
Enable migrate project with private images from the Renku Gitlab registry  from Renku V1 to Renku 2.0


/deploy #legacy