### PR TITLE
chore(helm-chart): use harbor-hosted bitnami artifacts

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -1,14 +1,14 @@
 dependencies:
   - name: postgresql
     version: "14.2.4"
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: "oci://harbor.renkulab.io/bitnami-mirror"
     condition: postgresql.enabled
   - name: keycloakx
     version: 2.1.0
     repository: "https://codecentric.github.io/helm-charts"
     condition: keycloakx.enabled
   - name: redis
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: "oci://harbor.renkulab.io/bitnami-mirror"
     version: 20.3.0
     condition: redis.install
   - name: renku-jena
@@ -32,7 +32,7 @@ dependencies:
     version: "0.4.2"
     condition: global.csi-rclone.install
   - name: solr
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: "oci://harbor.renkulab.io/bitnami-mirror"
     version: "8.9.2"
     condition: solr.enabled
     # setting the version of bitnami-common here to avoid conflicts in sub-charts bundling different versions

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -96,6 +96,10 @@ postgresql:
         memory: 300Mi
       requests:
         memory: 300Mi
+  # Use Bitnami's PostgreSQL image from Renkulab Harbor registry
+  image:
+    registry: harbor.renkulab.io
+    repository: bitnami-mirror/postgresql
 redis:
   architecture: standalone
   master:
@@ -103,6 +107,14 @@ redis:
       enabled: false
   sentinel:
     enabled: false
+    # Use Bitnami's Redis Sentinel image from Renkulab Harbor registry
+    image:
+      registry: harbor.renkulab.io
+      repository: bitnami-mirror/redis-sentinel
+  # Use Bitnami's Redis image from Renkulab Harbor registry
+  image:
+    registry: harbor.renkulab.io
+    repository: bitnami-mirror/redis
 secretsStorage:
   resources:
     limits:
@@ -117,6 +129,10 @@ solr:
     requests:
       cpu: 50m
       memory: 400Mi
+  # Use Bitnami's Solr image from Renkulab Harbor registry
+  image:
+    registry: harbor.renkulab.io
+    repository: bitnami-mirror/solr
 ui:
   client:
     resources:
@@ -131,4 +147,3 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
-


### PR DESCRIPTION
To avoid running into CI deployment issues with the [forthcoming changes to the Bitnami catalogue](https://github.com/bitnami/charts/issues/35164), this PR modifies the Renku Helm chart to pull the relevant Bitnami Helm charts and Docker images from Renkulab.io's Harbor instance instead of from Bitnami.

/deploy