### PR TITLE
fix: Allow config of WebOrigins & RedirectUris

### DIFF
--- a/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
@@ -109,6 +109,10 @@ spec:
               value: "false"
             - name: NOTEBOOKS_KC_CLIENT_OAUTH_FLOW
               value: "authorization_code"
+            - name: NOTEBOOKS_KC_CLIENT_EXTRA_REDIRECT_URIS
+              value: {{ .Values.notebooks.oidc.extraRedirectUris | quote }}
+            - name: NOTEBOOKS_KC_CLIENT_EXTRA_WEB_ORIGINS
+              value: {{ .Values.notebooks.oidc.extraWebOrigins | quote }}
             - name: SWAGGER_KC_CLIENT_ID
               value: swagger
             - name: SWAGGER_KC_CLIENT_PUBLIC

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -879,6 +879,8 @@ notebooks:
     tokenUrl:
     authUrl:
     allowUnverifiedEmail: false
+    extraRedirectUris:
+    extraWebOrigins:
   sessionIngress:
     host:
     ## If you want to use the default cluster tls cert, set the flag below to true.

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -879,8 +879,8 @@ notebooks:
     tokenUrl:
     authUrl:
     allowUnverifiedEmail: false
-    extraRedirectUris:
-    extraWebOrigins:
+    extraRedirectUris: '[]'
+    extraWebOrigins: '[]'
   sessionIngress:
     host:
     ## If you want to use the default cluster tls cert, set the flag below to true.

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -879,7 +879,15 @@ notebooks:
     tokenUrl:
     authUrl:
     allowUnverifiedEmail: false
+    ## This value is a yaml string of a json list of URIs strings, i.e.
+    ## '["https://domain-a.example.org/*", "https://domain-b.example.net/*"]'
+    ## Each URI should follow the format expected by Keycloak in the Redirect
+    ## URIs field of a keycloak client.
     extraRedirectUris: '[]'
+    ## This value is a yaml string of a json list of URIs strings, i.e.
+    ## '["https://domain-a.example.org/*", "https://domain-b.example.net/*"]'
+    ## Each URI should follow the format expected by Keycloak in the Web Origins
+    ## field of a keycloak client.
     extraWebOrigins: '[]'
   sessionIngress:
     host:

--- a/scripts/init-realm/utils.py
+++ b/scripts/init-realm/utils.py
@@ -93,6 +93,8 @@ class OIDCClient:
     service_account_roles: List[str] = field(default_factory=list)
     service_account_realm_roles: List[str] = field(default_factory=list)
     public_client: bool = False
+    client_extra_web_origins: List[str] = field(default_factory=list)
+    client_extra_redirect_uris: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         self.base_url = self.base_url.rstrip("/")
@@ -163,8 +165,8 @@ class OIDCClient:
             "baseUrl": self.base_url,
             "publicClient": self.public_client,
             "attributes": self.attributes,
-            "redirectUris": [self.base_url + "/*"],
-            "webOrigins": [self.base_url + "/*"],
+            "redirectUris": [self.base_url + "/*"] + self.client_extra_redirect_uris,
+            "webOrigins": [self.base_url + "/*"] + self.client_extra_web_origins,
             "protocolMappers": default_protocol_mappers
             + [
                 {
@@ -207,6 +209,12 @@ class OIDCClient:
             service_account_realm_roles=json.loads(
                 os.environ.get(f"{prefix}SERVICE_ACCOUNT_REALM_ROLES", "[]")
             ),
+            client_extra_redirect_uris=json.loads(
+                os.environ.get(f"{prefix}EXTRA_REDIRECT_URIS", "[]")
+            ),
+            client_extra_web_origins=json.loads(
+                os.environ.get(f"{prefix}EXTRA_WEB_ORIGINS", "[]")
+            )
         )
 
 


### PR DESCRIPTION
/deploy extra-values=notebooks.oidc.extraRedirectUris=["https://domainA.example.org/\*"\,"https://domainB.example.org/\*"],notebooks.oidc.extraWebOrigins=["https://domainC.example.org/\*"]
