### PR TITLE
chore: bump renku-ui to version 4.10.0

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -565,7 +565,7 @@ ui:
     replicaCount: 1
     image:
       repository: renku/renku-ui
-      tag: "4.9.0"
+      tag: "4.10.0"
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -749,7 +749,7 @@ ui:
     keepCookies: []
     image:
       repository: renku/renku-ui-server
-      tag: "4.9.0"
+      tag: "4.10.0"
       pullPolicy: IfNotPresent
     imagePullSecrets: []
     nameOverride: ""


### PR DESCRIPTION
Bump renku-ui to support private images and redirects on Legacy project pages

/deploy