### PR TITLE
docs: fix trailing slash

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -68,6 +68,8 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: url.pathname,
+  // `trailingSlash` should be `true` when deploying on readthedocs
+  trailingSlash: algoliaConfig ? true : undefined,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Reference: https://docs.readthedocs.com/platform/stable/intro/docusaurus.html#configure-trailing-slashes