### PR TITLE
feat: allow custom session egress network policies

### DIFF
--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -1029,30 +1029,9 @@ metadata:
   name: egress-from-renku-v1-sessions
 spec:
   egress:
-    - to:
-      # DNS resolution
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: kube-system
-        podSelector:
-          matchLabels:
-            k8s-app: kube-dns
-      ports:
-      - port: 53
-        protocol: UDP
-      - port: 53
-        protocol: TCP
-    - to:
-      # Allow access to any port/protocol as long as it is directed
-      # outside of the cluster. This is done by excluding
-      # IP ranges which are reserved for private networking from
-      # the allowed range.
-      - ipBlock:
-          cidr: 0.0.0.0/0
-          except:
-          - 10.0.0.0/8
-          - 172.16.0.0/12
-          - 192.168.0.0/16
+    {{- with .Values.networkPolicies.sessions.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     - to:
       # Allow access to data service, needed for secret mounting
       - podSelector:
@@ -1074,30 +1053,9 @@ metadata:
   name: egress-from-renku-v2-sessions
 spec:
   egress:
-    - to:
-      # DNS resolution
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: kube-system
-        podSelector:
-          matchLabels:
-            k8s-app: kube-dns
-      ports:
-      - port: 53
-        protocol: UDP
-      - port: 53
-        protocol: TCP
-    - to:
-      # Allow access to any port/protocol as long as it is directed
-      # outside of the cluster. This is done by excluding
-      # IP ranges which are reserved for private networking from
-      # the allowed range.
-      - ipBlock:
-          cidr: 0.0.0.0/0
-          except:
-          - 10.0.0.0/8
-          - 172.16.0.0/12
-          - 192.168.0.0/16
+    {{- with .Values.networkPolicies.sessions.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     - to:
       # Allow access to data service, needed for secret mounting
       - podSelector:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -232,6 +232,37 @@ networkPolicies:
   allowAllIngressFromPods: []
   ## List of namespaces that should be allowed all ingress to all services
   allowAllIngressFromNamespaces: []
+  sessions:
+    egress:
+      # NOTE: These prevent user sessions from accessing other services running in your cluster.
+      # In some cases these may need to be modified because you are using a specific K8s deployment
+      # or when all Renku services and Keycloak are accessible only internally in your network.
+      # The default setup here assumes that you have standard Kubernetes and that Renku is exposed
+      # to the internet.
+      - to:
+        # DNS resolution
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+        ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      - to:
+        # Allow access to any port/protocol as long as it is directed
+        # outside of the cluster. This is done by excluding
+        # IP ranges which are reserved for private networking from
+        # the allowed range.
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
 ## Keycloak configuration
 keycloakx:
   ## Spawn a keycloak instance


### PR DESCRIPTION
The stuff we had hardcoded is not general enough to work on Openshift or in cases where the Renku deployment is not exposed to the internet.

/deploy