### PR TITLE
feat: support published datasets with global data connectors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ User-Facing Changes
 **🌟 New Features**
 
 - **UI**: Datasets published on platforms such as Zenodo or Dataverse can be linked to
-a project by using their reference DOI (Digital Object Identifier).
+  a project by using their reference DOI (Digital Object Identifier).
 - **UI**: Support declaring environment variables on session launchers.
 
 **✨ Improvements**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,21 @@
 0.68.0
 ------
 
+TODO: changelog for global data connectors.
+
 User-Facing Changes
 ~~~~~~~~~~~~~~~~~~~
+
+**🌟 New Features**
+
+- **UI**: Datasets published on platforms such as Zenodo or Dataverse can be linked to
+a project by using their reference DOI (Digital Object Identifier).
+- **UI**: Support declaring environment variables on session launchers.
 
 **🐞 Bug Fixes**
 
 - **Core Service**: Fix a bug where removing activities wouldn't actually remove them.
+- **Data services**: Fix an issue where conflicting mount points would prevent sessions from starting.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -21,8 +30,9 @@ Individual Components
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `renku-data-services 0.39.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.39.0>`_
-- `renku-python 2.9.4 <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/v2.9.4>`_
+- `renku-data-services 0.40.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.40.0>`_
 - `renku-python 2.9.3 <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/v2.9.3>`_
+- `renku-python 2.9.4 <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/v2.9.4>`_
 
 0.67.2
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,15 @@ User-Facing Changes
 a project by using their reference DOI (Digital Object Identifier).
 - **UI**: Support declaring environment variables on session launchers.
 
+**✨ Improvements**
+
+- **UI**: Session UX improvements in Renku 2.0.
+
 **🐞 Bug Fixes**
 
 - **Core Service**: Fix a bug where removing activities wouldn't actually remove them.
 - **Data services**: Fix an issue where conflicting mount points would prevent sessions from starting.
+- **UI**: Fix an issue where pausing or resuming a session would crash the whole tab in Firefox.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.8-exp-doi-proxy"
+    version: "0.4.0"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.7"
+    version: "0.3.8-exp-doi-zenodo"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.3.8-exp-doi-zenodo"
+    version: "0.3.8-exp-doi-proxy"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -536,7 +536,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "3.53.1"
+      tag: "3.54.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -725,7 +725,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "3.53.1"
+      tag: "3.54.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1516,21 +1516,21 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.39.0"
+    tag: "0.40.0"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.39.0"
+      tag: "0.40.0"
       pullPolicy: IfNotPresent
     total:
       resources: {}
   k8sWatcher:
     image:
       repository: renku/data-service-k8s-watcher
-      tag: "0.39.0"
+      tag: "0.40.0"
       pullPolicy: IfNotPresent
     resources: {}
   service:
@@ -1609,7 +1609,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.39.0"
+    tag: "0.40.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
Add support for using published datasets hosted on InvenioRDM (including Zenodo) and Dataverse as global data connectors.

Global data connectors do not belong to any namespace and can be modified by admins only. As a special case, data connectors of type DOI can be added by logged in users.

Contents:
* https://github.com/SwissDataScienceCenter/renku-data-services/pull/823
* https://github.com/SwissDataScienceCenter/renku-ui/pull/3656
* https://github.com/SwissDataScienceCenter/rclone/pull/7
* https://github.com/SwissDataScienceCenter/csi-rclone/pull/53

Demo: https://ci-renku-3971.dev.renku.ch/v2/projects/flora.thiebaut/demo-project

/deploy extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-doi-zenodo,csi-rclone.storageClassName=csi-rclone-doi-zenodo,global.rcloneStorageClass=csi-rclone-doi-zenodo,amalthea-sessions.rcloneStorageClass=csi-rclone-doi-zenodo-secret-annotation,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=renku.io/node-purpose,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=user