### PR TITLE
Feat upgrade data service 0.56.0

### DIFF
--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -154,6 +154,8 @@ spec:
             {{- end }}
             - name: V1_SESSIONS_ENABLED
               value: {{ .Values.ui.client.supportLegacySessions | default false | quote }}
+            - name: ENABLE_INTERNAL_GITLAB
+              value: {{ .Values.enableInternalGitlab | default false | quote }}
             - name: POSTHOG_ENABLED
               value: {{ .Values.posthog.enabled | quote }}
             - name: KUBERNETES_NAMESPACE

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1564,6 +1564,18 @@ secretsStorage:
 # The support for this feature is experimental and it should not be set to false in production at all.
 enableV1Services: true
 
+# When this is set to false the gateway and data service will ignore the Gitlab
+# that can be integrated with Renku and will not ask users to log into this Gitlab.
+# NOTE: This flag has no effect on the core service and knowledge graph. Therefore
+# setting this to false should only be done if the enableV1Services flag is also false.
+# When this is set to false the gateway will not inject the internal gitlab tokens and
+# the data service will not require them and if tokens are passed it will just ignore them.
+# Setting this to false in existing Renku deployment will result in code repositories
+# that use the internal Gitlab not functioning properly. If you still want to set this
+# to false and keep operating with an internal Gitlab you should create an Integration
+# with the internal Gitlab and ask users to activate the connection.
+enableInternalGitlab: true
+
 podSecurityContext: {}
 securityContext:
   runAsUser: 1000

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1444,18 +1444,18 @@ dataService:
     create: true
   image:
     repository: renku/renku-data-service
-    tag: "0.55.0"
+    tag: "0.56.0"
     pullPolicy: IfNotPresent
   k8sWatcher:
     image:
       repository: renku/data-service-k8s-watcher
-      tag: "0.55.0"
+      tag: "0.56.0"
       pullPolicy: IfNotPresent
     resources: {}
   dataTasks:
     image:
       repository: renku/data-service-data-tasks
-      tag: "0.55.0"
+      tag: "0.56.0"
       pullPolicy: IfNotPresent
     resources: {}
   service:
@@ -1541,7 +1541,7 @@ authz:
 secretsStorage:
   image:
     repository: renku/secrets-storage
-    tag: "0.55.0"
+    tag: "0.56.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
/deploy

Bumps the data services version. Adds a separate flag in the values file to distinguish whether just the v1 services are shut down or both the v1 services and the internal gitlab is off.

This allows us to run Renku with internal services turned off but with the internal gitlab integration still functioning.