### PR TITLE
chore: fix read the docs build

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: url.toString(),
+  url: `http://${url.host}`,
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: url.pathname,

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,6 +4,8 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const url = new URL(process.env.READTHEDOCS_CANONICAL_URL || "https://renku.readthedocs.io");
+
 const config: Config = {
   title: 'Renku',
   tagline: 'Connecting data, code, compute, and people.',
@@ -15,10 +17,10 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: process.env.READTHEDOCS_CANONICAL_URL || "https://renku.readthedocs.io",
+  url: url.toString(),
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: url.pathname,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Docusaurus wants the url and the path to be separated. But read the docs shoves this into one url. This way we parse and split them up and use them in the right place.

Here is the output from the failed read the docs build:

```
npm --prefix docs run build
> docs@0.0.0 build
> docusaurus build


[ERROR] Error: The url is not supposed to contain a sub-path like "/en/latest/". Please use the baseUrl field for sub-paths.

    at validateConfig (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/server/configValidation.js:372:15)
    at loadSiteConfig (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/server/config.js:40:62)
    at async Promise.all (index 1)
    at async loadContext (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/server/site.js:39:97)
    at async getLocalesToBuild (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:55:21)
    at async Command.build (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:29:21)
    at async Promise.all (index 0)
    at async runCLI (/home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/lib/commands/cli.js:56:5)
    at async file:///home/docs/checkouts/readthedocs.org/user_builds/renku/checkouts/latest/docs/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3
[INFO] Docusaurus version: 3.8.1
Node version: v22.15.0

```
