### PR TITLE
feat: update csi-rclone to 0.5.0

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -29,7 +29,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.4.3"
+    version: "0.5.0"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://harbor.renkulab.io/bitnami-mirror"


### PR DESCRIPTION
This enables setting GOMEMLIMIT on the node plugin pods which should help avoid some out of memory events and restarts of the pod.

/deploy