### PR TITLE
fix: upgrade amalthea to 0.20.1

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -18,11 +18,11 @@ dependencies:
     condition: enableV1Services
   - name: amalthea
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.20.0"
+    version: "0.20.1"
     condition: enableV1Services
   - name: amalthea-sessions
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.20.0"
+    version: "0.20.1"
   - name: dlf-chart
     repository: "https://swissdatasciencecenter.github.io/datashim/"
     version: "0.3.9-renku-2"


### PR DESCRIPTION
Changes the order of the proxies so that sessions where the base URL path is stripped to "/" still works.

/deploy