### PR TITLE
chore: modify token permissions on image build

### DIFF
--- a/.github/workflows/build-global-renkulab-images.yml
+++ b/.github/workflows/build-global-renkulab-images.yml
@@ -27,14 +27,17 @@ jobs:
           - jupyterlab
           - vscodium
           - ttyd
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: RenkuBot
-          password: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta

--- a/.github/workflows/build-global-renkulab-images.yml
+++ b/.github/workflows/build-global-renkulab-images.yml
@@ -54,16 +54,18 @@ jobs:
 
           # publish only on pushes to master or release tags
           PUBLISH=0
+          EXTRA_FLAGS=""
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             PUBLISH=1
           elif [[ "${GITHUB_REF}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             PUBLISH=1
           fi
+          [ "${PUBLISH:-}" = "1" ] && EXTRA_FLAGS="--cache-image ${{ env.DOCKER_PREFIX }}/py-${{ matrix.FLAVOR }}-${{ matrix.FRONTEND }}-cache:latest"
 
           TAGS=$tags \
           FRONTEND=${{ matrix.FRONTEND }} \
           RUN_IMAGE=${{ env.RUN_IMAGE }} \
           BUILDER=${{ env.BUILDER_IMAGE }} \
           PUBLISH=$PUBLISH \
-          EXTRA_FLAGS="--cache-image ${{ env.DOCKER_PREFIX }}/py-${{ matrix.FLAVOR }}-${{ matrix.FRONTEND }}-cache:latest" \
+          EXTRA_FLAGS=$EXTRA_FLAGS \
           make -C global-images ${{ matrix.FLAVOR }}

--- a/.github/workflows/build-global-renkulab-images.yml
+++ b/.github/workflows/build-global-renkulab-images.yml
@@ -27,9 +27,6 @@ jobs:
           - jupyterlab
           - vscodium
           - ttyd
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
@@ -54,10 +51,19 @@ jobs:
         run: |
           tags=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',')
           tags=${tags::-1}
+
+          # publish only on pushes to master or release tags
+          PUBLISH=0
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            PUBLISH=1
+          elif [[ "${GITHUB_REF}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            PUBLISH=1
+          fi
+
           TAGS=$tags \
           FRONTEND=${{ matrix.FRONTEND }} \
           RUN_IMAGE=${{ env.RUN_IMAGE }} \
           BUILDER=${{ env.BUILDER_IMAGE }} \
-          PUBLISH=1 \
+          PUBLISH=$PUBLISH \
           EXTRA_FLAGS="--cache-image ${{ env.DOCKER_PREFIX }}/py-${{ matrix.FLAVOR }}-${{ matrix.FRONTEND }}-cache:latest" \
           make -C global-images ${{ matrix.FLAVOR }}

--- a/global-images/Makefile
+++ b/global-images/Makefile
@@ -10,7 +10,7 @@ all: basic datascience
 basic datascience:
 	@BASE=$@; \
 	PUBLISH_FLAG=""; \
-	if [ -n "$$PUBLISH" ]; then PUBLISH_FLAG="--publish"; fi; \
+	if [ "$${PUBLISH:-}" = "1" ]; then PUBLISH_FLAG="--publish"; fi; \
 	if [ -n "$$DOCKER_PREFIX" ]; then \
 		case "$$DOCKER_PREFIX" in \
 			*/) FINAL_PREFIX="$$DOCKER_PREFIX";; \

--- a/global-images/README.md
+++ b/global-images/README.md
@@ -21,7 +21,7 @@ There are a few environment variables you can set to modify the build.
 | BUILDER | Builder image to use | ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.0.8 |
 | DOCKER_PREFIX | Prefix to use for the image | None |
 | FRONTEND | The frontend to add (vscodium or jupyterlab) | vscodium |
-| PUBLISH | Push the image to the registry | False |
+| PUBLISH | Set to "1" to push the image to the registry | False |
 | RUN_IMAGE | Run image to use | ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.8 |
 | TAGS | Comma-separated list of image names | None |
 


### PR DESCRIPTION
dependabot was actually not able to push because it does not have access to repo secrets; use the explicit token permissions instead. 