### PR TITLE
feat: bump csi-rclone and renku-data-services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,27 @@
 0.70.0
 ------
 
+User-Facing Changes
+~~~~~~~~~~~~~~~~~~~
+
+**🐞 Bug Fixes**
+
+- **Data services**: Fix an issue with prevented sessions with private images from Renku Legacy (v1) to be resumed.
+- **Data services**: Fix an issue with data connectors not being correctly removed from Renku when their owning group was deleted.
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+- **Data services**: Update rclone to v1.69.2+renku-1
+- **Data services**: Fix an issue with namespaces in search
+- **CSI Rclone**: Update rclone to v1.69.2+renku-1
+
+Individual Components
+~~~~~~~~~~~~~~~~~~~~~
+
+- `renku-data-services 0.46.0 <https://github.com/SwissDataScienceCenter/renku-data-services/releases/tag/v0.46.0>`_
+- `csi-rclone 0.4.1 <https://github.com/SwissDataScienceCenter/csi-rclone/releases/tag/v0.4.1>`_
+
 Notes for Renku Administrators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -127,7 +148,13 @@ Individual Components
 - `amalthea-sessions 0.18.2 <https://github.com/SwissDataScienceCenter/amalthea/releases/tag/0.18.2>`_
 - `renku-ui 3.54.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.54.0>`_
 - `renku-ui 3.55.0 <https://github.com/SwissDataScienceCenter/renku-ui/releases/tag/3.55.0>`_
+- `csi-rclone 0.4.0 <https://github.com/SwissDataScienceCenter/csi-rclone/releases/tag/v0.4.0>`_
 
+Notes for Renku Administrators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This Renku version includes an update of the CSI Rclone driver which
+will result in the unmounting of cloud storage in all running user sessions.
 
 0.67.2
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
 .. _changelog:
 
+0.70.0
+------
+
+Notes for Renku Administrators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This Renku version includes an update of the CSI Rclone driver which
+will result in the unmounting of cloud storage in all running user sessions.
+
 0.69.0
 ------
 

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.4.0"
+    version: "0.4.1"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1516,27 +1516,27 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.45.0"
+    tag: "0.46.0"
     pullPolicy: IfNotPresent
   backgroundJobs:
     events:
       resources: {}
     image:
       repository: renku/data-service-background-jobs
-      tag: "0.45.0"
+      tag: "0.46.0"
       pullPolicy: IfNotPresent
     total:
       resources: {}
   k8sWatcher:
     image:
       repository: renku/data-service-k8s-watcher
-      tag: "0.45.0"
+      tag: "0.46.0"
       pullPolicy: IfNotPresent
     resources: {}
   dataTasks:
     image:
       repository: renku/data-service-data-tasks
-      tag: "0.45.0"
+      tag: "0.46.0"
       pullPolicy: IfNotPresent
     resources: {}
   service:
@@ -1622,7 +1622,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.45.0"
+    tag: "0.46.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
/deploy extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-doi-zenodo,csi-rclone.storageClassName=csi-rclone-doi-zenodo,global.rcloneStorageClass=csi-rclone-doi-zenodo,amalthea-sessions.rcloneStorageClass=csi-rclone-doi-zenodo-secret-annotation,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=renku.io/node-purpose,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=user,