### PR TITLE
fix: upgrade amalthea to 0.18.3

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -17,10 +17,10 @@ dependencies:
     alias: jena
   - name: amalthea
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.18.2"
+    version: "0.18.3"
   - name: amalthea-sessions
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.18.2"
+    version: "0.18.3"
   - name: dlf-chart
     repository: "https://swissdatasciencecenter.github.io/datashim/"
     version: "0.3.9-renku-2"


### PR DESCRIPTION
Contains package upgrades and a rollback to some python packages that were previously updated and causing restarts.