### PR TITLE
chore: add Sentry configuration for amalthea

### DIFF
--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -822,8 +822,7 @@ ui:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
 amalthea-sessions:
-  scope:
-    clusterWide: false
+  clusterScoped: false
   deployCrd: true
   controllerManager:
     manager:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -838,7 +838,7 @@ amalthea-sessions:
         enabled: false
         dsn:
         environment:
-        tracesSampleRate: 0.1
+        tracesSampleRate: 0.01
 ## Used only if S3 Mounts are enabled
 dlf-chart:
   csi-sidecars-rbac:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -821,16 +821,25 @@ ui:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
-amalthea:
+amalthea-sessions:
   scope:
     clusterWide: false
   deployCrd: true
-  resources:
-    requests:
-      cpu: 20m
-      memory: 200Mi
-    limits:
-      memory: 200Mi
+  controllerManager:
+    manager:
+      # resources:
+      #   limits:
+      #     cpu: 500m
+      #     memory: 128Mi
+      #   requests:
+      #     cpu: 10m
+      #     memory: 64Mi
+      ## Sentry configuration
+      sentry:
+        enabled: false
+        dsn:
+        environment:
+        tracesSampleRate: 0.1
 ## Used only if S3 Mounts are enabled
 dlf-chart:
   csi-sidecars-rbac:


### PR DESCRIPTION
Update the values file to show how to setup Sentry. Also replace `amalthea` by `amalthea-sessions` which is the chart for v2 sessions.

/deploy