### PR TITLE
fix: add self-signed certs to ui deployment

### DIFF
--- a/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
+++ b/helm-chart/renku/templates/ui/ui-client-deployment-template.yaml
@@ -26,6 +26,8 @@ spec:
         release: {{ .Release.Name }}
     spec:
       automountServiceAccountToken: {{ .Values.global.debug }}
+      initContainers:
+        {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .imageName }}
@@ -109,6 +111,7 @@ spec:
               value: {{ .Values.ui.client.prometheus.enabled | quote }}
             - name: LEGACY_SUPPORT
               value: {{ dict "enabled" false "supportLegacySessions" false | toJson | quote }}
+            {{- include "certificates.env.nodejs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /
@@ -125,6 +128,8 @@ spec:
 {{ toYaml .Values.ui.client.resources | indent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            {{- include "certificates.volumeMounts.system" . | nindent 12 }}
     {{- with .Values.ui.client.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -145,4 +150,6 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
+      volumes:
+        {{- include "certificates.volumes" . | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
Since we are using a full stack framework now the UI deployment is making API calls for the UI. So it needs any self-signed certs just like the ui server.

/deploy