### PR TITLE
chore: use renkubot to push images

### DIFF
--- a/.github/workflows/build-global-renkulab-images.yml
+++ b/.github/workflows/build-global-renkulab-images.yml
@@ -33,8 +33,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: RenkuBot
+          password: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta


### PR DESCRIPTION
Dependabot PRs cannot push the images so we can use renkubot's account to get around it