### PR TITLE
chore(ci): deploy Redis in standalone mode

### DIFF
--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -14,6 +14,11 @@ global:
   renku:
     domain: <deployment-FQDN>
   useHTTPS: true
+  redis:
+    port: 6379
+    host: renku-redis-master
+    sentinel:
+      enabled: false
 ingress:
   className: webapprouting.kubernetes.azure.com
   enabled: true
@@ -44,6 +49,9 @@ notebooks:
       operator: Equal
       value: user
 redis:
+  architecture: standalone
   master:
     persistence:
       enabled: false
+  sentinel:
+    enabled: false


### PR DESCRIPTION
This makes CI deployments of Renku use Redis in standalone mode. Which cuts down 2 redis instances (which are not small).

/deploy