### PR TITLE
refactor: move service account creation to own template

### DIFF
--- a/helm-chart/renku/templates/data-service/rbac.yaml
+++ b/helm-chart/renku/templates/data-service/rbac.yaml
@@ -118,16 +118,6 @@ rules:
       - delete
       - create
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "renku.fullname" . }}-data-service
-  labels:
-    app: {{ template "renku.name" . }}
-    chart: {{ template "renku.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm-chart/renku/templates/data-service/rbac_k8s_watcher.yaml
+++ b/helm-chart/renku/templates/data-service/rbac_k8s_watcher.yaml
@@ -58,16 +58,6 @@ rules:
       - watch
   {{- end }}
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "renku.fullname" . }}-k8s-watcher
-  labels:
-    app: {{ template "renku.name" . }}
-    chart: {{ template "renku.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm-chart/renku/templates/data-service/serviceaccounts.yaml
+++ b/helm-chart/renku/templates/data-service/serviceaccounts.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "renku.fullname" . }}-data-service
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "renku.fullname" . }}-k8s-watcher
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/helm-chart/renku/templates/secrets-storage/rbac.yaml
+++ b/helm-chart/renku/templates/secrets-storage/rbac.yaml
@@ -42,13 +42,3 @@ subjects:
     name: {{ template "renku.fullname" $ }}-secrets-storage
     namespace: {{ $.Release.Namespace }}
 {{ end }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "renku.fullname" . }}-secrets-storage
-  labels:
-    app: {{ template "renku.name" . }}
-    chart: {{ template "renku.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}

--- a/helm-chart/renku/templates/secrets-storage/serviceaccount.yaml
+++ b/helm-chart/renku/templates/secrets-storage/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "renku.fullname" . }}-secrets-storage
+  labels:
+    app: {{ template "renku.name" . }}
+    chart: {{ template "renku.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}


### PR DESCRIPTION
## Describe your changes

This PR separates the creation of ServiceAccount objects from the RBAC.

Currently disabling the rbac creation for some of the renku elements will also disable the ServiceAccount creation.

While both are related, the former is mandatory for pods to start while the latter can be applied independently (i.e. by cluster admins prior to Renku deployment).

This patch fixes that by moving all ServiceAccount creation in their own template.