### PR TITLE
docs: remove sitemap when deployed

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,49 +9,50 @@ const url = new URL(
 );
 const versionSlug = process.env.READTHEDOCS_VERSION;
 
-const algoliaConfig = process.env.ALGOLIA_APP_ID && process.env.ALGOLIA_API_KEY
-  ? ({
-      // The application ID provided by Algolia
-      appId: process.env.ALGOLIA_APP_ID,
+const algoliaConfig =
+  process.env.ALGOLIA_APP_ID && process.env.ALGOLIA_API_KEY
+    ? ({
+        // The application ID provided by Algolia
+        appId: process.env.ALGOLIA_APP_ID,
 
-      // Public API key: it is safe to commit it
-      apiKey: process.env.ALGOLIA_API_KEY,
+        // Public API key: it is safe to commit it
+        apiKey: process.env.ALGOLIA_API_KEY,
 
-      indexName: "renkulab docs",
+        indexName: "renkulab docs",
 
-      // Optional: see doc section below
-      contextualSearch: !versionSlug,
+        // Optional: see doc section below
+        contextualSearch: !versionSlug,
 
-      // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-      // externalUrlRegex: 'external\\.com|domain\\.com',
+        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+        // externalUrlRegex: 'external\\.com|domain\\.com',
 
-      // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-      replaceSearchResultPathname: {
-        from: "/en/[a-zA-Z0-9_-]+/",
-        to: "/",
-      },
+        // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
+        replaceSearchResultPathname: {
+          from: "/en/[a-zA-Z0-9_-]+/",
+          to: "/",
+        },
 
-      // Optional: Algolia search parameters
-      searchParameters: {
-        ...(versionSlug
-          ? {
-              facetFilters: ["language:en", `rtd_tag:${versionSlug}`],
-            }
-          : {}),
-      },
+        // Optional: Algolia search parameters
+        searchParameters: {
+          ...(versionSlug
+            ? {
+                facetFilters: ["language:en", `rtd_tag:${versionSlug}`],
+              }
+            : {}),
+        },
 
-      // Optional: path for search page that enabled by default (`false` to disable it)
-      // searchPagePath: 'search',
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        // searchPagePath: 'search',
 
-      // Optional: whether the insights feature is enabled or not on Docsearch (`false` by default)
-      insights: false,
+        // Optional: whether the insights feature is enabled or not on Docsearch (`false` by default)
+        insights: false,
 
-      // Optional: whether you want to use the new Ask AI feature (undefined by default)
-      // askAi: 'YOUR_ALGOLIA_ASK_AI_ASSISTANT_ID',
+        // Optional: whether you want to use the new Ask AI feature (undefined by default)
+        // askAi: 'YOUR_ALGOLIA_ASK_AI_ASSISTANT_ID',
 
-      //... other Algolia params
-    } satisfies Preset.ThemeConfig["algolia"])
-  : undefined;
+        //... other Algolia params
+      } satisfies Preset.ThemeConfig["algolia"])
+    : undefined;
 
 const config: Config = {
   title: "Renku",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,7 +9,7 @@ const url = new URL(
 );
 const versionSlug = process.env.READTHEDOCS_VERSION;
 
-const algoliaConfig = process.env.ALGOLIA_APP_ID
+const algoliaConfig = process.env.ALGOLIA_APP_ID && process.env.ALGOLIA_API_KEY
   ? ({
       // The application ID provided by Algolia
       appId: process.env.ALGOLIA_APP_ID,
@@ -107,6 +107,8 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
+        // Do not generate a sitemap if algolia is enabled
+        sitemap: algoliaConfig ? false : {},
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
It seems that the sitemap breaks the search crawler, as the sitemap generated by docusaurus does not reference the different versions.