### PR TITLE
chore: update frontend-bp to 0.0.8

### DIFF
--- a/.github/workflows/build-global-renkulab-images.yml
+++ b/.github/workflows/build-global-renkulab-images.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   DOCKER_PREFIX: ghcr.io/swissdatasciencecenter/renku
-  BUILDER_IMAGE: ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.0.6
-  RUN_IMAGE: ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.6
+  BUILDER_IMAGE: ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.0.8
+  RUN_IMAGE: ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.8
 jobs:
   build-images:
     runs-on: ubuntu-24.04

--- a/global-images/Makefile
+++ b/global-images/Makefile
@@ -1,6 +1,6 @@
 FRONTEND ?= vscodium
-BUILDER ?= ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.0.6
-RUN_IMAGE ?= ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.6
+BUILDER ?= ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.0.8
+RUN_IMAGE ?= ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.8
 GIT_SHA := $(shell git rev-parse --short=7 HEAD)
 
 .PHONY: all basic datascience


### PR DESCRIPTION
Bumps the version of the buildpacks used for global images to 0.0.8. 