### PR TITLE
chore: Disable Gitlab connection for CI deployments

### DIFF
--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -31,6 +31,7 @@ dataService:
       cpu: 50m
       memory: 750Mi
   replicaCount: 1
+enableInternalGitlab: false
 enableV1Services: false
 gateway:
   replicaCount: 1


### PR DESCRIPTION
Note: this is intentionally targeted to master as it modifies the CI, but it's irrelevant for proper releases.

/deploy