### PR TITLE
feat: bump csi-rclone

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.4.1"
+    version: "0.4.2"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://registry-1.docker.io/bitnamicharts"


### PR DESCRIPTION
Support for rclone v.169.3+renku-1 which fixes an issue with Zenodo datasets which have virtual subfolders.

Note: `renku-data-services` is NOT updated, but the patch version mismatch should not cause issues.

/deploy #legacy extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-doi-zenodo,csi-rclone.storageClassName=csi-rclone-doi-zenodo,global.rcloneStorageClass=csi-rclone-doi-zenodo,amalthea-sessions.rcloneStorageClass=csi-rclone-doi-zenodo-secret-annotation,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=renku.io/node-purpose,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=user