### PR TITLE
chore: use github releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 *               @SwissDataScienceCenter/renku-devs
 /helm-chart/    @SwissDataScienceCenter/kartografen
 /helm-chart/renku/requirements.yaml     @SwissDataScienceCenter/YAT
-/CHANGELOG.rst  @SwissDataScienceCenter/renku-product-management

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+template: |
+  # $RESOLVED_VERSION
+  Please create a discussion page in Notion and add a link to it here.
+
+  The changelog contents should be added to this Notion page.
+
+  When the release is ready copy the changelog contents from the Notion page into this page,
+  and finally publish the release.

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -28,18 +28,10 @@ jobs:
           git config push.autoSetupRemote true
       - name: Create Branch
         run: git checkout -b "release-${{ github.event.inputs.version }}"
-      - name: Update changelog
-        id: changelog
-        shell: bash
-        run: |
-          VERSION_LENGTH=$(echo -n "${{ github.event.inputs.version }}" | wc -m)
-          DELIMITER=$(printf "%.0s-" $(seq $VERSION_LENGTH))
-          sed -i -E "s/^(.*.. _changelog:)/\1\n\n${{ github.event.inputs.version }}\n$DELIMITER\n\n/" CHANGELOG.rst
-          head -n 10 CHANGELOG.rst
       - name: Commit changes
         run: |
           git add CHANGELOG.rst
-          git commit -m "chore: create release ${{ github.event.inputs.version }}"
+          git commit -m "chore: create release ${{ github.event.inputs.version }}" --allow-empty
           git push
       - name: Create Pull Request
         uses: actions/github-script@v7

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,4 +1,4 @@
-name: "Create Release PR"
+name: "Create Release PR and draft Github release."
 on:
   workflow_dispatch:
     inputs:
@@ -60,4 +60,12 @@ jobs:
               issue_number: result.data.number,
               labels: ['release']
             });
-
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: "${{ github.event.inputs.version }}"
+          name: "${{ github.event.inputs.version }}"
+          version: "${{ github.event.inputs.version }}"
+          disable-autolabeler: true
+          disable-releaser: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 .. _changelog:
 
-NOTE: Starting with version ``0.70.0`` release changelogs have moved to the `GitHub Release page <https://github.com/SwissDataScienceCenter/renku/releases>`_
+NOTE: Starting with version ``0.70.0`` release changelog was moved to the `GitHub Release page <https://github.com/SwissDataScienceCenter/renku/releases>`_
 
 0.69.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 .. _changelog:
 
+NOTE: Starting with version ``0.70.0`` release changelogs have moved to the `GitHub Release page <https://github.com/SwissDataScienceCenter/renku/releases>`_
+
 0.69.0
 ------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -34,6 +34,7 @@ Calamus
 cgroup
 Champak
 changelog
+changelogs
 chartpress
 Chartpress
 checksum


### PR DESCRIPTION
The draft release is here: https://github.com/SwissDataScienceCenter/renku/releases/tag/untagged-afcb7c821b481c8f4c4b

The discussion is here: https://www.notion.so/renku/Release-0-70-0-1eb0df2efafc8018a2d3c73101a3f345?pvs=4