### PR TITLE
feat: wait for the VFS queue to be purged before unmounting

### DIFF
--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
     condition: notebooks.cloudstorage.s3.installDatashim
   - name: csi-rclone
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-    version: "0.6.0"
+    version: "0.7.0"
     condition: global.csi-rclone.install
   - name: solr
     repository: "oci://harbor.renkulab.io/bitnami-mirror"


### PR DESCRIPTION
See: https://github.com/SwissDataScienceCenter/csi-rclone/pull/95

<code>
/deploy #notest extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-purge,csi-rclone.storageClassName=csi-rclone-purge,global.rcloneStorageClass=csi-rclone-purge,amalthea-sessions.rcloneStorageClass=csi-rclone-purge-secret-annotation,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Exists,dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user
</code>