### PR TITLE
feat: Add data tasks deployment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Internal Changes
 
 - **Helm chart**: Update the Keycloak theme image to use non-root user by default.
 - **Data services**: Added k8s cache service that caches sessions in the data services database.
+- **Data services**: Added data tasks deployment for running basic tasks in the scope of data services.
 - **Admin tools**: Add Harbor initialization script to setup a registry for RenkuLab v2.
 
 Individual Components

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Individual Components
 
 - `renku-data-services 0.39.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.39.0>`_
 - `renku-data-services 0.40.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.40.0>`_
+- `renku-data-services 0.41.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.41.0>`_
 - `renku-python 2.9.3 <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/v2.9.3>`_
 - `renku-python 2.9.4 <https://github.com/SwissDataScienceCenter/renku-python/releases/tag/v2.9.4>`_
 

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "renku.fullname" . }}-data-tasks
+  labels:
+    app: renku-data-tasks
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    {{- toYaml .Values.dataService.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      app: renku-data-tasks
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: renku-data-tasks
+        release: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.dataService.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.global.debug }}
+      initContainers:
+        {{- include "certificates.initContainer" . | nindent 8 }}
+      containers:
+        - name: data-tasks
+          image: "{{ .Values.dataService.dataTasks.image.repository }}:{{ .Values.dataService.dataTasks.image.tag }}"
+          imagePullPolicy: {{ .Values.dataService.dataTasks.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: VERSION
+              value: {{ .Values.dataService.image.tag | quote }}
+            - name: DB_HOST
+              value: {{ template "postgresql.fullname" . }}
+            - name: DB_USER
+              value: {{ .Values.global.db.common.username }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.db.common.passwordSecretName }}
+                  key: password
+            - name: SOLR_URL
+              value: "http://{{ template "solr.fullname" . }}:{{ .Values.global.solr.port }}"
+            - name: SOLR_CORE
+              value: "renku-data"
+            - name: SOLR_USER
+              value: {{ default "admin" .Values.solr.auth.adminUsername | quote }}
+            - name: SOLR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "solr.fullname" . }}
+                  key: solr-password
+            - name: AUTHZ_DB_HOST
+              value: {{ include "renku.fullname" . }}-authz
+            - name: AUTHZ_DB_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "renku.fullname" . }}-authz
+                  key: SPICEDB_GRPC_PRESHARED_KEY
+            - name: AUTHZ_DB_GRPC_PORT
+              value: "50051"
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            {{- include "certificates.env.python" . | nindent 12 }}
+          volumeMounts:
+            {{- include "certificates.volumeMounts.system" . | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/cache_ready
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            {{ toYaml .Values.dataService.dataTasks.resources | nindent 12 }}
+    {{- with .Values.dataService.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.dataService.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.dataService.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        {{- include "certificates.volumes" . | nindent 8 }}
+      serviceAccountName: {{ template "renku.fullname" . }}-data-tasks

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -83,22 +83,9 @@ spec:
                   key: SPICEDB_GRPC_PRESHARED_KEY
             - name: AUTHZ_DB_GRPC_PORT
               value: "50051"
-            - name: KUBERNETES_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
             {{- include "certificates.env.python" . | nindent 12 }}
           volumeMounts:
             {{- include "certificates.volumeMounts.system" . | nindent 12 }}
-          livenessProbe:
-            exec:
-              command:
-                - cat
-                - /tmp/cache_ready
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 6
           resources:
             {{ toYaml .Values.dataService.dataTasks.resources | nindent 12 }}
     {{- with .Values.dataService.nodeSelector }}
@@ -115,4 +102,3 @@ spec:
     {{- end }}
       volumes:
         {{- include "certificates.volumes" . | nindent 8 }}
-      serviceAccountName: {{ template "renku.fullname" . }}-data-service

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -100,4 +100,4 @@ spec:
     {{- end }}
       volumes:
         {{- include "certificates.volumes" . | nindent 8 }}
-      serviceAccountName: {{ template "renku.fullname" . }}-data-tasks
+      serviceAccountName: {{ template "renku.fullname" . }}-data-service

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -37,6 +37,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:
+            - name: TCP_PORT
+              value: "8001"
+            - name: TCP_HOST
+              value: "0.0.0.0"
             - name: VERSION
               value: {{ .Values.dataService.image.tag | quote }}
             - name: DB_HOST
@@ -86,6 +90,12 @@ spec:
             {{- include "certificates.env.python" . | nindent 12 }}
           volumeMounts:
             {{- include "certificates.volumeMounts.system" . | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
           resources:
             {{ toYaml .Values.dataService.dataTasks.resources | nindent 12 }}
     {{- with .Values.dataService.nodeSelector }}

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: renku-data-tasks
         release: {{ .Release.Name }}
+        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
       annotations:
       {{- with .Values.dataService.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -48,6 +48,21 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.db.common.passwordSecretName }}
                   key: password
+            - name: REDIS_HOST
+              value: {{ .Values.global.redis.host | quote }}
+            - name: REDIS_PORT
+              value: {{ .Values.global.redis.port | quote }}
+            - name: REDIS_DATABASE
+              value: {{ .Values.global.redis.dbIndex.events| quote }}
+            - name: REDIS_IS_SENTINEL
+              value: {{ .Values.global.redis.sentinel.enabled | quote }}
+            - name: REDIS_MASTER_SET
+              value: {{ .Values.global.redis.sentinel.masterSet | quote }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: {{ .Values.global.redis.existingSecretPasswordKey }}
             - name: SOLR_URL
               value: "http://{{ template "solr.fullname" . }}:{{ .Values.global.solr.port }}"
             - name: SOLR_CORE

--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -664,6 +664,10 @@ spec:
               release: {{ .Release.Name }}
         - podSelector:
             matchLabels:
+              app: renku-data-tasks
+              release: {{ .Release.Name }}
+        - podSelector:
+            matchLabels:
               app: search-api
         - podSelector:
             matchLabels:

--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -76,6 +76,12 @@ spec:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
         - podSelector:
             matchLabels:
+              app: renku-data-tasks
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - podSelector:
+            matchLabels:
               app: keycloak-sync
           namespaceSelector:
             matchLabels:
@@ -619,6 +625,10 @@ spec:
         - podSelector:
             matchLabels:
               app: renku-data-service
+              release: {{ .Release.Name }}
+        - podSelector:
+            matchLabels:
+              app: renku-data-tasks
               release: {{ .Release.Name }}
         - podSelector:
             matchLabels:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1516,27 +1516,27 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.40.0"
+    tag: "0.41.0"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.40.0"
+      tag: "0.41.0"
       pullPolicy: IfNotPresent
     total:
       resources: {}
   k8sWatcher:
     image:
       repository: renku/data-service-k8s-watcher
-      tag: "0.40.0"
+      tag: "0.41.0"
       pullPolicy: IfNotPresent
     resources: {}
   dataTasks:
     image:
       repository: renku/data-service-data-tasks
-      tag: "0.39.0"
+      tag: "0.41.0"
       pullPolicy: IfNotPresent
     resources: {}
   service:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1533,6 +1533,12 @@ dataService:
       tag: "0.40.0"
       pullPolicy: IfNotPresent
     resources: {}
+  dataTasks:
+    image:
+      repository: renku/data-service-data-tasks
+      tag: "0.39.0"
+      pullPolicy: IfNotPresent
+    resources: {}
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
Adds configuration for the data tasks deployment. This runs background tasks in the scope of data services in one python runtime.

/deploy
