### PR TITLE
feat: configure k8s watcher according to enableV1Services

### DIFF
--- a/helm-chart/renku/templates/data-service/deployment_k8s_watcher.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_k8s_watcher.yaml
@@ -55,7 +55,7 @@ spec:
             - name: IMAGE_BUILDERS_ENABLED
               value: {{ .Values.dataService.imageBuilders.enabled | quote }}
             - name: V1_SERVICES_ENABLED
-              value: {{ .Values.enableV1Services | default false }}
+              value: {{ .Values.enableV1Services | default false | quote }}
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
TODO: bump up the data services version once https://github.com/SwissDataScienceCenter/renku-data-services/pull/968 is merged.

/deploy renku-data-services=leafty/fix-k8s-watcher extra-values=enableV1Services=true,postgresql.primary.persistence.enabled=true