### PR TITLE
fix: bump amalthea to 0.19.1

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -18,10 +18,10 @@ dependencies:
     condition: enableV1Services
   - name: amalthea
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.19.0"
+    version: "0.19.1"
   - name: amalthea-sessions
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.19.0"
+    version: "0.19.1"
   - name: dlf-chart
     repository: "https://swissdatasciencecenter.github.io/datashim/"
     version: "0.3.9-renku-2"


### PR DESCRIPTION
Amalthea 0.19.1 fixes a bug where anonymous sessions could not start because of an invalid session resource spec (duplicated authproxy key in spec).

/deploy