### PR TITLE
feat: remove enableInternalGitlab value from the chart

### DIFF
--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -159,7 +159,7 @@ spec:
             - name: V1_SESSIONS_ENABLED
               value: {{ .Values.ui.client.supportLegacySessions | default false | quote }}
             - name: ENABLE_INTERNAL_GITLAB
-              value: {{ .Values.enableInternalGitlab | default false | quote }}
+              value: "false"
             - name: POSTHOG_ENABLED
               value: {{ .Values.posthog.enabled | quote }}
             - name: LOG_FORMAT_STYLE

--- a/helm-chart/renku/templates/gateway/configmap.yaml
+++ b/helm-chart/renku/templates/gateway/configmap.yaml
@@ -36,7 +36,7 @@ data:
           audience: renku
           authorizedParty: renku-cli
     revproxy:
-      enableInternalGitlab: {{ .Values.enableInternalGitlab | default false }}
+      enableInternalGitlab: "false"
       renkuBaseUrl: {{ include "renku.baseUrl" . | quote }}
       externalGitlabUrl: {{ .Values.global.gitlab.url | default "" | quote }}
       k8sNamespace: {{ .Release.Namespace }}
@@ -47,7 +47,7 @@ data:
         uiserver: {{ printf "http://%s" (include "ui-server.fullname" .) | quote }} 
         search: {{ printf "http://%s-search-api" .Release.Name | quote }}
     login:
-      enableInternalGitlab: {{ .Values.enableInternalGitlab | default false }}
+      enableInternalGitlab: "false"
       renkuBaseUrl: {{ include "renku.baseUrl" . | quote }}
       loginRoutesBasePath: "/api/auth"
       defaultAppRedirectURL: {{ include "renku.baseUrl" . | quote }}
@@ -60,14 +60,6 @@ data:
           scopes: ["profile", "email", "openid", "microprofile-jwt"]
           callbackURI:  {{ printf "%s/api/auth/callback" (include "renku.baseUrl" .) }}
           usePKCE: false
-        {{- if .Values.enableInternalGitlab }}
-        gitlab:
-          issuer: {{ .Values.global.gitlab.url | quote }}
-          clientID: {{ .Values.gateway.gitlabClientId | default .Values.global.gateway.gitlabClientId | quote }}
-          scopes: ["openid", "api", "read_user", "read_repository"] 
-          callbackURI: {{ printf "%s/api/auth/callback" (include "renku.baseUrl" .) }}
-          usePKCE: false
-        {{- end }}
       oldGitLabLogout: {{ .Values.gateway.oldGitLabLogout | default false }}
       logoutGitLabUponRenkuLogout: {{ .Values.gateway.logoutGitLabUponRenkuLogout | default true }}
     redis:

--- a/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
+++ b/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
@@ -71,13 +71,6 @@ spec:
                 secretKeyRef:
                   name: {{ cat (include "renku.fullname" .) "-gateway" | nospace }}
                   key: oidcClientSecret
-            {{- if .Values.enableInternalGitlab }}
-            - name: GATEWAY_LOGIN_PROVIDERS_GITLAB_CLIENTSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ cat (include "renku.fullname" .) "-gateway" | nospace }}
-                  key: gitlabClientSecret
-            {{- end }}
             - name: GATEWAY_LOGIN_TOKENENCRYPTION_SECRETKEY
               valueFrom:
                 secretKeyRef:
@@ -93,18 +86,6 @@ spec:
                 secretKeyRef:
                   name: {{ cat (include "renku.fullname" .) "-gateway" | nospace }}
                   key: cookieHashKey
-            {{- if .Values.enableInternalGitlab }}
-            - name: GATEWAY_LOGIN_PROVIDERS_GITLAB_COOKIEENCODINGKEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ cat (include "renku.fullname" .) "-gateway" | nospace }}
-                  key: cookieEncodingKey
-            - name: GATEWAY_LOGIN_PROVIDERS_GITLAB_COOKIEHASHKEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ cat (include "renku.fullname" .) "-gateway" | nospace }}
-                  key: cookieHashKey
-            {{- end }}
             - name: GATEWAY_MONITORING_SENTRY_DSN
               value: {{ .Values.gateway.sentry.dsn }}
             - name: GATEWAY_POSTHOG_ENABLED

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -1347,18 +1347,6 @@ secretsStorage:
   tolerations: []
   affinity: {}
 
-# When this is set to false the gateway and data service will ignore the Gitlab
-# that can be integrated with Renku and will not ask users to log into this Gitlab.
-# NOTE: This flag has no effect on the core service and knowledge graph. Therefore,
-# setting this to false should only be done if the enableV1Services flag is also false.
-# When this is set to false the gateway will not inject the internal gitlab tokens and
-# the data service will not require them and if tokens are passed it will just ignore them.
-# Setting this to false in existing Renku deployment will result in code repositories
-# that use the internal Gitlab not functioning properly. If you still want to set this
-# to false and keep operating with an internal Gitlab you should create an Integration
-# with the internal Gitlab and ask users to activate the connection.
-enableInternalGitlab: false
-
 podSecurityContext: {}
 securityContext:
   runAsUser: 1000

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,6 +5,10 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
+## Upgrading to Renku 2.8.0
+
+* DELETE `enableInternalGitlab`, it is now not possible to configure Renku to use an "internal" GitLab instance. Admins can set up a GitLab integration instead.
+
 ## Upgrading to Renku 2.15.0
 
 * DELETE `global.gateway.cliClientSecret` the client is public and has no secret in Keycloak 25.


### PR DESCRIPTION
Remove the helm chart value `enableInternalGitlab`. Connecting to GitLab instances is now done exclusively through integrations.

/deploy