### PR TITLE
doc: csi-rclone deployment on OpenShift

### DIFF
--- a/docs/docs/20-admins/40-openshift/20-csi-rclone.md
+++ b/docs/docs/20-admins/40-openshift/20-csi-rclone.md
@@ -115,16 +115,4 @@ driver:
   create: false
 storageClass:
   create: false
-
-csiControllerRclone:
-  rclone:
-    image:
-      repository: renku/csi-rclone
-      tag: v0.5.0
-
-csiNodepluginRclone:
-  rclone:
-    image:
-      repository: renku/csi-rclone
-      tag: v0.5.0
 ```


### PR DESCRIPTION
## Describe your changes

This PR adds a chapter to the OpenShift documentation on the deployment of the SDSC fork of csi-rclone.
