### PR TITLE
fix: add env variable for nodejs to use CA certs

### DIFF
--- a/helm-chart/renku/templates/_certificates-env.tpl
+++ b/helm-chart/renku/templates/_certificates-env.tpl
@@ -9,3 +9,8 @@
 - name: GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
   value: /etc/ssl/certs/ca-certificates.crt
 {{- end -}}
+
+{{- define "certificates.env.nodejs" -}}
+- name: NODE_EXTRA_CA_CERTS
+  value: /etc/ssl/certs/ca-certificates.crt
+{{- end -}}

--- a/helm-chart/renku/templates/ui/ui-server-deployment.yaml
+++ b/helm-chart/renku/templates/ui/ui-server-deployment.yaml
@@ -96,6 +96,7 @@ spec:
                   key: {{ .Values.global.redis.existingSecretPasswordKey }}
             - name: PROMETHEUS_ENABLED
               value: {{ .Values.ui.server.prometheus.enabled | quote }}
+            {{- include "certificates.env.nodejs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /liveness


### PR DESCRIPTION
Similar to what is done for python.

See for example: https://github.com/SwissDataScienceCenter/renku/blob/master/helm-chart/renku/templates/data-service/deployment.yaml#L189

We tested this out with @aledegano in a deployment he has been trying to get up and running.

/deploy