### PR TITLE
feat: prepare Legacy sessions phase out

### DIFF
--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -98,6 +98,8 @@ spec:
               value: {{ toJson .Values.ui.client.sessionClassEmailUs | quote }}
             - name: IMAGE_BUILDERS_ENABLED
               value: {{ .Values.dataService.imageBuilders.enabled | quote }}
+            - name: SUPPORT_LEGACY_SESSIONS
+              value: {{ .Values.ui.client.support_legacy_sessions | quote }}
             - name: LEGACY_SUPPORT
               value: {{ printf "{\"enabled\": %t }" .Values.enableV1Services | quote }}
           livenessProbe:

--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -98,10 +98,8 @@ spec:
               value: {{ toJson .Values.ui.client.sessionClassEmailUs | quote }}
             - name: IMAGE_BUILDERS_ENABLED
               value: {{ .Values.dataService.imageBuilders.enabled | quote }}
-            - name: SUPPORT_LEGACY_SESSIONS
-              value: {{ .Values.ui.client.supportLegacySessions | quote }}
             - name: LEGACY_SUPPORT
-              value: {{ printf "{\"enabled\": %t }" .Values.enableV1Services | quote }}
+              value: {{ dict "enabled" .Values.enableV1Services "supportSessions" .Values.ui.client.supportLegacySessions | toJson | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -99,7 +99,7 @@ spec:
             - name: IMAGE_BUILDERS_ENABLED
               value: {{ .Values.dataService.imageBuilders.enabled | quote }}
             - name: LEGACY_SUPPORT
-              value: {{ dict "enabled" .Values.enableV1Services "supportSessions" .Values.ui.client.supportLegacySessions | toJson | quote }}
+              value: {{ dict "enabled" .Values.enableV1Services "supportLegacySessions" .Values.ui.client.supportLegacySessions | toJson | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -99,7 +99,7 @@ spec:
             - name: IMAGE_BUILDERS_ENABLED
               value: {{ .Values.dataService.imageBuilders.enabled | quote }}
             - name: SUPPORT_LEGACY_SESSIONS
-              value: {{ .Values.ui.client.support_legacy_sessions | quote }}
+              value: {{ .Values.ui.client.supportLegacySessions | quote }}
             - name: LEGACY_SUPPORT
               value: {{ printf "{\"enabled\": %t }" .Values.enableV1Services | quote }}
           livenessProbe:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -565,7 +565,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "4.5.0"
+      tag: "4.6.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -749,7 +749,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "4.5.0"
+      tag: "4.6.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -741,6 +741,7 @@ ui:
       image:
         repository: renku/renku-ui
         tag: "0.11.16"
+    supportLegacySessions: true
   server:
     ## The URL for the server service; the URL used by the client is the server.url + /ui-server endpoint.
     url:

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -7,7 +7,7 @@ Please follow this convention when adding a new row
 
 ## Upgrading to Renku 2.6.0
 
-+* NEW `ui.client.supportLegacySessions` used to disabled Legacy sessions.
++* NEW `ui.client.supportLegacySessions` used to disable Legacy sessions.
 
 ## Upgrading to Renku 2.5.0
 

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,6 +5,10 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
+## Upgrading to Renku 2.6.0
+
++* NEW `ui.client.supportLegacySessions` used to disabled Legacy sessions.
+
 ## Upgrading to Renku 2.5.0
 
 The notebook service and asscociated K8s services and components like Service, Roles, Rolebindings, etc. have been


### PR DESCRIPTION
Add a new value `ui.client.supportLegacySessions` to turn off the Legacy sessions on the UI side -- see [lorenzo/v1-sessions-warnings](https://github.com/SwissDataScienceCenter/renku-ui/pull/3789)

This PR includes the latest UI version 4.6.0 with a bunch of other minor improvements and bugfixes

/deploy extra-values=ui.client.supportLegacySessions=false

