### PR TITLE
docs: move tutorial repos out of our gitlab

### DIFF
--- a/docs/docs/10-users/20-getting-started/40-connect-code.md
+++ b/docs/docs/10-users/20-getting-started/40-connect-code.md
@@ -1,7 +1,16 @@
 # Connect Code
 
+:::info
+
+You can connect code repositories from [GitHub](https://github.com) and [GitLab.com](https://about.gitlab.com/) to RenkuLab, too!
+
+Check out the **Integrations** page (accessible via the 👤 user menu in the top right) to connect your accounts and sync access to repositories. For more information, see [How to connect your Renku account to your GitHub or GitLab account](../50-code/guides/20-connect-renku-account-to-github-or-gitlab-account.md).
+And, if your institution has a dedicated GitLab instance you would like to integrate with Renku, do not hesitate to [Contact us](../99-community.md), and we will be happy to add it to RenkuLab’s Integrations!
+
+:::
+
 For this project, we've created a [code
-repository](https://gitlab.renkulab.io/learn-renku/air-quality-analysis) for this project on GitLab.
+repository](https://gitlab.com/renku/air-quality-analysis) for this project on GitLab.
 We need to connect this git repository to the Renku project in order to access it.
 
 Here's how to add the code repository to your project:
@@ -11,16 +20,7 @@ Here's how to add the code repository to your project:
 In this case, we already provide you with the code here:
 
     ```
-    https://gitlab.renkulab.io/learn-renku/air-quality-analysis.git
+    https://gitlab.com/renku/air-quality-analysis
     ```
-
-:::info
-
-You can connect code repositories from [GitHub](https://github.com) and [GitLab.com](https://about.gitlab.com/) to RenkuLab, too!
-
-Check out the **Integrations** page (accessible via the 👤 user menu in the top right) to connect your accounts and sync access to repositories. For more information, see [How to connect your Renku account to your GitHub or GitLab account](../50-code/guides/20-connect-renku-account-to-github-or-gitlab-account.md).
-And, if your institution has a dedicated GitLab instance you would like to integrate with Renku, do not hesitate to [Contact us](../99-community.md), and we will be happy to add it to RenkuLab’s Integrations!
-
-:::
 
 For more information about working with code repositories on Renku, check out the **code** section in the [How To Guides](../50-code/00-code-repository.md).


### PR DESCRIPTION
We should not be using our gitlab for tutorial repos anymore 😢 