### PR TITLE
Chart changes to support gitlab redirects

### DIFF
--- a/helm-chart/renku/templates/gateway/configmap.yaml
+++ b/helm-chart/renku/templates/gateway/configmap.yaml
@@ -96,7 +96,8 @@ data:
         enabled: {{ .Values.gateway.metrics.enabled }}
         port: {{ .Values.gateway.metrics.port }}
     redirects:
-      enabled: {{ .Values.gateway.redirects.enabled }}
-      renkuBaseUrl: {{ include "renku.baseUrl" . | quote }}
-      redirectedHost: {{ .Values.gateway.redirects.redirectedHost | default "" | quote }}
+      gitlab:
+        enabled: {{ .Values.gateway.redirects.gitlab.enabled }}
+        renkuBaseUrl: {{ include "renku.baseUrl" . | quote }}
+        redirectedHost: {{ .Values.gateway.redirects.gitlab.redirectedHost | default "" | quote }}
 ---

--- a/helm-chart/renku/templates/gateway/gitlab-redirect-ingress.yaml
+++ b/helm-chart/renku/templates/gateway/gitlab-redirect-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.redirects.enabled -}}
+{{- if .Values.gateway.redirects.gitlab.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,23 +8,20 @@ metadata:
     chart: {{ template "renku.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.gateway.redirects.gitlab.ingress.annotations }}
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /api/gitlab-redirect/$1
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
-  ingressClassName: webapprouting.kubernetes.azure.com
+  ingressClassName: {{ .Values.gateway.redirects.gitlab.ingress.className }}
 {{- if .Values.ingress.tls }}
   tls:
   - hosts:
-    - {{ .Values.gateway.redirects.serveHost }}
+    - {{ .Values.gateway.redirects.gitlab.ingress.host }}
     secretName: gitlab-{{ .Values.global.renku.domain }}-tls
 {{- end }}
   rules:
-    - host: {{ .Values.gateway.redirects.serveHost }}
+    - host: {{ .Values.gateway.redirects.gitlab.ingress.host }}
       http:
         paths:
         - backend:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1184,9 +1184,19 @@ gateway:
     targetCPUUtilizationPercentage: 75
   updateStrategy: {}
   redirects:
-    enabled: false
-    redirectedHost: gitlab.renkulab.io
-    serveHost: gitlab.renkulab.io
+    gitlab:
+      enabled: false
+      redirectedHost: gitlab.renkulab.io
+      ingress:
+        className: webapprouting.kubernetes.azure.com
+        host: gitlab.renkulab.io
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production # Use null as value if not using cert-manager to remove this entry
+          nginx.ingress.kubernetes.io/proxy-body-size: "0" # Adjust to a reasonable value for production to avoid DOS attacks.
+          nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # Needed if GitLab is behind this ingress
+          nginx.ingress.kubernetes.io/proxy-buffer-size: "8k" # Default is 4k, larger size necessary for keycloak
+          nginx.ingress.kubernetes.io/use-regex: "true"
+          nginx.ingress.kubernetes.io/rewrite-target: /api/gitlab-redirect/$1
 jena:
   image:
     repository: renku/renku-jena


### PR DESCRIPTION
# Summary

- Adds values used to configure the Gitlab redirects in the gateway
- Adds values + ingress template for redirecting requests to the domain that Gitlab is served from

See it in action at https://gitlab.renku-ci-ui-3902.dev.renku.ch/, for example https://gitlab.renku-ci-ui-3902.dev.renku.ch/test/project