### PR TITLE
chore: update resource in minimal deployment values

### DIFF
--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -13,23 +13,23 @@ dataService:
   dataTasks:
     resources:
       limits:
-        memory: 160Mi
+        memory: 200Mi
       requests:
         cpu: 50m
-        memory: 160Mi
+        memory: 200Mi
   k8sWatcher:
     resources:
       limits:
-        memory: 150Mi
+        memory: 200Mi
       requests:
         cpu: 20m
-        memory: 150Mi
+        memory: 200Mi
   resources:
     limits:
-      memory: 600Mi
+      memory: 650Mi
     requests:
       cpu: 50m
-      memory: 600Mi
+      memory: 650Mi
   replicaCount: 1
 enableV1Services: false
 gateway:
@@ -93,17 +93,17 @@ redis:
 secretsStorage:
   resources:
     limits:
-      memory: 400Mi
+      memory: 450Mi
     requests:
       cpu: 50m
-      memory: 400Mi
+      memory: 450Mi
 solr:
   resources:
     limits:
-      memory: 300Mi
+      memory: 350Mi
     requests:
       cpu: 50m
-      memory: 300Mi
+      memory: 350Mi
 ui:
   client:
     resources:

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -26,10 +26,10 @@ dataService:
         memory: 200Mi
   resources:
     limits:
-      memory: 650Mi
+      memory: 700Mi
     requests:
       cpu: 50m
-      memory: 650Mi
+      memory: 700Mi
   replicaCount: 1
 enableV1Services: false
 gateway:

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -63,6 +63,12 @@ ingress:
     - hosts:
         - <deployment-FQDN>
       secretName: <certificate-secret-name>
+keycloakx:
+  resources:
+    requests:
+      memory: 600Mi
+    limits:
+      memory: 600Mi
 notebooks:
   oidc:
     allowUnverifiedEmail: true
@@ -83,6 +89,13 @@ notebooks:
       key: renku.io/dedicated
       operator: Equal
       value: user
+postgresql:
+  primary:
+    resources:
+      limits:
+        memory: 300Mi
+      requests:
+        memory: 300Mi
 redis:
   architecture: standalone
   master:
@@ -112,4 +125,10 @@ ui:
       requests:
         cpu: 10m
         memory: 150Mi
+  server:
+    resources:
+      limits:
+        memory: 75Mi
+      requests:
+        memory: 75Mi
 

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -4,12 +4,11 @@
 ---
 authz:
   resources:
-    resources:
-      limits:
-        memory: 50Mi
-      requests:
-        cpu: 20m
-        memory: 50Mi
+    limits:
+      memory: 50Mi
+    requests:
+      cpu: 20m
+      memory: 50Mi
 dataService:
   dataTasks:
     resources:

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -1,5 +1,40 @@
+# NOTE: Any resource requests and replica counts here are used only for development and testing purposes
+# and likely will not be able to support more than 5 concurrent users.
+# Therefore the resource requests, limits, replica counts here and are NOT SUITABLE FOR PRODUCTION.
 ---
+authz:
+  resources:
+    resources:
+      limits:
+        memory: 50Mi
+      requests:
+        cpu: 20m
+        memory: 50Mi
+dataService:
+  dataTasks:
+    resources:
+      limits:
+        memory: 160Mi
+      requests:
+        cpu: 50m
+        memory: 160Mi
+  k8sWatcher:
+    resources:
+      limits:
+        memory: 150Mi
+      requests:
+        cpu: 20m
+        memory: 150Mi
+  resources:
+    limits:
+      memory: 600Mi
+    requests:
+      cpu: 50m
+      memory: 600Mi
+  replicaCount: 1
 enableV1Services: false
+gateway:
+  replicaCount: 1
 gitlab:
   enabled: false
 global:
@@ -56,3 +91,26 @@ redis:
       enabled: false
   sentinel:
     enabled: false
+secretsStorage:
+  resources:
+    limits:
+      memory: 400Mi
+    requests:
+      cpu: 50m
+      memory: 400Mi
+solr:
+  resources:
+    limits:
+      memory: 300Mi
+    requests:
+      cpu: 50m
+      memory: 300Mi
+ui:
+  client:
+    resources:
+      limits:
+        memory: 65Mi
+      requests:
+        cpu: 10m
+        memory: 65Mi
+

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -5,18 +5,18 @@
 authz:
   resources:
     limits:
-      memory: 50Mi
+      memory: 75Mi
     requests:
-      cpu: 20m
-      memory: 50Mi
+      cpu: 50m
+      memory: 75Mi
 dataService:
   dataTasks:
     resources:
       limits:
-        memory: 200Mi
+        memory: 250Mi
       requests:
         cpu: 50m
-        memory: 200Mi
+        memory: 250Mi
   k8sWatcher:
     resources:
       limits:
@@ -106,17 +106,17 @@ redis:
 secretsStorage:
   resources:
     limits:
-      memory: 450Mi
+      memory: 500Mi
     requests:
       cpu: 50m
-      memory: 450Mi
+      memory: 500Mi
 solr:
   resources:
     limits:
-      memory: 350Mi
+      memory: 400Mi
     requests:
       cpu: 50m
-      memory: 350Mi
+      memory: 400Mi
 ui:
   client:
     resources:

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -108,8 +108,8 @@ ui:
   client:
     resources:
       limits:
-        memory: 65Mi
+        memory: 150Mi
       requests:
         cpu: 10m
-        memory: 65Mi
+        memory: 150Mi
 


### PR DESCRIPTION
The values are just based on running `kubectl top pods` on a random but relatively recent CI deployment.

/deploy
