### PR TITLE
refactor: harmonize security context handling

### DIFF
--- a/helm-chart/renku/templates/_certificates-init-container.tpl
+++ b/helm-chart/renku/templates/_certificates-init-container.tpl
@@ -3,10 +3,7 @@
 - name: init-certificates
   image: "{{ .Values.global.certificates.image.repository }}:{{ .Values.global.certificates.image.tag }}"
   securityContext:
-    allowPrivilegeEscalation: false
-    runAsUser: 1000
-    runAsGroup: 1000
-    runAsNonRoot: true
+    {{- toYaml .Values.securityContext | nindent 4 }}
   volumeMounts:
     - name: etc-ssl-certs
       mountPath: /etc/ssl/certs/

--- a/helm-chart/renku/templates/authz/deployment.yaml
+++ b/helm-chart/renku/templates/authz/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           # and the database migration will not read the db connection uri string from an env variable
           image: "{{ .Values.authz.image.repository }}:{{ .Values.authz.image.tag }}-debug"
           imagePullPolicy: {{ .Values.authz.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: "SPICEDB_DATASTORE_CONN_URI"
               valueFrom:

--- a/helm-chart/renku/templates/setup-job-authz-db.yaml
+++ b/helm-chart/renku/templates/setup-job-authz-db.yaml
@@ -23,10 +23,7 @@ spec:
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"
           args: [ "authz_db_init.py" ]
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: DB_HOST
               value: {{ template "postgresql.fullname" . }}

--- a/helm-chart/renku/templates/setup-job-authz-db.yaml
+++ b/helm-chart/renku/templates/setup-job-authz-db.yaml
@@ -18,6 +18,8 @@ spec:
         chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: initialize-postgres-authz
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"

--- a/helm-chart/renku/templates/setup-job-keycloak-db.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-db.yaml
@@ -19,6 +19,8 @@ spec:
         chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: initialize-postgres-keycloak
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"

--- a/helm-chart/renku/templates/setup-job-keycloak-db.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-db.yaml
@@ -24,10 +24,7 @@ spec:
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"
           args: [ "keycloak_db_init.py" ]
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: DB_HOST
               value: {{ template "postgresql.fullname" . }}

--- a/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
@@ -20,6 +20,8 @@ spec:
         chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:

--- a/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
@@ -26,10 +26,7 @@ spec:
         - name: init-keycloak
           image: "{{ .Values.keycloakx.initRealm.image.repository }}:{{ .Values.keycloakx.initRealm.image.tag }}"
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["python"]
           args: [
             "/app/init-realm.py",

--- a/helm-chart/renku/templates/setup-job-platform-init.yaml
+++ b/helm-chart/renku/templates/setup-job-platform-init.yaml
@@ -20,6 +20,8 @@ spec:
         chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: initialize-platform
           image: "{{ .Values.platformInit.image.repository }}:{{ .Values.platformInit.image.tag }}"

--- a/helm-chart/renku/templates/setup-job-platform-init.yaml
+++ b/helm-chart/renku/templates/setup-job-platform-init.yaml
@@ -25,10 +25,7 @@ spec:
           image: "{{ .Values.platformInit.image.repository }}:{{ .Values.platformInit.image.tag }}"
           args: [ "platform-init.py" ]
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: K8S_NAMESPACE
               value: {{ .Release.Namespace }}

--- a/helm-chart/renku/templates/setup-job-renku-dbs.yaml
+++ b/helm-chart/renku/templates/setup-job-renku-dbs.yaml
@@ -23,10 +23,7 @@ spec:
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"
           args: [ "renku_db_init.py" ]
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: DB_HOST
               value: {{ template "postgresql.fullname" . }}

--- a/helm-chart/renku/templates/setup-job-renku-dbs.yaml
+++ b/helm-chart/renku/templates/setup-job-renku-dbs.yaml
@@ -18,6 +18,8 @@ spec:
         chart: {{ template "renku.chart" . }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: initialize-postgres-renku
           image: "{{ .Values.initDb.image.repository }}:{{ .Values.initDb.image.tag }}"

--- a/helm-chart/renku/templates/tests/test-renku.yaml
+++ b/helm-chart/renku/templates/tests/test-renku.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   volumes:
   - name: dshm
     emptyDir:
@@ -15,6 +17,8 @@ spec:
   containers:
   - name: sbt
     image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
     env:
       - name: RENKU_TEST_URL
         value: '{{ template "renku.http" . }}://{{ .Values.global.renku.domain }}'

--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -113,7 +113,7 @@ spec:
           resources:
 {{ toYaml .Values.ui.client.resources | indent 12 }}
           securityContext:
-            {{- toYaml .Values.ui.client.securityContext | nindent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
     {{- with .Values.ui.client.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -127,7 +127,7 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       securityContext:
-        {{- toYaml .Values.ui.client.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.ui.client.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.ui.client.image.pullSecrets }}

--- a/helm-chart/renku/templates/ui/ui-server-deployment.yaml
+++ b/helm-chart/renku/templates/ui/ui-server-deployment.yaml
@@ -29,14 +29,14 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       securityContext:
-        {{- toYaml .Values.ui.server.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.global.debug }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.ui.server.securityContext | nindent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.ui.server.image.repository }}:{{ .Values.ui.server.image.tag }}"
           imagePullPolicy: {{ .Values.ui.server.image.pullPolicy }}
           ports:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -338,9 +338,7 @@ keycloakx:
             - ALL
     - name: init-certificates
       securityContext:
-        allowPrivilegeEscalation: false
-        runAsGroup: 65534
-        runAsUser: 65534
+        {{- toYaml .Values.securityContext | nindent 8 }}
       image: "registry.access.redhat.com/ubi8/ubi:8.4"
       command: ["sh", "-c"]
       args: ["mkdir -p /etc/pki/ca-trust/extracted/openssl/ /etc/pki/ca-trust/extracted/pem/ /etc/pki/ca-trust/extracted/java/ /etc/pki/ca-trust/extracted/edk2 && update-ca-trust"]

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -562,11 +562,6 @@ ui:
     nodeSelector: {}
     tolerations: []
     affinity: {}
-    podSecurityContext: {}
-    securityContext:
-      runAsUser: 1000
-      runAsNonRoot: true
-      allowPrivilegeEscalation: false
     # This defines the message displayed on the home page of logged in users.
     dashboardMessage:
       enabled: false
@@ -733,12 +728,6 @@ ui:
       # The name of the service account to use.
       # If not set and create is true, a name is generated using the fullname template
       name: ""
-    podSecurityContext: {}
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      runAsNonRoot: true
-      allowPrivilegeEscalation: false
     service:
       type: ClusterIP
       port: 80
@@ -1601,6 +1590,9 @@ securityContext:
   runAsGroup: 1000
   runAsNonRoot: true
   allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -11,6 +11,25 @@ Please follow this convention when adding a new row
 
 This will result in 2 fewer deployments in your cluster. If the values are left in the values file they will be ignored. Therefore this does not require immediate action by administrators, it is just good practice to remove deprecated sections that you may have in your values file.
 
+* DELETE `ui.client.podSecurityContext`, replaced by `podSecurityContext`
+* DELETE `ui.client.securityContext`, replaced by `securityContext`
+* DELETE `ui.server.podSecurityContext`, replaced by `podSecurityContext`
+* DELETE `ui.server.securityContext`, replaced by `securityContext`
+* EDIT `securityContext` added "drop all capabilities" to the default value
+
+There are also several other components that were using hardcoded security contexts that 
+now are using the centralized `securityContext` and `podSecurityContext` from the values file. 
+These are:
+- Helm tests
+- setup job for the authorization database
+- setup job for for the Keycloak database in Postgres
+- setup job for the Keycloak realms
+- setup job for the platform initiliazation
+- setup job for the Renku database initialization in Postgres
+- self-signed CA certificates initialization container
+- Keycloak initialization container that injects self signed CA certificates is now using the 
+  centralized security context instead of a custom one
+
 ## Upgrading to Renku 0.71.0
 
 +* NEW `enableV1Services` used to indicate whether services needed exclusively for Renku V1 are deployed or not. The support for this feature is experimental and it should not yet be used in production at all.


### PR DESCRIPTION
## Describe your changes

This patch harmonizes the handling/configuration of the securityContext field through all the templates.

Its content was defined in multiple different manifests. Being hard coded there made them unsuitable for modifications such as required for OpenShift deployment.

They now all use the content coming from the values file since they were mostly all using the same values.