### PR TITLE
chore: ignore - testing for how to run a single instance of Redis instead of having it in HA mode

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -165,7 +165,7 @@ global:
     port: 6379
     ## Not that the host is the same as fullnameOverride only in sentinel mode.
     ## In other cases the redis service is usually called <fullnameOverride>-headless.
-    host: renku-redis
+    host: renku-redis-master
     sentinel:
       ## Set to true if redis host/port point to a redis sentinel.
       enabled: false


### PR DESCRIPTION
Test for using standalone (i.e. not HA mode) redis for CI deployments.

/deploy