### PR TITLE
fix: use trixie for Python scripts

### DIFF
--- a/scripts/init-db/Dockerfile
+++ b/scripts/init-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-trixie
 
 RUN apt-get update && apt-get install -y \
     postgresql-client \


### PR DESCRIPTION
Using `bullseye` fails to build -> https://github.com/SwissDataScienceCenter/renku/actions/runs/34371500998/job/102780079033

/deploy