### PR TITLE
feat: mount self signed certs from configmaps

### DIFF
--- a/helm-chart/renku/templates/_certificates-volumes.tpl
+++ b/helm-chart/renku/templates/_certificates-volumes.tpl
@@ -14,8 +14,13 @@
               path: {{ include "renku.CASecretName" . }}-internal-communication-ca.crt
     {{- if $customCAsEnabled }}
     {{- range $customCA := .Values.global.certificates.customCAs }}
+    {{- if $customCA.secret }}
       - secret:
           name: {{ $customCA.secret }}
-    {{- end -}}
-    {{- end -}}
-{{- end -}}
+    {{- else if $customCA.configMap }}
+      - configMap:
+          name: {{ $customCA.configMap }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -134,10 +134,10 @@ global:
   anonymousSessions:
     ## Set to true to enable anonymous sessions
     enabled: false
-  ## Specify the name of an existing K8s secret that contains the certificate
+  ## Specify the name of an existing K8s secret or configmap that contains the certificate
   ## if you would like to use a custom CA. The key for the secret
   ## should have the .crt extension otherwise it is ignored. The
-  ## keys across all secrets are mounted as files in one location so
+  ## keys across all secrets and configmaps are mounted as files in one location so
   ## the keys across all secrets have to be unique. In addition to the
   ## changes here modifications need to be made in the keycloak section below
   certificates:
@@ -145,7 +145,8 @@ global:
       repository: renku/certificates
       tag: "0.0.2"
     customCAs: []
-    # - secret:
+    # - secret: a-secret-name
+    # - configMap: a-configmap-name
   ## Database credentials for postgres
   db:
     ## Used by the renku-data-services and potentially other backend services
@@ -291,10 +292,15 @@ keycloakx:
         defaultMode: 0777
         sources:
         {{- range $customCA := .Values.global.certificates.customCAs }}
+        {{- if $customCA.secret }}
           - secret:
               name: {{ $customCA.secret }}
-        {{- end -}}
-    {{- end -}}
+        {{- else if $customCA.configMap }}
+          - configMap:
+              name: {{ $customCA.configMap }}
+        {{- end }}
+        {{- end }}
+    {{- end }}
   ## Create a demo user in keycloak? Note that the password for the demo
   ## user must be queried from kubernetes (see the rendered NOTES.txt
   ## template which is shown after a successful deployment).
@@ -823,8 +829,7 @@ dlf-chart:
     enabled: false
   dataset-operator-chart:
     enabled: true
-csi-rclone:
-  {}
+csi-rclone: {}
   # This section is only relevant if you are installing csi-rclone as part of Renku
   ## Name of the csi storage class to use for RClone/Cloudstorage. Should be unique per cluster.
   # storageClassName: csi-rclone
@@ -1256,8 +1261,7 @@ dataService:
     ## The name of the BuildStrategy to use for image builds.
     strategyName: renku-buildpacks-v3
     ## Configuration overrides for specific target platforms
-    platformOverrides:
-      {}
+    platformOverrides: {}
       # linux/arm64:
       #   builderImage: "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/cuda-selector:0.5.1"
       #   runImage: "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/cuda-run-image:0.5.1"


### PR DESCRIPTION
Currently we only support secrets. But in a lot of cases you can create a configmap, annotate it and then k8s will populate it with cluster-specific CA certs. This is an option for the internal image registry that comes with openshift. And the auto-population with the cert works only on configmaps, not on secrets.

/deploy extra-values=global.certificates.customCAs[0].secret=custom-ca-cert-1,global.certificates.customCAs[1].configMap=custom-ca-cert-2