### PR TITLE
chore[docs]: add documentation for extending the vscodium image

### DIFF
--- a/docs/docs/10-users/60-sessions/guides/25-create-environment-with-custom-packages-private-code-repository.md
+++ b/docs/docs/10-users/60-sessions/guides/25-create-environment-with-custom-packages-private-code-repository.md
@@ -4,7 +4,7 @@ Would you like Renku to create an environment for you with the packages you need
 
 If your code repository is public, you can have Renku build this image directly as part of your project! See [How to create an environment with custom packages installed](create-environment-with-custom-packages-installed).
 
-If your code repository is private, follow the instructions below.
+If your code repository is private, follow the instructions below or check out the [example repository](https://github.com/SwissDataScienceCenter/renku-custom-vscodium-image-template).
 
 ## Create a GitHub action to build a docker image
 

--- a/docs/docs/10-users/60-sessions/guides/45-use-your-own-docker-image-for-renku-session.md
+++ b/docs/docs/10-users/60-sessions/guides/45-use-your-own-docker-image-for-renku-session.md
@@ -36,7 +36,7 @@ In the project page:
             - `registry.renkulab.io/laura.kinkead1/n2o-pathway-analysis:980f4a3`
 		- if you want to use a custom image built with Github Actions:
     		- `ghcr.io/<username>/<projectname>:sha-<hash>`
-			- You can follow the README of this [template](https://github.com/SwissDataScienceCenter/renku-custom-vscodium-image-template) to build your own custom image
+			- You can follow the documentation how to [Use Your Own Docker Image For Renku Sessions](use-your-own-docker-image-for-renku-session)
     - The image identifier should be in the format that works with `docker pull`
 4. Depending on the image you’re using, you’ll need to fill in the **Advanced settings**. See the information below for how to fill it in:
 


### PR DESCRIPTION
I've added an example how to build a custom image based on the VSCodium Renku image ([here](https://github.com/SwissDataScienceCenter/renku-custom-vscodium-image-template)) and referenced it in the documentation.