### PR TITLE
chore: swap swagger services order to show data service first

### DIFF
--- a/helm-chart/renku/templates/swagger.yaml
+++ b/helm-chart/renku/templates/swagger.yaml
@@ -26,10 +26,10 @@ spec:
             - name: URLS
               value: >
                 [
-                  {"url": "/api/renku/spec.json", "name": "core service"},
+                  {"url": "/api/data/spec.json", "name": "data service"},
                   {"url": "/api/kg/spec.json", "name": "knowledge graph"},
                   {"url": "/api/notebooks/spec.json", "name": "notebooks service"},
-                  {"url": "/api/data/spec.json", "name": "data service"},
+                  {"url": "/api/renku/spec.json", "name": "core service"},
                   {"url": "/api/search/spec.json", "name": "search service"}
                 ]
             - name: OAUTH2_REDIRECT_URL


### PR DESCRIPTION
By default, we still load the renku-python "core" service as default when opening Swagger, although we mostly use the data services now.
This change makes Data Service the default selected service.

P.S. We might want to remove some entries from the list -- probably Notebooks and Search?

<img width="1655" height="669" alt="image" src="https://github.com/user-attachments/assets/a5868e79-d7fa-42e2-8812-be60c34f0dc9" />

/deploy
