### PR TITLE
feat: add support for ingress class name to sessionIngress

### DIFF
--- a/helm-chart/renku/templates/notebooks/env-secret.yaml
+++ b/helm-chart/renku/templates/notebooks/env-secret.yaml
@@ -24,6 +24,9 @@ stringData:
   NB_SESSIONS__OIDC__ALLOW_UNVERIFIED_EMAIL: {{ .Values.notebooks.oidc.allowUnverifiedEmail | quote }}
   NB_SESSIONS__INGRESS__HOST: {{ .Values.notebooks.sessionIngress.host | default .Values.global.renku.domain }}
   NB_SESSIONS__INGRESS__TLS_SECRET: {{ .Values.notebooks.sessionIngress.tlsSecret | default (printf "%s-ch-tls" .Release.Name) }}
+  {{- if .Values.notebooks.sessionIngress.className }}
+  NB_SESSIONS__INGRESS__CLASS_NAME: {{- .Values.notebooks.sessionIngress.className | quote }}
+  {{- end }}
   NB_SESSIONS__INGRESS__ANNOTATIONS: |
     {{- .Values.notebooks.sessionIngress.annotations | toYaml | nindent 4 }}
   NB_GIT__URL: {{ .Values.global.gitlab.url | quote }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -892,8 +892,8 @@ notebooks:
   sessionIngress:
     host:
     tlsSecret:
+    className: "" # nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"


### PR DESCRIPTION
## Describe your changes

This PR implements the bits to configure the ingress class name for session's ingress.

## Issue ticket number and link
Fixes #4109
Part of https://github.com/SwissDataScienceCenter/renku-data-services/issues/1044