### PR TITLE
fix: Increase default resources for Search containers.

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1259,10 +1259,10 @@ search:
       port: 80
     resources:
       limits:
-        memory: 400Mi
+        memory: 450Mi
       requests:
         cpu: 50m
-        memory: 400Mi
+        memory: 450Mi
     jvmXmx: 256M
   searchProvision:
     replicas: 1
@@ -1275,10 +1275,10 @@ search:
       port: 8081
     resources:
       limits:
-        memory: 800Mi
+        memory: 900Mi
       requests:
         cpu: 100m
-        memory: 800Mi
+        memory: 900Mi
     jvmXmx: 256M
 ## Configuration for renku-graph services
 graph:


### PR DESCRIPTION
I am opening this to target `master` as its something needed by CI
deployments mostly.
Let me know if I should rather target the release, but it should be
merged sooner rather than later.
