### PR TITLE
Revert "docs: fix trailing slash (#4437)"

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,8 +69,6 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: url.pathname,
-  // `trailingSlash` should be `true` when deploying on readthedocs
-  trailingSlash: algoliaConfig ? true : undefined,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
The broken link checker and link swap process break down when setting `trailingSlash: true` or `trailingSlash: false`. Leaving `trailingSlash: undefined` seems to work with the current links.

This reverts commit 9422324c444690702c04229ca00207905ca42f0d.