### PR TITLE
fix: ci deployment ingress class name

### DIFF
--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -82,8 +82,7 @@ notebooks:
                 values:
                   - user
   sessionIngress:
-    annotations:
-      kubernetes.io/ingress.class: webapprouting.kubernetes.azure.com
+    className: webapprouting.kubernetes.azure.com
   sessionTolerations:
     - effect: NoSchedule
       key: renku.io/dedicated


### PR DESCRIPTION
The default value is "nginx" but we use a different controller after we moved to azure. This worked before because there was a bug in the data service that ignored this setting. Now that it is fixed our CI deployments start failing with a message from Amalthea which finds the conflicting ingress annotation for the class name and the explicit class name.

/deploy