### PR TITLE
fix: service account in ssh jump host not needed

### DIFF
--- a/helm-chart/renku/templates/notebooks/ssh.yaml
+++ b/helm-chart/renku/templates/notebooks/ssh.yaml
@@ -30,7 +30,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ if .Values.notebooks.rbac.create }}"{{ template "renku.notebooks.fullname" . }}"{{ else }}"{{ .Values.notebooks.rbac.serviceAccountName }}"{{ end }}
       securityContext:
         fsGroup: 1000
       containers:


### PR DESCRIPTION
/deploy

This is a bug in 2.5.0 because I removed a lot of unneeded and unused notebooks helm chart manifests. But we still need the ssh jump host. However I did not notice that the jump host is using a service account same as the old notebooks deployment (which was removed)

This service account is not needed in the ssh jump host. So we can just remove it.