### PR TITLE
feat: make swagger-ui image configurable

### DIFF
--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: swagger
-          image: swaggerapi/swagger-ui
+          image: "{{ .Values.swagger.image.repository }}:{{ .Values.swagger.image.tag }}"
           env:
             - name: BASE_URL
               value: /swagger

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1449,6 +1449,9 @@ core:
 ## Configuration for the Swagger-UI available at <renku-domain>/swagger
 swagger:
   enabled: true
+  image:
+    repository: swaggerapi/swagger-ui
+    tag: "latest"
 ## The image used in startup scripts to initialize different postgress databases
 initDb:
   image:


### PR DESCRIPTION
## Describe your changes

Change the swagger template so that the image can also be configured when deploying Renku.

This allows to customize swagger in the same way as other components.

Useful for example when deploying on OpenShift where the default image cannot run due to security constraints.