### PR TITLE
chore(ci): increase memory for the data service

### DIFF
--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -26,10 +26,10 @@ dataService:
         memory: 200Mi
   resources:
     limits:
-      memory: 700Mi
+      memory: 750Mi
     requests:
       cpu: 50m
-      memory: 700Mi
+      memory: 750Mi
   replicaCount: 1
 enableV1Services: false
 gateway:


### PR DESCRIPTION
@leafty reported restarts when trying to run migrations from a shell from inside the data service. This should work without restarting for CI deployments.