### PR TITLE
refactor(chart): bitnami redis -> valkey helm dependency

### DIFF
--- a/docs/docs/20-admins/10-architecture/10-services.md
+++ b/docs/docs/20-admins/10-architecture/10-services.md
@@ -28,7 +28,7 @@ in Kubernetes.
 ### Third party
 
 - **Postgres**: Stores all information about projects, users and sessions.
-- **Redis**: Stores user login sessions.
+- **Valkey**: Stores user login sessions.
 - **Authzed (SpiceDB)**: Stores authorization information and is queries for authorization decisions.
 - **Solr**: Stores search documents and indices.
 - **Keycloak**: Stores user information and is used for Authentication.
@@ -49,7 +49,7 @@ flowchart LR
     end
     DS[Data services]
     PG[(Postgres)]
-    Redis[(Redis)]
+    Valkey[(Valkey)]
     Solr(Solr)
     Ingress --/api/*--> Proxy
     Proxy --/api/data/*--> DS
@@ -62,7 +62,7 @@ flowchart LR
     DS -.- K8s(Kubernetes API)
     Solr -.- SolrDB[(Postgres)]
     Authzed -.- AuthzedDB[(Postgres)]
-    Login -.- Redis
+    Login -.- Valkey
     Ingress --/auth/*--> Keycloak(Keycloak)
     Keycloak -.- KeycloakDB[(Postgres)]
     Ingress --/*--> UI

--- a/docs/docs/20-admins/20-installation/20-configuration.md
+++ b/docs/docs/20-admins/20-installation/20-configuration.md
@@ -155,20 +155,14 @@ keycloakx:
     requests:
       cpu: 1000m
       memory: 2Gi
-redis:
-  replica:
-    resources:
-      limits:
-        cpu: 2
-        memory: 3.0Gi
-      requests:
-        cpu: 2
-        memory: 3.0Gi
-  sentinel:
-    resources:
-      requests:
-        cpu: 1
-        memory: 64Mi
+valkey:
+  resources:
+    limits:
+      cpu: 2
+      memory: 3.0Gi
+    requests:
+      cpu: 2
+      memory: 3.0Gi
 solr:
   resources:
     limits:

--- a/docs/docs/20-admins/40-openshift/10-setup.md
+++ b/docs/docs/20-admins/40-openshift/10-setup.md
@@ -353,7 +353,7 @@ start properly.
 Here follows a full configuration based on the minimal deployment values file.
 
 Beside Renku specific elements, customization of child charts are also required.
-Here we can see the changes to be applied to make KeycloakX, PostgreSQL, Redis
+Here we can see the changes to be applied to make KeycloakX, PostgreSQL, Valkey
 and Solr start properly.
 
 Note that these changes are not Renku specific, they need to be applied in any
@@ -468,11 +468,6 @@ global:
   renku:
     domain: renku.apps.my-openshift.ch
   useHTTPS: true
-  redis:
-    port: 6379
-    host: renku-redis-master
-    sentinel:
-      enabled: false
 ingress:
   className: openshift-default
   enabled: true
@@ -535,26 +530,6 @@ postgresql:
   image:
     registry: harbor.renkulab.io
     repository: bitnami-mirror/postgresql
-redis:
-  architecture: standalone
-  master:
-    persistence:
-      enabled: false
-  metrics:
-    # Use the bitnami metrics image from the Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-exporter
-  sentinel:
-    enabled: false
-    # Use Bitnami's Redis Sentinel image from Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-sentinel
-  # Use Bitnami's Redis image from Renkulab Harbor registry
-  image:
-    registry: harbor.renkulab.io
-    repository: bitnami-mirror/redis
 secretsStorage:
   resources:
     limits:
@@ -598,4 +573,17 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
+valkey:
+  # added
+  # The valkey chart hardcodes UID/GID 1000, which restricted-v2 rejects. The
+  # bitnami charts drop those themselves, through
+  # global.compatibility.openshift.adaptSecurityContext=auto; the valkey chart has
+  # no equivalent. The nulls have to be explicit, helm merges values maps.
+  podSecurityContext:
+    fsGroup: null
+    runAsGroup: null
+    runAsUser: null
+  securityContext:
+    runAsUser: null
+  # end added
 ```

--- a/docs/docs/20-admins/40-openshift/10-setup.md
+++ b/docs/docs/20-admins/40-openshift/10-setup.md
@@ -574,6 +574,11 @@ ui:
       requests:
         memory: 75Mi
 valkey:
+  # No session persistence + volume in throwaway deployments.
+  dataStorage:
+    enabled: false
+  valkeyConfig: |-
+    save ""
   # added
   # The valkey chart hardcodes UID/GID 1000, which restricted-v2 rejects. The
   # bitnami charts drop those themselves, through

--- a/helm-chart/README.rst
+++ b/helm-chart/README.rst
@@ -55,10 +55,32 @@ Most information related to upgrading from one chart version to another is cover
 in the `values changelog file <https://github.com/SwissDataScienceCenter/renku/blob/master/helm-chart/values.yaml.changelog.md>`_.
 For upgrades that require some steps other than modifying the values files to be executed, we add some instructions here.
 
-Upgrading to 0.xx.x
-*******************
-This version replaces bitnami-redis with the opensource fork valkey as a helm chart dependency.
-It is a drop-in replacement, but the migration will flush the cache, logging out all users.
+Upgrading to Renku 2.21.0
+*************************
+This version replaces the ``redis`` bitnami helm chart dependency (version ``20.3.0``)
+with the official `valkey chart <https://valkey.io/valkey-helm/>`_ (version ``0.12.0``).
+
+Redis ran 3 nodes with a Sentinel, this is not yet supported by the Valkey chart,
+this chart is therefore configured to run a single valkey pod. This means that users will be
+logged when the pod goes down, such as during a migration.
+
+Deployments that need the old behaviour can point ``global.redis`` at an external
+sentinel backed redis instance and set ``valkey.install`` to ``false``.
+
+The values of the two charts vary significantly, hence the ``redis`` section is replaced
+by a ``valkey`` section rather than renamed. The client side settings stay under 
+``global.redis``, because they configure the redis clients in the renku services. See the
+``values.yaml.changelog.md`` for the details.
+
+The password is preserved: the ``redis-secret`` secret is annotated with
+``helm.sh/resource-policy: keep`` and is now used as the password of the valkey
+``default`` ACL user, under the same ``redis-password`` key.
+
+If you scrape valkey with Prometheus: bitnami redis brought its own network policy to open
+the exporter port, and the valkey chart does not. The renku chart's ``ingress-to-valkey-from-services`` 
+policy only admits the renku services, so allow your Prometheus through
+``networkPolicies.allowAllIngressFromNamespaces`` or
+``networkPolicies.allowAllIngressFromPods``, as you would for any other component.
 
 Upgrading to 0.27.0
 *******************

--- a/helm-chart/README.rst
+++ b/helm-chart/README.rst
@@ -55,6 +55,11 @@ Most information related to upgrading from one chart version to another is cover
 in the `values changelog file <https://github.com/SwissDataScienceCenter/renku/blob/master/helm-chart/values.yaml.changelog.md>`_.
 For upgrades that require some steps other than modifying the values files to be executed, we add some instructions here.
 
+Upgrading to 0.xx.x
+*******************
+This version replaces bitnami-redis with the opensource fork valkey as a helm chart dependency.
+It is a drop-in replacement, but the migration will flush the cache, logging out all users.
+
 Upgrading to 0.27.0
 *******************
 This version contains an upgrade to the ``keycloak`` Helm chart dependency from version ``15.0.2`` to ``20.0.1``.

--- a/helm-chart/README.rst
+++ b/helm-chart/README.rst
@@ -61,8 +61,9 @@ This version replaces the ``redis`` bitnami helm chart dependency (version ``20.
 with the official `valkey chart <https://valkey.io/valkey-helm/>`_ (version ``0.12.0``).
 
 Redis ran 3 nodes with a Sentinel, this is not yet supported by the Valkey chart,
-this chart is therefore configured to run a single valkey pod. This means that users will be
-logged when the pod goes down, such as during a migration.
+this chart is therefore configured to run a single valkey pod. Sessions are kept on a
+persistent volume, so restarting that pod does not log users out.
+The migration from redis itself logs everyone out, as the redis data is not carried over.
 
 Deployments that need the old behaviour can point ``global.redis`` at an external
 sentinel backed redis instance and set ``valkey.install`` to ``false``.

--- a/helm-chart/renku/requirements.yaml
+++ b/helm-chart/renku/requirements.yaml
@@ -7,10 +7,10 @@ dependencies:
     version: 7.3.0
     repository: "https://codecentric.github.io/helm-charts"
     condition: keycloakx.enabled
-  - name: redis
-    repository: "oci://harbor.renkulab.io/bitnami-mirror"
-    version: 20.3.0
-    condition: redis.install
+  - name: valkey
+    repository: "https://valkey.io/valkey-helm/"
+    version: "0.12.0"
+    condition: valkey.install
   - name: amalthea-sessions
     repository: "https://swissdatasciencecenter.github.io/helm-charts/"
     version: "0.31.0"

--- a/helm-chart/renku/templates/_helpers.tpl
+++ b/helm-chart/renku/templates/_helpers.tpl
@@ -61,6 +61,17 @@ Define subcharts full names
 {{- printf "%s-%s" .Release.Name "solr" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Deliberately not called "valkey.fullname": valkey subchart already defines that name.
+*/}}
+{{- define "renku.valkeyHost" -}}
+{{- if .Values.valkey.install -}}
+{{- printf "%s-%s" .Release.Name "valkey" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Values.global.redis.host -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "gitlab.fullname" -}}
 {{- printf "%s-%s" .Release.Name "gitlab" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - name: MAX_PINNED_PROJECTS
               value: {{ .Values.dataService.maxPinnedProjects | quote }}
             - name: REDIS_HOST
-              value: {{ .Values.global.redis.host | quote }}
+              value: {{ include "renku.valkeyHost" . | quote }}
             - name: REDIS_PORT
               value: {{ .Values.global.redis.port | quote }}
             - name: REDIS_DATABASE

--- a/helm-chart/renku/templates/data-service/deployment.yaml
+++ b/helm-chart/renku/templates/data-service/deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         app: renku-data-service
         release: {{ .Release.Name }}
-        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
       annotations:
         # NOTE: Without this the pod will not restart when the secret values change.
         checksum/config: {{ include (print $.Template.BasePath "/data-service/session-env-secret.yaml") . | sha256sum }}

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -72,7 +72,7 @@ spec:
             - name: K8S_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: REDIS_HOST
-              value: {{ .Values.global.redis.host | quote }}
+              value: {{ include "renku.valkeyHost" . | quote }}
             - name: REDIS_PORT
               value: {{ .Values.global.redis.port | quote }}
             - name: REDIS_DATABASE

--- a/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
+++ b/helm-chart/renku/templates/data-service/deployment_data_tasks.yaml
@@ -20,7 +20,6 @@ spec:
       labels:
         app: renku-data-tasks
         release: {{ .Release.Name }}
-        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
       annotations:
       {{- with .Values.dataService.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/renku/templates/gateway/configmap.yaml
+++ b/helm-chart/renku/templates/gateway/configmap.yaml
@@ -65,7 +65,7 @@ data:
     redis:
       type: redis 
       addresses: 
-        - {{ printf "%s:%d" .Values.global.redis.host (.Values.global.redis.port | int) | quote }}
+        - {{ printf "%s:%d" (include "renku.valkeyHost" .) (.Values.global.redis.port | int) | quote }}
       isSentinel: {{ .Values.global.redis.sentinel.enabled }}
       masterName: {{ .Values.global.redis.sentinel.masterSet | quote }}
       dbIndex: {{ .Values.global.redis.dbIndex.gateway }}

--- a/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
+++ b/helm-chart/renku/templates/gateway/deployment-revproxy.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         app: {{ template "gateway.name" . }}
         release: {{ .Release.Name }}
-        # The label below enables the gateway to connect to redis
-        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
       {{- if .Values.gateway.podAnnotations }}
       {{- with .Values.gateway.podAnnotations }}
       annotations:

--- a/helm-chart/renku/templates/network-policies.yaml
+++ b/helm-chart/renku/templates/network-policies.yaml
@@ -419,12 +419,12 @@ spec:
           port: http
         - protocol: TCP
           port: grpc
-{{- if .Values.redis.install }}
+{{- if .Values.valkey.install }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: ingress-to-redis-from-services
+  name: ingress-to-valkey-from-services
   labels:
     app: {{ template "renku.name" . }}
     chart: {{ template "renku.chart" . }}
@@ -433,7 +433,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: redis
+      app.kubernetes.io/name: valkey
+      app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
     - Ingress
   ingress:
@@ -456,7 +457,8 @@ spec:
               release: {{ .Release.Name }}
       ports:
         - protocol: TCP
-          port: redis
+          # the name of the valkey container port, see the valkey chart
+          port: tcp
 {{- end }}
 {{- if .Values.solr.enabled }}
 ---

--- a/helm-chart/renku/templates/secrets.yaml
+++ b/helm-chart/renku/templates/secrets.yaml
@@ -26,19 +26,21 @@ type: Opaque
 data:
   dataServiceKeycloakClientSecret: {{ $data_service_kc_client_secret }}
 
-{{- if and (eq .Values.redis.install true) (eq .Values.redis.createSecret true) }}
+{{- if and (eq .Values.valkey.install true) (eq .Values.valkey.createSecret true) }}
 ---
-{{ $redisPassword := .Values.redis.password | default (randAlphaNum 64) | b64enc | quote }}
-{{- if not .Values.redis.password -}}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.redis.auth.existingSecret) }}
+{{/* Valkey authenticates through ACL users, so the password lives in this
+     secret under the key configured for its "default" user. */}}
+{{ $redisPassword := .Values.valkey.password | default (randAlphaNum 64) | b64enc | quote }}
+{{- if not .Values.valkey.password -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.global.redis.existingSecret) }}
 {{- if $secret }}
-{{- $redisPassword = index $secret.data .Values.redis.auth.existingSecretPasswordKey }}
+{{- $redisPassword = index $secret.data .Values.global.redis.existingSecretPasswordKey }}
 {{- end -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.redis.auth.existingSecret }}
+  name: {{ .Values.global.redis.existingSecret }}
   labels:
     app: {{ template "renku.name" . }}
     chart: {{ template "renku.chart" . }}
@@ -50,5 +52,5 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
 type: Opaque
 data:
-  {{ .Values.redis.auth.existingSecretPasswordKey }}: {{ $redisPassword }}
+  {{ .Values.global.redis.existingSecretPasswordKey }}: {{ $redisPassword }}
 {{- end }}

--- a/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
+++ b/helm-chart/renku/templates/setup-job-keycloak-realms.yaml
@@ -1,6 +1,3 @@
-{{- if hasKey .Values "keycloak" -}}
-{{- fail "Values to configure Keycloak should be under `keycloakx`." -}}
-{{- end -}}
 {{- if .Values.keycloakx.enabled }}
 apiVersion: batch/v1
 kind: Job

--- a/helm-chart/renku/templates/ui/ui-server-deployment.yaml
+++ b/helm-chart/renku/templates/ui/ui-server-deployment.yaml
@@ -21,8 +21,6 @@ spec:
       labels:
         app.kubernetes.io/name: "uiserver"
         app.kubernetes.io/instance: {{ .Release.Name }}
-        # The label below enables the gateway to connect to redis
-        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
     spec:
     {{- with .Values.ui.server.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-chart/renku/templates/ui/ui-server-deployment.yaml
+++ b/helm-chart/renku/templates/ui/ui-server-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: WEBSOCKET_ENABLED
               value: {{ .Values.ui.server.webSocket.enabled | quote }}
             - name: REDIS_HOST
-              value: {{ .Values.global.redis.host | quote }}
+              value: {{ include "renku.valkeyHost" . | quote }}
             - name: REDIS_IS_SENTINEL
               value: {{ .Values.global.redis.sentinel.enabled | quote }}
             - name: REDIS_MASTER_SET

--- a/helm-chart/renku/templates/validate-values.yaml
+++ b/helm-chart/renku/templates/validate-values.yaml
@@ -1,0 +1,18 @@
+{{/*
+Validation of the renku values with actionable messages on failure.
+*/}}
+
+{{- if hasKey .Values "redis" }}
+  {{- fail "The 'redis' values section no longer exists: renku now deploys valkey instead of bitnami redis. Move your settings to the 'valkey' section and adapt them (see helm-chart/values.yaml.changelog.md). Client side settings stay in 'global.redis'." }}
+{{- end }}
+
+{{- if .Values.valkey.install }}
+  {{- $valkeyPasswordKey := dig "default" "passwordKey" "default" .Values.valkey.auth.aclUsers }}
+  {{- if ne $valkeyPasswordKey .Values.global.redis.existingSecretPasswordKey }}
+    {{- fail (printf "the passwordKey of the default user in valkey.auth.aclUsers (%s) must match global.redis.existingSecretPasswordKey (%s) to let the renku services authenticate against valkey" $valkeyPasswordKey .Values.global.redis.existingSecretPasswordKey) }}
+  {{- end }}
+{{- end }}
+
+{{- if hasKey .Values "keycloak" }}
+  {{- fail "Values to configure Keycloak should be under `keycloakx`." }}
+{{- end }}

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -115,9 +115,9 @@ global:
     ## the subcharts which represent the applications which are clients to valkey,
     ## but not the valkey deployment itself.
     port: 6379
-    ## Must match valkey.fullnameOverride when valkey.install is true; the renku
-    ## chart checks that they agree.
-    host: renku-valkey
+    ## Only used when valkey.install is false. The bundled valkey is named after
+    ## the release, and the renku services derive that name themselves.
+    host:
     sentinel:
       ## Set to true if host/port point to a redis sentinel. The valkey chart
       ## bundled here does not support sentinel, so this is only useful when
@@ -436,8 +436,6 @@ valkey:
   ### https://github.com/valkey-io/valkey-helm/tree/main/valkey           ###
   ###########################################################################
 
-  # Must match global.redis.host.
-  fullnameOverride: renku-valkey
   # the image version used is the default specified in the helm chart
   # image:
 

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -417,118 +417,72 @@ postgresql:
         cpu: 100m
         memory: 300Mi
 
-redis:
-  # If set to true, a HA redis will be included in the Renku release.
+valkey:
+  # If set to true, a valkey instance will be included in the Renku release.
+  # Valkey is a drop-in replacement for redis.
   install: true
   ###########################################################################
-  ### Configuration that is unknown to the redis chart but picked up      ###
+  ### Configuration that is unknown to the valkey chart but picked up     ###
   ### by the renku chart.                                                 ###
   ###########################################################################
-  # If set to true, we'll create a k8s secret to be used as existingSecret
+  # If set to true, we'll create a k8s secret to be used as usersExistingSecret
   # for password auth.
   createSecret: true
   # The actual password, ignored if createSecret is false.
   password: # openssl rand -hex 32
   ###########################################################################
-  ### Configuration that is passed on to the redis chart, for details and ###
-  ### further config options check out                                    ###
-  ### https://github.com/bitnami/charts/tree/master/bitnami/redis         ###
+  ### Configuration that is passed on to the valkey chart, for            ###
+  ### details and further config options check out                        ###
+  ### https://github.com/valkey-io/valkey-helm/tree/main/valkey           ###
   ###########################################################################
 
-  # the values below were taken from the default values for the chart
-  # and adapted to our context. The following contains a mix of specific
-  # customizations plus some higher level defaults which have been
-  # retained here so someone can get some overview of what this values
-  # file can do.
-  fullnameOverride: renku-redis
+  # Must match global.redis.host.
+  fullnameOverride: renku-valkey
   # the image version used is the default specified in the helm chart
   # image:
 
-  # replication is the default; standalone is also an option but this results in
-  # no read only replicas
-  architecture: replication
+  # A single valkey pod: the chart has no sentinel support, so there is no
+  # automatic failover and a restart drops all sessions. See the 2.21.0 upgrade
+  # note in the chart readme.
+  replica:
+    enabled: false
+  # Recreate rather than RollingUpdate, so that two independent valkey
+  # instances never sit behind the same service handing out different sessions.
+  deploymentStrategy: Recreate
+  # No persistent volume gets created; valkey only holds sessions and event
+  # streams.
+  dataStorage:
+    enabled: false
+  # No point snapshotting to a volume that is deleted with the pod. AOF is
+  # already off by default.
+  valkeyConfig: |-
+    save ""
+  # Valkey authenticates through ACL users, so the renku secret becomes the
+  # password of the "default" user. The chart templates usersExistingSecret, so
+  # it is derived; passwordKey is not, so validate-values.yaml checks it.
   auth:
     enabled: true
-    # renku-gateway requires sentinel authentication to be enabled
-    sentinel: true
-    existingSecret: redis-secret
-    existingSecretPasswordKey: redis-password
-    # this is a default but is kept here to highlight the fact that AOF is not used
-    # in this install. Note that having this enabled without a persistent volume
-    # is quite useless as it meant that keys get written to a file (and hence slower writes)
-    # but that file is deleted when the pod is deleted.
-    commonConfiguration: |-
-      # Disable AOF https://redis.io/topics/persistence#append-only-file
-      appendonly no
-      # Disable RDB persistence.
-      save ""
-  # when using sentinel the master block is completely ignored
-  # master:
-  replica:
-    # this controls the amount of redis+sentinel pods which get created
-    # it does relate to sentinel.quorum - if the latter is larger than this,
-    # then clearly things are misconfigured
-    replicaCount: 3
-    resources:
-      limits:
-        cpu: 250m
-        memory: 256Mi
-      requests:
-        cpu: 250m
-        memory: 256Mi
-    updateStrategy:
-      type: RollingUpdate
-    persistence:
-      # pvc will not get created
-      enabled: false
-    autoscaling:
-      enabled: false
-  # when sentinel is enabled, a sentinel container is placed in each
-  # pod and this does checking to ensure that the system always has a
-  # master
-  sentinel:
-    enabled: true
-    # this determines how many nodes must agree before a master
-    # reelection is required
-    quorum: 2
-    service:
-      sentinel: 26379
-    resources:
-      requests:
-        cpu: 200m
-        memory: 64Mi
-    downAfterMilliseconds: 1000
-    failoverTimeout: 2000
-    # the default is 220 which causes redis to take ~4 minutes to fully start
-    getMasterTimeout: 5
-    # Use Bitnami's Redis Sentinel image from Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-sentinel
-  # network policies are supported by the chart
-  networkPolicy:
-    enabled: true
-    # this adds a specific ingress rule which allows pods to connect to
-    # this redis instance if they have the label redis-client: true
-    allowExternal: false
+    usersExistingSecret: '{{ .Values.global.redis.existingSecret }}'
+    aclUsers:
+      default:
+        permissions: "~* &* +@all"
+        passwordKey: redis-password
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
   metrics:
-    # when this is enabled, a metrics container is inserted into each pod
+    # when this is enabled, a metrics container is inserted into the pod
     enabled: true
-    # defaults - included here to be explicit
-    podAnnotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "9121"
-    # Use the bitnami metrics image from the Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-exporter
-  # default - making explicit
-  sysctl:
-    enabled: false
-  # Use Bitnami's Redis image from Renkulab Harbor registry
-  image:
-    registry: harbor.renkulab.io
-    repository: bitnami-mirror/redis
+  # Prometheus scrapes the exporter off the pod. 9121 is the valkey chart's
+  # metrics.exporter.port default. The chart renders these unconditionally, so
+  # null the keys individually when disabling metrics (an empty map merges).
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9121"
 solr:
   enabled: true
   cloudEnabled: false

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -97,9 +97,9 @@ global:
   solr:
     port: 8983
 
-  # Connection details for a globally used redis instance for the
-  # entire platform. For specifying an actual instance as part of
-  # this chart, check out the non-global "redis" section.
+  # Connection details for a globally used redis-compatible instance for the
+  # entire platform. Renku ships valkey as a subchart;
+  # for configuring that instance, check out the non-global "valkey" section.
   redis:
     # Specify which renku component should use which DB index
     dbIndex:
@@ -107,28 +107,23 @@ global:
       coreService: "1"
       uiServer: "2"
       events: "3"
-    # Note: these two entries MUST match the ones in the top level redis section.
+    # The valkey section derives its secret name from existingSecret, and the
+    # renku chart checks that its password key agrees with the one below.
     existingSecret: redis-secret
     existingSecretPasswordKey: redis-password
-    ## Specify the redis host and port. Notice that these settings only affect
-    ## the subcharts which represent the applications which are clients to redis,
-    ## but not the redis cluster deployment itself.
-    ## If you're deploying redis through this chart, and you want to deviate from
-    ## the defaults, you'll have to match whatever you set here in the non-global
-    ## redis section below which defines the actual redis cluster.
-    port: 26379
-    ## Not that the host is the same as fullnameOverride only in sentinel mode.
-    ## In other cases the redis service is usually called <fullnameOverride>-headless.
-    host: renku-redis
+    ## Specify the host and port. Notice that these settings only affect
+    ## the subcharts which represent the applications which are clients to valkey,
+    ## but not the valkey deployment itself.
+    port: 6379
+    ## Must match valkey.fullnameOverride when valkey.install is true; the renku
+    ## chart checks that they agree.
+    host: renku-valkey
     sentinel:
-      ## Set to true if redis host/port point to a redis sentinel.
-      enabled: true
+      ## Set to true if host/port point to a redis sentinel. The valkey chart
+      ## bundled here does not support sentinel, so this is only useful when
+      ## pointing renku at an external sentinel-backed instance.
+      enabled: false
       masterSet: mymaster
-    ## The label added to client pods so that they can access redis.
-    ## Needed only if the network policy from the redis helm chart that adds this
-    ## restriction is enabled.
-    clientLabel:
-      renku-redis-client: "true"
   ## Set to true if using https
   useHTTPS: false
   anonymousSessions:

--- a/helm-chart/renku/values.yaml
+++ b/helm-chart/renku/values.yaml
@@ -449,19 +449,24 @@ valkey:
   # Recreate rather than RollingUpdate, so that two independent valkey
   # instances never sit behind the same service handing out different sessions.
   deploymentStrategy: Recreate
-  # No persistent volume gets created; valkey only holds sessions and event
-  # streams.
+  # Sessions and event streams are kept on a ReadWriteOnce volume to survive the pod.
   dataStorage:
-    enabled: false
-  # No point snapshotting to a volume that is deleted with the pod. AOF is
-  # already off by default.
+    enabled: true
+    # Required. With an empty requestedSize the chart falls back to an emptyDir
+    # and nothing is persisted.
+    requestedSize: 2Gi
+    # Empty means the default storage class of the cluster.
+    className: ""
+  # Persistence enabled via append-only file (AOF). RDB snapshots disabled.
+    # Note: valkey periodically compacts AOF to an RDB base. See https://valkey.io/topics/persistence/
   valkeyConfig: |-
+    appendonly yes
     save ""
-  # Valkey authenticates through ACL users, so the renku secret becomes the
-  # password of the "default" user. The chart templates usersExistingSecret, so
-  # it is derived; passwordKey is not, so validate-values.yaml checks it.
+  # Valkey authenticates through ACL users, the renku secret is the
+  # password of the "default" user.
   auth:
     enabled: true
+    # derived by subchart templating.
     usersExistingSecret: '{{ .Values.global.redis.existingSecret }}'
     aclUsers:
       default:

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -5,6 +5,30 @@ For changes that require manual steps other than changing values, please check o
 Please follow this convention when adding a new row
 * `<type: NEW|EDIT|DELETE> - *<resource name>*: <details>`
 
+## Upgrading to Renku 2.21.0
+
+Renku now deploys `valkey` instead of the bitnami `redis` chart.
+
+* DELETE `redis`, the whole section. The valkey settings differ differently.
+* NEW `valkey`, replacing the section above. It keeps `install`, `createSecret` and
+  `password` with the same meaning as before, and passes the rest on to the valkey
+  chart. Valkey authenticates through ACL users rather than a single
+  password, so the password key is configured under
+  `valkey.auth.aclUsers.default.passwordKey` instead of
+  `redis.auth.existingSecretPasswordKey`; it still defaults to `redis-password`, so
+  the existing password is kept. The secret *name* no longer needs to be repeated,
+  `valkey.auth.usersExistingSecret` is templated from `global.redis.existingSecret`.
+  The chart fails with an explanatory message if these disagree.
+* EDIT `global.redis.host`, from `renku-redis` to `renku-valkey`. This section is
+  *not* renamed, so that deployments pointing renku at their own redis or valkey
+  keep working across the upgrade.
+* EDIT `global.redis.port`, from `26379` (the sentinel port) to `6379`.
+* EDIT `global.redis.sentinel.enabled`, from `true` to `false`. The valkey chart does
+  not support sentinel. Keep this set to `true` only when pointing `global.redis` at
+  an external sentinel backed instance, together with `valkey.install: false`.
+* DELETE `global.redis.clientLabel`. It labelled the client pods for the network
+  policy that the bitnami chart brought along.
+
 ## Upgrading to Renku 2.18.0
 
 * DELETE `enableInternalGitlab`, it is now not possible to configure Renku to use an "internal" GitLab instance. Admins can set up a GitLab integration instead.

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -19,6 +19,10 @@ Renku now deploys `valkey` instead of the bitnami `redis` chart.
   the existing password is kept. The secret *name* no longer needs to be repeated,
   `valkey.auth.usersExistingSecret` is templated from `global.redis.existingSecret`.
   The chart fails with an explanatory message if these disagree.
+* NEW `valkey.dataStorage`, on by default with 2Gi from the default storage class.
+  Set `enabled: false` to disable persistence, e.g. in minimal deployments.
+* NEW `valkey.valkeyConfig`, enables AOF and disables RDB snapshots by default (see [docs](https://valkey.io/topics/persistence/)).
+  Set back to `save ""` whenever `dataStorage` is disabled.
 * EDIT `global.redis.host`, from `renku-redis` to `renku-valkey`. This section is
   *not* renamed, so that deployments pointing renku at their own redis or valkey
   keep working across the upgrade.

--- a/helm-chart/values.yaml.changelog.md
+++ b/helm-chart/values.yaml.changelog.md
@@ -23,9 +23,8 @@ Renku now deploys `valkey` instead of the bitnami `redis` chart.
   Set `enabled: false` to disable persistence, e.g. in minimal deployments.
 * NEW `valkey.valkeyConfig`, enables AOF and disables RDB snapshots by default (see [docs](https://valkey.io/topics/persistence/)).
   Set back to `save ""` whenever `dataStorage` is disabled.
-* EDIT `global.redis.host`, from `renku-redis` to `renku-valkey`. This section is
-  *not* renamed, so that deployments pointing renku at their own redis or valkey
-  keep working across the upgrade.
+* EDIT `global.redis.host`, now only read when `valkey.install` is `false`. The
+  bundled valkey is named after the release, like every other subchart.
 * EDIT `global.redis.port`, from `26379` (the sentinel port) to `6379`.
 * EDIT `global.redis.sentinel.enabled`, from `true` to `false`. The valkey chart does
   not support sentinel. Keep this set to `true` only when pointing `global.redis` at

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -97,3 +97,11 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
+valkey:
+  # Sessions are not worth a volume in a throwaway deployment, they go away
+  # with the pod. Without a save point valkey writes nothing to disk, so this
+  # also turns off the snapshots that the renku defaults enable.
+  dataStorage:
+    enabled: false
+  valkeyConfig: |-
+    save ""

--- a/minimal-deployment/minimal-deployment-values.yaml
+++ b/minimal-deployment/minimal-deployment-values.yaml
@@ -40,11 +40,6 @@ global:
   renku:
     domain: <deployment-FQDN>
   useHTTPS: true
-  redis:
-    port: 6379
-    host: renku-redis-master
-    sentinel:
-      enabled: false
 ingress:
   enabled: true
   hosts:
@@ -70,26 +65,6 @@ postgresql:
   image:
     registry: harbor.renkulab.io
     repository: bitnami-mirror/postgresql
-redis:
-  architecture: standalone
-  master:
-    persistence:
-      enabled: false
-  metrics:
-    # Use the bitnami metrics image from the Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-exporter
-  sentinel:
-    enabled: false
-    # Use Bitnami's Redis Sentinel image from Renkulab Harbor registry
-    image:
-      registry: harbor.renkulab.io
-      repository: bitnami-mirror/redis-sentinel
-  # Use Bitnami's Redis image from Renkulab Harbor registry
-  image:
-    registry: harbor.renkulab.io
-    repository: bitnami-mirror/redis
 secretsStorage:
   resources:
     limits:

--- a/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
+++ b/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
@@ -200,3 +200,11 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
+valkey:
+  # Sessions are not worth a volume in a throwaway deployment, they go away
+  # with the pod. Without a save point valkey writes nothing to disk, so this
+  # also turns off the snapshots that the renku defaults enable.
+  dataStorage:
+    enabled: false
+  valkeyConfig: |-
+    save ""

--- a/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
+++ b/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
@@ -200,3 +200,8 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
+valkey:
+  dataStorage:
+    enabled: false
+  valkeyConfig: |-
+    save ""

--- a/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
+++ b/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
@@ -200,11 +200,3 @@ ui:
         memory: 75Mi
       requests:
         memory: 75Mi
-valkey:
-  # Sessions are not worth a volume in a throwaway deployment, they go away
-  # with the pod. Without a save point valkey writes nothing to disk, so this
-  # also turns off the snapshots that the renku defaults enable.
-#  dataStorage:
-#    enabled: false
-#  valkeyConfig: |-
-#    save ""

--- a/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
+++ b/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
@@ -52,11 +52,6 @@ global:
   renku:
     domain: <deployment-FQDN>
   useHTTPS: true
-  redis:
-    port: 6379
-    host: renku-redis-master
-    sentinel:
-      enabled: false
 ingress:
   enabled: true
   className: webapprouting.kubernetes.azure.com
@@ -165,23 +160,6 @@ postgresql:
         memory: 300Mi
       requests:
         memory: 300Mi
-redis:
-  architecture: standalone
-  image:
-    registry: harbor.dev.renku.ch
-    repository: bitnami-mirror/redis
-  master:
-    persistence:
-      enabled: false
-  metrics:
-    image:
-      registry: harbor.dev.renku.ch
-      repository: bitnami-mirror/redis-exporter
-  sentinel:
-    enabled: false
-    image:
-      registry: harbor.dev.renku.ch
-      repository: bitnami-mirror/redis-sentinel
 secretsStorage:
   image:
     repository: harbor.dev.renku.ch/dockerhub_cache/renku/secrets-storage

--- a/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
+++ b/minimal-deployment/sdsc-azure-ci-deployment-values.yaml
@@ -204,7 +204,7 @@ valkey:
   # Sessions are not worth a volume in a throwaway deployment, they go away
   # with the pod. Without a save point valkey writes nothing to disk, so this
   # also turns off the snapshots that the renku defaults enable.
-  dataStorage:
-    enabled: false
-  valkeyConfig: |-
-    save ""
+#  dataStorage:
+#    enabled: false
+#  valkeyConfig: |-
+#    save ""


### PR DESCRIPTION
## Context
Renku ships redis through bitnami's deprecated chart.

## Goal

Migrate RenkuHelm chart from Bitnami's Redis to the official Valkey chart, a redis-compatible open-source fork.

## Summary

* Subchart updated to valkey
* Adapted values with a new `valkey` section.
* Removed sentinel architecture (not supported in valkey chart), and added persistence in a dedicated volume instead.
* Updated admin and migration docs

## Additional changes

* Fixed valkey resource naming to be release-scoped (was not the case in redis)

/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)